### PR TITLE
server: add psycopg v3 dep + dispatch postgres URLs through PostgresStore stub

### DIFF
--- a/server/backend/README.md
+++ b/server/backend/README.md
@@ -38,9 +38,9 @@ the runtime store factory (`cq_server.store.create_store`). Precedence:
 
 1. `CQ_DATABASE_URL` — used verbatim. SQLite URLs (`sqlite:///<path>`)
    work today; `postgresql+psycopg://...` is reserved for the Postgres
-   backend and currently rejected at startup with a
-   `NotImplementedError` pointing at the Phase 2 child issues
-   ([#311][issue-311] / [#312][issue-312]).
+   backend and currently dispatches at the `PostgresStore` stub, which
+   raises `NotImplementedError` pointing at the Phase 2 implementation
+   issue ([#312][issue-312]).
 2. `CQ_DB_PATH` — wrapped as `sqlite:///<path>`. The SQLite shortcut
    for single-instance deployments; supported alongside
    `CQ_DATABASE_URL`.
@@ -71,5 +71,4 @@ CQ_DB_PATH=./dev.db uv run alembic upgrade head
 The full environment-variable table for self-hosters lives in
 [DEVELOPMENT.md](../../DEVELOPMENT.md#self-hosted-server).
 
-[issue-311]: https://github.com/mozilla-ai/cq/issues/311
 [issue-312]: https://github.com/mozilla-ai/cq/issues/312

--- a/server/backend/pyproject.toml
+++ b/server/backend/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "cq-sdk~=0.9.1",
     "sqlalchemy>=2.0.49,<2.1",
     "alembic>=1.18.4,<2",
+    "psycopg[binary,pool]>=3.3.4,<4",
 ]
 
 [project.scripts]

--- a/server/backend/src/cq_server/store/__init__.py
+++ b/server/backend/src/cq_server/store/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import cast
 
 from sqlalchemy.engine import make_url
 from sqlalchemy.exc import ArgumentError
@@ -57,7 +58,12 @@ def create_store(database_url: str) -> Store:
     # than falling through to the generic "unsupported scheme" branch
     # which would obscure the real reason.
     if driver == "postgresql+psycopg":
-        return PostgresStore(database_url)
+        # ``PostgresStore.__init__`` raises ``NotImplementedError`` until
+        # Phase 2 (#312) lands, so this ``return`` is unreachable at
+        # runtime. The ``cast`` keeps the type checker happy without
+        # forcing the stub to fully impersonate the ``Store`` protocol —
+        # #312 will replace the cast with a proper implementation.
+        return cast(Store, PostgresStore(database_url))
     if driver == "postgresql" or driver.startswith("postgresql+"):
         raise NotImplementedError(
             f"PostgreSQL driver {driver!r} is not supported; use "

--- a/server/backend/src/cq_server/store/__init__.py
+++ b/server/backend/src/cq_server/store/__init__.py
@@ -8,11 +8,13 @@ from sqlalchemy.engine import make_url
 from sqlalchemy.exc import ArgumentError
 
 from ._normalize import normalize_domains
+from ._postgres import PostgresStore
 from ._protocol import Store
 from ._sqlite import DEFAULT_DB_PATH, SqliteStore
 
 __all__ = [
     "DEFAULT_DB_PATH",
+    "PostgresStore",
     "SqliteStore",
     "Store",
     "create_store",
@@ -40,24 +42,26 @@ def create_store(database_url: str) -> Store:
     driver = parsed.drivername
     if driver.startswith("sqlite"):
         if not parsed.database:
-            raise ValueError(
-                "SQLite URL must point at a file path; got an empty database."
-            )
+            raise ValueError("SQLite URL must point at a file path; got an empty database.")
         if parsed.database == ":memory:":
             raise ValueError(
-                "in-memory SQLite databases are not supported; the cq server "
-                "needs a persistent file path."
+                "in-memory SQLite databases are not supported; the cq server needs a persistent file path."
             )
         return SqliteStore(db_path=Path(parsed.database))
-    # Match every Postgres driver suffix (``+psycopg``, ``+psycopg2``,
-    # ``+asyncpg``, …) so a typo'd driver still hits the helpful
-    # NotImplementedError instead of falling through to the generic
-    # "unsupported scheme" branch. Phase 2 (#311) will pick the actual
-    # driver; until then anything postgres-shaped is rejected the same
-    # way.
+    # The canonical Postgres URL (``postgresql+psycopg://...``) is
+    # dispatched through the ``PostgresStore`` stub so that Phase 2 only
+    # needs to fill in the class — the factory wiring is already correct.
+    # Every other Postgres driver suffix (bare ``postgresql://``,
+    # ``+psycopg2``, ``+asyncpg``, …) is also rejected with a helpful
+    # NotImplementedError pointing at the implementation issue, rather
+    # than falling through to the generic "unsupported scheme" branch
+    # which would obscure the real reason.
+    if driver == "postgresql+psycopg":
+        return PostgresStore(database_url)
     if driver == "postgresql" or driver.startswith("postgresql+"):
         raise NotImplementedError(
-            "PostgreSQL backend is not implemented yet; lands with "
-            "PostgresStore in epic #257 (issues #311/#312)."
+            f"PostgreSQL driver {driver!r} is not supported; use "
+            "``postgresql+psycopg://...`` once the PostgresStore "
+            "implementation lands in epic #257 (issue #312)."
         )
     raise ValueError(f"Unsupported database URL scheme: {driver!r}")

--- a/server/backend/src/cq_server/store/__init__.py
+++ b/server/backend/src/cq_server/store/__init__.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import cast
 
 from sqlalchemy.engine import make_url
 from sqlalchemy.exc import ArgumentError
@@ -30,11 +29,12 @@ def create_store(database_url: str) -> Store:
     lifespan and any future Postgres caller can't drift on which scheme
     maps to which store.
 
-    SQLite URLs return a live ``SqliteStore``. Postgres URLs raise
-    ``NotImplementedError`` until the Phase 2 ``PostgresStore`` lands
-    (#311/#312); the message names those issues so the failure is
-    self-explanatory. Anything else raises ``ValueError`` with the
-    offending driver string.
+    SQLite URLs return a live ``SqliteStore``. The canonical
+    ``postgresql+psycopg://...`` URL is dispatched through the
+    ``PostgresStore`` stub, which raises ``NotImplementedError`` until
+    the Phase 2 implementation lands (#312). Other PostgreSQL driver
+    suffixes are rejected inline with a message naming the canonical
+    driver. Anything else raises ``ValueError``.
     """
     try:
         parsed = make_url(database_url)
@@ -49,21 +49,8 @@ def create_store(database_url: str) -> Store:
                 "in-memory SQLite databases are not supported; the cq server needs a persistent file path."
             )
         return SqliteStore(db_path=Path(parsed.database))
-    # The canonical Postgres URL (``postgresql+psycopg://...``) is
-    # dispatched through the ``PostgresStore`` stub so that Phase 2 only
-    # needs to fill in the class — the factory wiring is already correct.
-    # Every other Postgres driver suffix (bare ``postgresql://``,
-    # ``+psycopg2``, ``+asyncpg``, …) is also rejected with a helpful
-    # NotImplementedError pointing at the implementation issue, rather
-    # than falling through to the generic "unsupported scheme" branch
-    # which would obscure the real reason.
     if driver == "postgresql+psycopg":
-        # ``PostgresStore.__init__`` raises ``NotImplementedError`` until
-        # Phase 2 (#312) lands, so this ``return`` is unreachable at
-        # runtime. The ``cast`` keeps the type checker happy without
-        # forcing the stub to fully impersonate the ``Store`` protocol —
-        # #312 will replace the cast with a proper implementation.
-        return cast(Store, PostgresStore(database_url))
+        return PostgresStore(database_url)
     if driver == "postgresql" or driver.startswith("postgresql+"):
         raise NotImplementedError(
             f"PostgreSQL driver {driver!r} is not supported; use "

--- a/server/backend/src/cq_server/store/_postgres.py
+++ b/server/backend/src/cq_server/store/_postgres.py
@@ -1,0 +1,20 @@
+"""PostgresStore: psycopg v3-backed implementation of the async Store protocol.
+
+Phase 2 stub. Construction raises ``NotImplementedError`` pointing at the
+implementation issue (#312) so that the URL → backend dispatch in
+``create_store`` is wired up now and Phase 2 only needs to fill in the
+class body.
+"""
+
+from __future__ import annotations
+
+
+class PostgresStore:
+    """psycopg v3-backed Store. Implementation lands in #312."""
+
+    def __init__(self, database_url: str) -> None:
+        raise NotImplementedError(
+            "PostgresStore is not implemented yet; the psycopg v3-backed "
+            "implementation lands in epic #257 (issue #312). "
+            f"Got database URL: {database_url!r}"
+        )

--- a/server/backend/src/cq_server/store/_postgres.py
+++ b/server/backend/src/cq_server/store/_postgres.py
@@ -8,8 +8,10 @@ class body.
 
 from __future__ import annotations
 
+from ._protocol import Store
 
-class PostgresStore:
+
+class PostgresStore(Store):
     """psycopg v3-backed Store. Implementation lands in #312."""
 
     def __init__(self, database_url: str) -> None:

--- a/server/backend/tests/test_app.py
+++ b/server/backend/tests/test_app.py
@@ -439,8 +439,8 @@ class TestDatabaseUrlBoot:
         with pytest.raises(NotImplementedError) as exc, TestClient(app):
             pass
         message = str(exc.value)
-        assert "#311" in message
         assert "#312" in message
+        assert "PostgresStore" in message
 
 
 class TestApiKeyEnforcement:

--- a/server/backend/tests/test_store_factory.py
+++ b/server/backend/tests/test_store_factory.py
@@ -13,7 +13,7 @@ from pathlib import Path
 import pytest
 from cq.models import Insight, create_knowledge_unit
 
-from cq_server.store import SqliteStore, create_store
+from cq_server.store import PostgresStore, SqliteStore, create_store
 
 from .db_helpers import init_test_db
 
@@ -58,11 +58,11 @@ class TestPostgres:
         [
             # Bare ``postgresql://`` is a common copy-paste from libpq URLs;
             # the explicit driver suffixes cover the drivers users actually
-            # paste — psycopg v3 (#311's target), psycopg2 (still ubiquitous),
-            # and asyncpg. All four must hit the same NotImplementedError so
-            # the #311/#312 pointer is the user's first signal rather than a
-            # generic "unsupported scheme" or a SQLAlchemy dialect-load
-            # failure.
+            # paste — psycopg v3 (the canonical driver), psycopg2 (still
+            # ubiquitous), and asyncpg. All four must hit a clear
+            # NotImplementedError pointing at the Phase 2 implementation
+            # (#312) rather than a generic "unsupported scheme" or a
+            # SQLAlchemy dialect-load failure.
             "postgresql://u:p@h/d",
             "postgresql+psycopg://u:p@h/d",
             "postgresql+psycopg2://u:p@h/d",
@@ -73,7 +73,22 @@ class TestPostgres:
         with pytest.raises(NotImplementedError) as exc:
             create_store(url)
         message = str(exc.value)
-        assert "#311" in message
+        assert "#312" in message
+        assert "PostgresStore" in message
+
+    def test_psycopg_url_dispatches_through_postgres_store(self) -> None:
+        # The canonical psycopg v3 URL must be routed through the
+        # ``PostgresStore`` stub (not raised inline by the factory) so
+        # that Phase 2 only needs to fill in the class — the factory
+        # dispatch is already correct.
+        with pytest.raises(NotImplementedError) as exc:
+            create_store("postgresql+psycopg://u:p@h/d")
+        assert "#312" in str(exc.value)
+
+    def test_postgres_store_stub_raises_not_implemented(self) -> None:
+        with pytest.raises(NotImplementedError) as exc:
+            PostgresStore("postgresql+psycopg://u:p@h/d")
+        message = str(exc.value)
         assert "#312" in message
 
 

--- a/server/backend/tests/test_store_factory.py
+++ b/server/backend/tests/test_store_factory.py
@@ -57,14 +57,15 @@ class TestPostgres:
         "url",
         [
             # Bare ``postgresql://`` is a common copy-paste from libpq URLs;
-            # the explicit driver suffixes cover the drivers users actually
-            # paste — psycopg v3 (the canonical driver), psycopg2 (still
-            # ubiquitous), and asyncpg. All four must hit a clear
-            # NotImplementedError pointing at the Phase 2 implementation
+            # ``+psycopg2`` and ``+asyncpg`` cover the other drivers users
+            # paste. All three must hit a clear NotImplementedError pointing
+            # at the canonical ``+psycopg`` driver and Phase 2 implementation
             # (#312) rather than a generic "unsupported scheme" or a
-            # SQLAlchemy dialect-load failure.
+            # SQLAlchemy dialect-load failure. The canonical ``+psycopg``
+            # URL is exercised separately by
+            # ``test_psycopg_url_dispatches_through_postgres_store`` since
+            # it goes through the stub instead of the inline-raise branch.
             "postgresql://u:p@h/d",
-            "postgresql+psycopg://u:p@h/d",
             "postgresql+psycopg2://u:p@h/d",
             "postgresql+asyncpg://u:p@h/d",
         ],
@@ -80,10 +81,14 @@ class TestPostgres:
         # The canonical psycopg v3 URL must be routed through the
         # ``PostgresStore`` stub (not raised inline by the factory) so
         # that Phase 2 only needs to fill in the class — the factory
-        # dispatch is already correct.
+        # dispatch is already correct. ``Got database URL:`` is unique to
+        # the stub's message; the inline-raise branch quotes the driver
+        # only, so this substring proves the dispatch path was taken.
         with pytest.raises(NotImplementedError) as exc:
             create_store("postgresql+psycopg://u:p@h/d")
-        assert "#312" in str(exc.value)
+        message = str(exc.value)
+        assert "Got database URL:" in message
+        assert "#312" in message
 
     def test_postgres_store_stub_raises_not_implemented(self) -> None:
         with pytest.raises(NotImplementedError) as exc:

--- a/server/backend/uv.lock
+++ b/server/backend/uv.lock
@@ -178,6 +178,7 @@ dependencies = [
     { name = "bcrypt" },
     { name = "cq-sdk" },
     { name = "fastapi" },
+    { name = "psycopg", extra = ["binary", "pool"] },
     { name = "pydantic" },
     { name = "pyjwt" },
     { name = "sqlalchemy" },
@@ -208,6 +209,7 @@ requires-dist = [
     { name = "bcrypt", specifier = ">=4.0" },
     { name = "cq-sdk", specifier = "~=0.9.1" },
     { name = "fastapi" },
+    { name = "psycopg", extras = ["binary", "pool"], specifier = ">=3.3.4,<4" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pyjwt", specifier = ">=2.0" },
     { name = "sqlalchemy", specifier = ">=2.0.49,<2.1" },
@@ -562,6 +564,90 @@ wheels = [
 ]
 
 [[package]]
+name = "psycopg"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/2f/cb91e5502ec9de1de6f1b76cfbf69531932725361168bb06963620c77e2e/psycopg-3.3.4.tar.gz", hash = "sha256:e21207764952cff81b6b8bdacad9a3939f2793367fdac2987b3aac36a651b5bc", size = 165799, upload-time = "2026-05-01T23:31:55.179Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/e0/7b3dee031daae7743609ce3c746565d4a3ed7c2c186479eb48e34e838c64/psycopg-3.3.4-py3-none-any.whl", hash = "sha256:b6bbc25ccf05c8fad3b061d9db2ef0909a555171b84b07f29458a447253d679a", size = 213001, upload-time = "2026-05-01T23:20:50.816Z" },
+]
+
+[package.optional-dependencies]
+binary = [
+    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
+]
+pool = [
+    { name = "psycopg-pool" },
+]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/82/df3312c0ca083d5b43b352f27d4dd8b1e614bd334473074715d9e0000da4/psycopg_binary-3.3.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:612a627d733f695b1de1f9b4bd511c15f999a5d8b915d444bbd7dd71cf3370da", size = 4609813, upload-time = "2026-05-01T23:26:30.612Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/b5/d74d542458d3e8ac0571d8a88f57ca369999b9a82f4fa528052d0d7d3e4c/psycopg_binary-3.3.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:13a7f380824c35896dcac7fe0f61440f7ca49d6dc73f3c13a9a4471e6a3b302e", size = 4676799, upload-time = "2026-05-01T23:26:38.475Z" },
+    { url = "https://files.pythonhosted.org/packages/09/67/06bab9c60671999f4c6ceff1b334f3ac1f9fc5789eb467c714623ea21de9/psycopg_binary-3.3.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:276904e3452d6a23d474ef9a21eee19f20eed3d53ddd2576af033827e0ba0992", size = 5497050, upload-time = "2026-05-01T23:26:47.061Z" },
+    { url = "https://files.pythonhosted.org/packages/72/9b/023433e2b20f970de1e22d29132a95281277646da0b2e2879dd4ee94b8c1/psycopg_binary-3.3.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ab8cca8ef8fb1ccf5b048ae5bd78ba55b9e4b5d472e3ce5ca39ff4d2a9c249e4", size = 5172428, upload-time = "2026-05-01T23:26:56.708Z" },
+    { url = "https://files.pythonhosted.org/packages/08/cd/ae16da8fde228a38b2fe9269bbc13cf89e0186173f2265600f02d6a71e64/psycopg_binary-3.3.4-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7465bfe6087d2d5b42d4c53b9b11ca9f218e477317a4a162a10e3c19e984ba8e", size = 6762746, upload-time = "2026-05-01T23:27:07.023Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/81/0ba09fa5f5f88779093a2541a8e02489825721f258ab88058b11d68b3eb5/psycopg_binary-3.3.4-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:22cdbf5f91ef7bb91fe0c5757e1962d3127a8010256eefd9c61fcaf441802097", size = 5006033, upload-time = "2026-05-01T23:27:12.221Z" },
+    { url = "https://files.pythonhosted.org/packages/73/6a/629136040cc3497adb442a305710b5913f2a754d4630fc3d3717c4c0df65/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e2631da29253a98bd496e6c4813b24e09a4fe3fb2a9e88513305d6f8747cce95", size = 4534175, upload-time = "2026-05-01T23:27:18.248Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/32/1027f843c6dc2d5d51960ee62cc0c2cf755a4c39455aff1371173edbef7d/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:7f7668f30b9dd5163197e5cbf4e0efd54e00f0a859cc566ce56cfc31f4054839", size = 4224203, upload-time = "2026-05-01T23:27:24.3Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/e1/380a724d9093c74adb14d4fce920ea8327838abb61f760b1448586b14a8e/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:cffc3408d77a27973f33e5d909b624cce683db5fc25964b02fe0aae7886c1007", size = 3954509, upload-time = "2026-05-01T23:27:30.815Z" },
+    { url = "https://files.pythonhosted.org/packages/db/cd/895893ae575a09c97ccfd5def070d88993d955ef34df45a881fd5ff506d6/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0579252a1202cd73e4da137a1426e2dae993ae44e757605344282af3a082848c", size = 4259551, upload-time = "2026-05-01T23:27:38.828Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/c6/2330a20794e37a3ec609ef2fd8522919ec7a4395a1abf979a8e2d1775cd5/psycopg_binary-3.3.4-cp311-cp311-win_amd64.whl", hash = "sha256:41f2ec0fea529832982bcb6c9415de3c86264ebe562b77a467c0fbcd7efbba8d", size = 3572054, upload-time = "2026-05-01T23:27:45.455Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7d/03818e13ba7f36de93573c93ee3482006d3dfa8b0f8d28df511bad0a1a92/psycopg_binary-3.3.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5ab28a2a7649df3b72e6b674b4c190e448e8e77cf496a65bd846472048de2089", size = 4591122, upload-time = "2026-05-01T23:27:56.162Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/b9/11b341edf8d54e2694726b273fe9652b254d989f4f63e3ac6816ad6b55f4/psycopg_binary-3.3.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6402a9d8146cf4b3974ded3fd28a971e83dc6a0333eb7822524a3aa20b546578", size = 4669943, upload-time = "2026-05-01T23:28:04.522Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/18/4665bacd65e7865b4372fcd8abb8b9186ada4b0025f8c2ca691b364a556c/psycopg_binary-3.3.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:580ae30a5f95ccd90008ec697d3ed6a4a2047a516407ad904283fa42086936e9", size = 5469697, upload-time = "2026-05-01T23:28:11.337Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/b1/b83136c6e510593d9b0c759ba5384337bc4ad82d19fda675adc4b2703c84/psycopg_binary-3.3.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e7510c37550f91a187e3660a8cc50d4b760f8c3b8b2f89ebc5698cd2c7f2c85d", size = 5152995, upload-time = "2026-05-01T23:28:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/67/8d/a9821e2a648afe6091989929982a3b0f00b2631a859cb81379728f08fb75/psycopg_binary-3.3.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:77df19583501ea288eaf15ac0fe7ad01e6d8091a91d5c41df5c718f307d8e31b", size = 6738180, upload-time = "2026-05-01T23:28:30.654Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/58/2e349e8d23905dc2317b80ac65f48fb6f821a4777a4e994a60da91c4850f/psycopg_binary-3.3.4-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:018fbed325936da502feb546642c982dcc4b9ffdea32dfef78dbf3b7f7ad4070", size = 4978828, upload-time = "2026-05-01T23:28:37.277Z" },
+    { url = "https://files.pythonhosted.org/packages/45/48/57b00d03b4721878326122a1f1e6b0a90b85bcaec56b5b2f8ea6cfa45235/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:17a21953a9e5ff3a16dab692625a3676e2f101db5e40072f39dbee2250194d68", size = 4509757, upload-time = "2026-05-01T23:28:43.078Z" },
+    { url = "https://files.pythonhosted.org/packages/25/37/33b47d8c007df69aec500df5889767c4d313748e8e9e27a2fef8a6dabcee/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:eb05ee1c2b817d27c537333224c9e83c7afb86fe7296ba970990068baf819b16", size = 4190546, upload-time = "2026-05-01T23:28:50.016Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/c6/32b0835dbc2122617902b649d76a91c1e75406e76bf3d595b0c3bb5ffad6/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:773d573e11f437ce0bdb95b7c18dc58390494f96d43f8b45b9760436114f7652", size = 3926197, upload-time = "2026-05-01T23:28:55.55Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/68/d190ef0c0c5b16ded07831dabc8ddd412f4cdab07ec6e30ed38d9bda0e1f/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:71e55ccbdfae79a2ed9c6369c3008a3025817ff9d7e27b32a2d84e2a4267e66e", size = 4236627, upload-time = "2026-05-01T23:29:05.336Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8f/81dcbc2e8454b74d14881275ea45f00791052dac531a9fa8be1730d1685b/psycopg_binary-3.3.4-cp312-cp312-win_amd64.whl", hash = "sha256:494ca54901be8cf9eb7e02c25b731f2317c378efa44f43e8f9bd0e1184ae7be4", size = 3560782, upload-time = "2026-05-01T23:29:11.967Z" },
+    { url = "https://files.pythonhosted.org/packages/09/43/13e9c406fbbf354580476e248a16b64802a376873ebe6339e30bb655572d/psycopg_binary-3.3.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fbd1d4ed566895ad2d3bf4ddfd8bae90026930ddf29df3b9d91d32c8c47866a7", size = 4590377, upload-time = "2026-05-01T23:29:18.782Z" },
+    { url = "https://files.pythonhosted.org/packages/22/be/2923cd7c3683e7afdecf4f10796a18de02f5c5ddc0969aa2ad0a8cdd3bbd/psycopg_binary-3.3.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:75a9067e236f9b9ae3535b66fe99bddb33d39c0de10112e49b9ab11eee53dc31", size = 4669023, upload-time = "2026-05-01T23:29:25.884Z" },
+    { url = "https://files.pythonhosted.org/packages/96/a0/2c913d6fe13d6a8bd13597d36739bf47af063ad9399e402cfecab16f3c1e/psycopg_binary-3.3.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:b56b603ebcea8aa10b46228b8410ba7f13e7c2ee54389d4d9be0927fd8ce2a70", size = 5467423, upload-time = "2026-05-01T23:29:33.416Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/38/205d10bc1ad0df4a21c5c51659126bd3ea0ef98fcad1e852f78c249bb9c3/psycopg_binary-3.3.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c677c4ad433cb7150c8cd304a0769ae3bcfbe5ea0676eb53faa7b1443b16d0d3", size = 5151137, upload-time = "2026-05-01T23:29:42.013Z" },
+    { url = "https://files.pythonhosted.org/packages/36/fc/f0381ddcd45eff3bb70dbca6823a996048d7f507b2ec3fc92c6fabc0fe87/psycopg_binary-3.3.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:26df2717e59c0473e4465a97dfb1b7afebaa479277870fd5784d1436470db47c", size = 6736671, upload-time = "2026-05-01T23:29:51.626Z" },
+    { url = "https://files.pythonhosted.org/packages/95/40/fa545ae152c24327651e5624e4902121e808270be36c10b12e9939be09bc/psycopg_binary-3.3.4-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1dc1f79fd16bb1f3f4421417a514607539f17804d95c7ed617265369d1981cae", size = 4979601, upload-time = "2026-05-01T23:29:56.961Z" },
+    { url = "https://files.pythonhosted.org/packages/86/e4/2f8a47ee97f90cd2b933d0463081d35631ff419de2b8c984a5f369857de0/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:136f199a407b5348b9b857c504aff60c77622a28482e7195839ce1b51238c4cc", size = 4510513, upload-time = "2026-05-01T23:30:07.243Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/0e/94e842ff4a7f98ed162580ca2e8b8864b28c1e0350f2443f8ee47f821167/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:b6f5a29e9c775b9f12a1a717aa7a2c80f9e1db6f27ba44a5b59c80ac61d2ffcf", size = 4187243, upload-time = "2026-05-01T23:30:15.352Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/83/fc6c174b672e29b7de996ea77b6cbddf46c891751c3355f6974292baa6b4/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:ee17a2cf4943cde261adfad1bbc5bf38d6b3776d7afff74c7cabcbeaeb08c260", size = 3927347, upload-time = "2026-05-01T23:30:21.186Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/65/768364d4a97a15b1a7f47ba52688c1686f22941d8332a8398cefc468e25f/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5c4ab71be17bdca30cb34c34c4e1496e2f5d6f20c199c12bad226070b22ef9bf", size = 4236393, upload-time = "2026-05-01T23:30:26.211Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/3b/218efbc9e645becd80cdf651acda05f85cfe546b7a9c0458c7cbc8fe1f74/psycopg_binary-3.3.4-cp313-cp313-win_amd64.whl", hash = "sha256:dbfdb9b6cc79f31104a7b162a2b921b765fcc62af6c00540a167a8de47e4ed38", size = 3564592, upload-time = "2026-05-01T23:30:31.764Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a6/828c9185701dab71b234c2a76c38a08b098ebfec5020716b4e93807492b5/psycopg_binary-3.3.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:28b7398fdd19db3232c884fb24550bdfe951221f510e195e233299e4c9b78f97", size = 4607292, upload-time = "2026-05-01T23:30:38.962Z" },
+    { url = "https://files.pythonhosted.org/packages/92/58/5b40dbc9d839045c9dae956960e4fb6d20bcabe6c59a2aa34fc3a371913f/psycopg_binary-3.3.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1fbaa292a3c8bb61b45df1ad3da1908ccee7cb889db9425e3557d9e34e2a4829", size = 4687023, upload-time = "2026-05-01T23:30:47.227Z" },
+    { url = "https://files.pythonhosted.org/packages/85/a9/793f0ac107a9003b48441d0d1f9f616d96e0f37458dd8dc12528ceff55fb/psycopg_binary-3.3.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:94596f9e7633ee3f6440711d43bb70aa31cc0a46a900ab8b4201a366ace5c9e7", size = 5486985, upload-time = "2026-05-01T23:30:55.517Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/26/42e8533497e2592334f68ec529cf5f840f7fa4e99575a4bb61aa184dbfbf/psycopg_binary-3.3.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8c0056529e68dbe9184cd4019a1f3d8f3a4ead2f6fc7a5afcf27d3314edd1277", size = 5168745, upload-time = "2026-05-01T23:31:01.904Z" },
+    { url = "https://files.pythonhosted.org/packages/15/af/b7151776cc08d5935d45c833ec818a9beb417cf7c08239af1aafbdae78ee/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c09aad7051326e7603c14e50636db9c01f78272dc54b3accff03d46370461e6", size = 6761486, upload-time = "2026-05-01T23:31:14.511Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/ed/c92533b9124712d592cbf1cd6c76da933a2e0acea81dfe1fbe7e735f0cff/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:514404ed543efd620c85602b747df2a23cf1241b4067199e1a66f2d2757aaa41", size = 4997427, upload-time = "2026-05-01T23:31:20.901Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/23/ccadfd0de416aa188356daa199453af24087b042e296088706d190ae0295/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:46893c26858be12cc49ca4226ed6a60b4bfccadd946b3bebb783a60b38788228", size = 4533549, upload-time = "2026-05-01T23:31:26.204Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a0/c8f43cee36386f7bc891ab41a9d31ea07cf9826038e732da79f26b1e5f34/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:df1d567fc430f6df15c9fcf67d87685fc49bdb325adc0db5af1adfb2f44eb5c9", size = 4210256, upload-time = "2026-05-01T23:31:33.884Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/2c/c1547871be3790676e8868b38655496422f94f0978dfb66b74bdba2f1676/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:6b9016b1714da4dd5ecaaa75b82098aa5a0b87854ce9b092e21c27c4ae23e014", size = 3946204, upload-time = "2026-05-01T23:31:39.626Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b1/f6670f00fa7ea601584623f6c11602ab92117d83eaff885e0210f6de7418/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:47c656a8a7ba6eb0cff1801a4caaa9c8bdc12d03080e273aff1c8ac39971a77e", size = 4255811, upload-time = "2026-05-01T23:31:44.986Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e6/5fff07a70d1f945ed90ae131c3bd76cab32beff7c58c6db15ad5820b6d1f/psycopg_binary-3.3.4-cp314-cp314-win_amd64.whl", hash = "sha256:c37e024c07308cd06cf3ec51bfd0e7f6157585a4d84d1bce4a7f5f7913719bf8", size = 3666849, upload-time = "2026-05-01T23:31:51.165Z" },
+]
+
+[[package]]
+name = "psycopg-pool"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/82/7a23d26039827ecd4ebe93905651029ddd307c5182ad59296dfb6f67b528/psycopg_pool-3.3.1.tar.gz", hash = "sha256:b10b10b7a175d5cc1592147dc5b7eec8a9e0834eb3ed2c4a92c858e2f51eb63c", size = 31661, upload-time = "2026-05-01T23:31:59.809Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/ed/89c2c620af0e1660354cd8aabf9f5b21f911597ce22acb37c805d6c86bc8/psycopg_pool-3.3.1-py3-none-any.whl", hash = "sha256:2af5b432941c4c9ad5c87b3fa410aec910ec8f7c122855897983a06c45f2e4b5", size = 40023, upload-time = "2026-05-01T23:31:53.136Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.12.5"
 source = { registry = "https://pypi.org/simple" }
@@ -907,6 +993,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Phase 2 step (1) of #257 / RFC #275, closing #311.

- Add `psycopg[binary,pool]>=3.3.4,<4` to `server/backend/pyproject.toml` and regenerate `uv.lock`.
- New `cq_server.store._postgres.PostgresStore` stub whose `__init__` raises `NotImplementedError` pointing at the Phase 2 implementation issue (#312).
- `create_store()` dispatches `postgresql+psycopg://...` URLs through `PostgresStore(database_url)`; other Postgres driver suffixes still raise `NotImplementedError` inline with a sharper message steering users at `+psycopg`.
- Update tests/docs to reflect the new pointer (only #312 now that #311 itself is landing).

## TDD

- `test_postgres_store_stub_raises_not_implemented` and `test_psycopg_url_dispatches_through_postgres_store` were red before the `PostgresStore` stub existed.
- Existing parameterized Postgres-URL test updated to assert `#312` + `PostgresStore` in the error message (instead of the old `#311`/`#312` pair).
- `test_app.py::TestDatabaseUrlBoot::test_postgres_url_fails_fast_with_guidance` updated to match the new lifespan boot message shape.

## Definition of Done checklist

- [x] TDD: failing test for the Postgres branch landed first
- [x] Full test suite green (314 passed)
- [x] Lint clean (`make lint-server-backend` — ruff, ruff format, ty, uv lock --check, detect-secrets)
- [x] `uv.lock` committed

## Test plan

- [x] CI runs `pytest` + `ruff` against `server/backend` (Lint, Test 3.11/3.12/3.13, Validate schemas — all green)
- [x] Manual smoke: default-fallback path (no `CQ_DATABASE_URL`, `CQ_DB_PATH=/tmp/cq-smoke/default.db`) — server boots, `/health` returns 200, migrations run
- [x] Manual smoke: legacy `CQ_DB_PATH=/tmp/cq-smoke/legacy.db` — server boots, `/health` returns 200, db file created
- [x] Manual smoke: `CQ_DATABASE_URL=sqlite:////tmp/cq-smoke/explicit.db` — server boots, `/health` returns 200
- [x] Manual smoke: `CQ_DATABASE_URL=postgresql+psycopg://u:p@h/d` — fails fast at startup; traceback dispatches through `create_store → PostgresStore.__init__` and surfaces `NotImplementedError: PostgresStore is not implemented yet; the psycopg v3-backed implementation lands in epic #257 (issue #312). Got database URL: 'postgresql+psycopg://u:p@h/d'`

Closes #311.

🤖 Generated with [Claude Code](https://claude.com/claude-code)