### PR TITLE
cli: add cq auth key for per-agent API key management

### DIFF
--- a/cli/cmd/auth.go
+++ b/cli/cmd/auth.go
@@ -116,6 +116,7 @@ func NewAuthCmd(opts ...AuthOption) *cobra.Command {
 		Long:  authLongDoc,
 	}
 
+	cmd.AddCommand(newAuthKeyCmd(cfg))
 	cmd.AddCommand(newAuthLoginCmd(cfg))
 	cmd.AddCommand(newAuthLogoutCmd(cfg))
 	cmd.AddCommand(newAuthProvidersCmd(cfg))

--- a/cli/cmd/auth_key.go
+++ b/cli/cmd/auth_key.go
@@ -1,0 +1,383 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/mozilla-ai/cq/cli/internal/auth"
+	"github.com/mozilla-ai/cq/cli/internal/credstore"
+)
+
+// ttlPattern is the canonical (lower-case) form of the platform's TTL
+// grammar. Inputs are lower-cased before matching so "3D" and "3d" are
+// accepted equivalently from the CLI even though the platform expects
+// the lower-case form on the wire.
+//
+// TODO: replace with a shared SDK helper once the Go and Python SDKs
+// expose a single TTL parser; see mozilla-ai/cq issue tracking the lift.
+var ttlPattern = regexp.MustCompile(`^[0-9]+[smhd]$`)
+
+// authKeyCreateLongDoc is the help text shown for cq auth key create.
+var authKeyCreateLongDoc = `Create a new API key.
+
+The API key is shown exactly once, on stdout, so it can be captured by
+a shell script with command substitution:
+
+    KEY=$(cq auth key create --name claude-cursor --ttl 90d)
+
+Human-readable status (the key's ID, prefix, and expiry) is written to
+stderr so it does not contaminate the captured value. The API key is
+not recoverable after this command returns; if you lose it, revoke the
+key and create a new one.`
+
+// authKeyListLongDoc is the help text shown for cq auth key list.
+var authKeyListLongDoc = `List your API keys.
+
+The platform never returns API keys themselves; only metadata is
+shown. Revoked and expired keys are included so you can audit your own
+revocation history.
+
+Use --json for machine-readable output suitable for piping into jq or
+similar tooling.`
+
+// authKeyLongDoc is the help text shown for the cq auth key parent
+// command.
+var authKeyLongDoc = `Manage long-lived API keys for the authenticated user.
+
+API keys authenticate data-plane commands (cq propose, cq confirm,
+cq flag, ...). Each key is independent: revoking one does not affect
+any other key. Keys are scoped to the human account; the key name and
+labels are metadata for the operator, not a separate identity.
+
+All subcommands here use the session JWT stored by cq auth login, not
+an API key. If your session has expired, run cq auth login again.`
+
+// authKeyRevokeLongDoc is the help text shown for cq auth key revoke.
+var authKeyRevokeLongDoc = `Revoke an API key by its ID.
+
+Revocation is idempotent: revoking an already-revoked key returns
+success. A cq platform should retain the API key record with a
+revoked-at marker so the listing remains audit-friendly while the key
+itself stops working immediately.
+
+Pass the key's ID (not its prefix) as the positional argument. Find it
+with cq auth key list.`
+
+// newAuthKeyCmd returns the cq auth key parent command and its
+// create, list, and revoke subcommands.
+func newAuthKeyCmd(cfg authOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "key",
+		Short: "Manage API keys for the authenticated user.",
+		Long:  authKeyLongDoc,
+	}
+
+	cmd.AddCommand(newAuthKeyCreateCmd(cfg))
+	cmd.AddCommand(newAuthKeyListCmd(cfg))
+	cmd.AddCommand(newAuthKeyRevokeCmd(cfg))
+
+	return cmd
+}
+
+// newAuthKeyCreateCmd returns the cq auth key create subcommand.
+func newAuthKeyCreateCmd(cfg authOptions) *cobra.Command {
+	var (
+		name   string
+		ttl    string
+		labels []string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a new API key.",
+		Long:  authKeyCreateLongDoc,
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			// Args/flag validation has already run; anything from here
+			// down is an operational failure where the usage banner only
+			// adds noise, so suppress it for any error path below.
+			cmd.SilenceUsage = true
+
+			canonicalTTL, err := parseTTL(ttl)
+			if err != nil {
+				return err
+			}
+
+			client, jwt, err := authKeySetup(cfg)
+			if err != nil {
+				return err
+			}
+
+			created, err := client.CreateAPIKey(cmd.Context(), jwt, auth.CreateAPIKeyRequest{
+				Name:   name,
+				TTL:    canonicalTTL,
+				Labels: labels,
+			})
+			if err != nil {
+				return mapAuthKeyError(cmd, err)
+			}
+
+			renderCreatedKey(cmd.OutOrStdout(), cmd.ErrOrStderr(), created)
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&name, "name", "", "Display name for the key (required).")
+	cmd.Flags().StringVar(&ttl, "ttl", "", "Lifetime in the format <integer><s|m|h|d>, e.g. 30d, 12h. Max 365d. Required.")
+	cmd.Flags().StringSliceVar(&labels, "labels", nil, "Optional labels (repeat --labels or supply a comma-separated list).")
+
+	_ = cmd.MarkFlagRequired("name")
+	_ = cmd.MarkFlagRequired("ttl")
+
+	return cmd
+}
+
+// newAuthKeyListCmd returns the cq auth key list subcommand.
+func newAuthKeyListCmd(cfg authOptions) *cobra.Command {
+	var asJSON bool
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List your API keys.",
+		Long:  authKeyListLongDoc,
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cmd.SilenceUsage = true
+
+			client, jwt, err := authKeySetup(cfg)
+			if err != nil {
+				return err
+			}
+
+			keys, err := client.ListAPIKeys(cmd.Context(), jwt)
+			if err != nil {
+				return mapAuthKeyError(cmd, err)
+			}
+
+			return renderKeyList(cmd.OutOrStdout(), cmd.ErrOrStderr(), keys, asJSON)
+		},
+	}
+
+	cmd.Flags().BoolVar(&asJSON, "json", false, "Emit JSON instead of plain text.")
+
+	return cmd
+}
+
+// newAuthKeyRevokeCmd returns the cq auth key revoke subcommand.
+func newAuthKeyRevokeCmd(cfg authOptions) *cobra.Command {
+	return &cobra.Command{
+		Use:   "revoke <key-id>",
+		Short: "Revoke an API key by its ID.",
+		Long:  authKeyRevokeLongDoc,
+		Args: func(_ *cobra.Command, args []string) error {
+			if len(args) != 1 || strings.TrimSpace(args[0]) == "" {
+				return errors.New(`key ID required. Run "cq auth key list" to find one`)
+			}
+
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
+
+			client, jwt, err := authKeySetup(cfg)
+			if err != nil {
+				return err
+			}
+
+			keyID := strings.TrimSpace(args[0])
+
+			if err := client.RevokeAPIKey(cmd.Context(), jwt, keyID); err != nil {
+				return mapAuthKeyError(cmd, err)
+			}
+
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Revoked API key %s.\n", keyID)
+
+			return nil
+		},
+	}
+}
+
+// authKeySetup resolves the platform address, opens the credential
+// store, loads the session JWT, and builds the platform client. It
+// centralises the prerequisites every auth key subcommand shares.
+func authKeySetup(cfg authOptions) (auth.Client, string, error) {
+	addr, err := requireAuthAddr()
+	if err != nil {
+		return nil, "", err
+	}
+
+	store, err := cfg.newStore()
+	if err != nil {
+		return nil, "", fmt.Errorf("opening credential store: %w", err)
+	}
+
+	creds, err := store.Load()
+	if err != nil {
+		if errors.Is(err, credstore.ErrNotFound) {
+			return nil, "", errors.New(`not signed in. Run "cq auth login <provider>" first`)
+		}
+
+		return nil, "", fmt.Errorf("loading credentials: %w", err)
+	}
+
+	if creds.SessionJWT == "" {
+		return nil, "", errors.New(`stored credentials missing session JWT. Run "cq auth login <provider>" again`)
+	}
+
+	return cfg.newClient(addr), creds.SessionJWT, nil
+}
+
+// formatKeyStatus returns a single-word status for the key suitable for
+// table rendering. The platform-supplied IsExpired and IsActive fields
+// are computed at response time, so we trust them rather than recomputing
+// against the local clock.
+func formatKeyStatus(k auth.APIKey) string {
+	switch {
+	case k.RevokedAt != nil:
+		return "revoked"
+	case k.IsExpired:
+		return "expired"
+	case k.IsActive:
+		return "active"
+	default:
+		return "inactive"
+	}
+}
+
+// formatLabels renders a key's labels for plain-text output. An empty
+// list renders as "-" so columns line up.
+func formatLabels(labels []string) string {
+	if len(labels) == 0 {
+		return "-"
+	}
+
+	return strings.Join(labels, ",")
+}
+
+// parseTTL validates that s matches the platform's TTL grammar and
+// returns it in canonical (lower-case) form. The grammar is
+// <integer><unit>, where unit is one of s, m, h, d. The CLI accepts
+// either case (3D and 3d are equivalent on input) and always sends
+// the lower-case form on the wire because the platform validator is
+// case-sensitive today.
+//
+// TODO: replace with the shared SDK TTL parser once it lands; the
+// validator should be a single source of truth across CLI and any
+// other Go consumers. Tracked in mozilla-ai/cq.
+func parseTTL(s string) (string, error) {
+	canonical := strings.ToLower(strings.TrimSpace(s))
+
+	if canonical == "" {
+		return "", errors.New("--ttl is required: supply a value like 30d, 12h, 90d (max 365d)")
+	}
+
+	if !ttlPattern.MatchString(canonical) {
+		return "", fmt.Errorf("--ttl %q is not a valid duration: expected <integer><s|m|h|d>, e.g. 30d, 12h", s)
+	}
+
+	return canonical, nil
+}
+
+// mapAuthKeyError turns a platform error into a user-friendly cobra
+// error. The cmd is used to silence cobra's usage banner on the typed
+// errors where it would only add noise.
+func mapAuthKeyError(cmd *cobra.Command, err error) error {
+	if errors.Is(err, auth.ErrSessionExpired) {
+		cmd.SilenceUsage = true
+
+		return errors.New(`session expired or invalid. Run "cq auth login <provider>" to sign in again`)
+	}
+
+	var capReached *auth.APIKeyLimitReachedError
+	if errors.As(err, &capReached) {
+		cmd.SilenceUsage = true
+
+		if capReached.Detail != "" {
+			return fmt.Errorf("cannot create key: %s", capReached.Detail)
+		}
+
+		return errors.New("cannot create key: active API key limit reached. Revoke a key first")
+	}
+
+	var notFound *auth.APIKeyNotFoundError
+	if errors.As(err, &notFound) {
+		cmd.SilenceUsage = true
+
+		return fmt.Errorf("API key %s not found", notFound.KeyID)
+	}
+
+	var validation *auth.APIKeyValidationError
+	if errors.As(err, &validation) {
+		cmd.SilenceUsage = true
+
+		if validation.Detail != "" {
+			return fmt.Errorf("invalid request: %s", validation.Detail)
+		}
+
+		return errors.New("invalid request")
+	}
+
+	return err
+}
+
+// renderCreatedKey writes the create response: the API key to stdout
+// (so a shell can capture it cleanly) and a human-readable banner to
+// stderr.
+func renderCreatedKey(stdout, stderr io.Writer, created auth.CreatedAPIKey) {
+	_, _ = fmt.Fprintln(stdout, created.Token)
+
+	expires := created.ExpiresAt.UTC().Format(time.RFC3339)
+	labels := formatLabels(created.Labels)
+	_, _ = fmt.Fprintf(stderr,
+		"Created API key '%s' (id=%s prefix=%s labels=%s expires=%s).\n"+
+			"The API key above is shown only once. Save it now (e.g. export CQ_API_KEY=...).\n",
+		created.Name, created.ID, created.Prefix, labels, expires,
+	)
+}
+
+// renderKeyList writes the list response in either plain text or JSON.
+// Plain text is one row per key with id, prefix, status, expiry, name,
+// and labels. The empty-list message is written to stderr so a script
+// capturing stdout (e.g. KEYS=$(cq auth key list)) sees an empty
+// string in the no-keys case rather than a sentinel "No API keys."
+// line that callers would otherwise have to special-case.
+func renderKeyList(stdout, stderr io.Writer, keys []auth.APIKey, asJSON bool) error {
+	if asJSON {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", jsonIndent)
+
+		// Emit a stable envelope so jq users can rely on the shape
+		// regardless of how the platform wraps its response.
+		return enc.Encode(struct {
+			Data  []auth.APIKey `json:"data"`
+			Count int           `json:"count"`
+		}{Data: keys, Count: len(keys)})
+	}
+
+	if len(keys) == 0 {
+		_, _ = fmt.Fprintln(stderr, "No API keys.")
+
+		return nil
+	}
+
+	for _, k := range keys {
+		_, _ = fmt.Fprintf(stdout, "%s\t%s\t%s\t%s\t%s\t%s\n",
+			k.ID,
+			k.Prefix,
+			formatKeyStatus(k),
+			k.ExpiresAt.UTC().Format(time.RFC3339),
+			k.Name,
+			formatLabels(k.Labels),
+		)
+	}
+
+	return nil
+}

--- a/cli/cmd/auth_key.go
+++ b/cli/cmd/auth_key.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -14,6 +15,11 @@ import (
 	"github.com/mozilla-ai/cq/cli/internal/auth"
 	"github.com/mozilla-ai/cq/cli/internal/credstore"
 )
+
+// maxAPIKeyTTL caps the lifetime parseTTL will accept. Matches the
+// platform's upper bound; kept here so the CLI can fail fast without
+// a round-trip and the help text and validator agree.
+const maxAPIKeyTTL = 365 * 24 * time.Hour // pragma: allowlist secret
 
 // ttlPattern is the canonical (lower-case) form of the platform's TTL
 // grammar. Inputs are lower-cased before matching so "3D" and "3d" are
@@ -267,7 +273,8 @@ func formatLabels(labels []string) string {
 // <integer><unit>, where unit is one of s, m, h, d. The CLI accepts
 // either case (3D and 3d are equivalent on input) and always sends
 // the lower-case form on the wire because the platform validator is
-// case-sensitive today.
+// case-sensitive today. Values whose total duration exceeds
+// maxAPIKeyTTL are rejected so the help text and the validator agree.
 //
 // TODO: replace with the shared SDK TTL parser once it lands; the
 // validator should be a single source of truth across CLI and any
@@ -281,6 +288,34 @@ func parseTTL(s string) (string, error) {
 
 	if !ttlPattern.MatchString(canonical) {
 		return "", fmt.Errorf("--ttl %q is not a valid duration: expected <integer><s|m|h|d>, e.g. 30d, 12h", s)
+	}
+
+	// The grammar guarantees a non-empty digit run followed by exactly
+	// one unit byte, so the slice operations below are safe and the
+	// numeric parse only fails when the user supplies more digits than
+	// fit in an int64 (which trivially exceeds the cap anyway).
+	digits := canonical[:len(canonical)-1]
+	unit := canonical[len(canonical)-1]
+
+	value, err := strconv.ParseInt(digits, 10, 64)
+	if err != nil {
+		return "", fmt.Errorf("--ttl %q exceeds the maximum of 365d", s)
+	}
+
+	var unitDuration time.Duration
+	switch unit {
+	case 's':
+		unitDuration = time.Second
+	case 'm':
+		unitDuration = time.Minute
+	case 'h':
+		unitDuration = time.Hour
+	case 'd':
+		unitDuration = 24 * time.Hour
+	}
+
+	if value > int64(maxAPIKeyTTL/unitDuration) {
+		return "", fmt.Errorf("--ttl %q exceeds the maximum of 365d", s)
 	}
 
 	return canonical, nil

--- a/cli/cmd/auth_key_test.go
+++ b/cli/cmd/auth_key_test.go
@@ -1,0 +1,521 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mozilla-ai/cq/cli/internal/auth"
+	"github.com/mozilla-ai/cq/cli/internal/credstore"
+)
+
+// signedInStore returns a memStore preloaded with a session JWT, the
+// usual prerequisite for any `cq auth key` subcommand.
+func signedInStore(t *testing.T) *memStore {
+	t.Helper()
+
+	s := &memStore{}
+	require.NoError(t, s.Save(credstore.Credentials{SessionJWT: "test-jwt", Username: "alice"}))
+
+	return s
+}
+
+// runKey runs the named `cq auth key` subcommand against the supplied
+// client and store, returning the stdout, stderr, and error.
+func runKey(t *testing.T, client auth.Client, store credstore.Store, args ...string) (string, string, error) {
+	t.Helper()
+	testSetup(t)
+	setFlag(t, &flagAddr, "https://platform.example.com")
+
+	cmd := NewAuthCmd(stubStore(store), stubClient(client))
+	cmd.SetArgs(append([]string{"key"}, args...))
+
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	err := cmd.ExecuteContext(context.Background())
+
+	return stdout.String(), stderr.String(), err
+}
+
+// TestParseTTL covers the inline TTL validator the create flow uses
+// before reaching the platform. Mixed-case input is accepted and
+// normalised to lower-case; anything that does not match the platform
+// grammar is rejected with a single-shot, parse-locally error.
+//
+// TODO: remove this test once TTL parsing moves into the Go SDK; the
+// SDK should own its own coverage and the CLI will then exercise it
+// only through the create command's stub-based tests above.
+func TestParseTTL(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr string
+	}{
+		{name: "lower-case days", input: "30d", want: "30d"},
+		{name: "lower-case hours", input: "12h", want: "12h"},
+		{name: "lower-case minutes", input: "45m", want: "45m"},
+		{name: "lower-case seconds", input: "60s", want: "60s"},
+		{name: "upper-case days canonicalised", input: "3D", want: "3d"},
+		{name: "upper-case hours canonicalised", input: "2H", want: "2h"},
+		{name: "leading and trailing whitespace trimmed", input: "  90d  ", want: "90d"},
+		{name: "empty rejected", input: "", wantErr: "--ttl is required"},
+		{name: "whitespace-only rejected", input: "   ", wantErr: "--ttl is required"},
+		{name: "weeks rejected", input: "1w", wantErr: `--ttl "1w" is not a valid duration`},
+		{name: "missing unit rejected", input: "30", wantErr: `--ttl "30" is not a valid duration`},
+		{name: "unit only rejected", input: "d", wantErr: `--ttl "d" is not a valid duration`},
+		{name: "wrong order rejected", input: "d30", wantErr: `--ttl "d30" is not a valid duration`},
+		{name: "decimal rejected", input: "3.5d", wantErr: `--ttl "3.5d" is not a valid duration`},
+		{name: "negative rejected", input: "-1d", wantErr: `--ttl "-1d" is not a valid duration`},
+		{name: "compound rejected", input: "1d2h", wantErr: `--ttl "1d2h" is not a valid duration`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := parseTTL(tc.input)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.wantErr)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestNewAuthKeyCmd_RegistersExpectedSubcommands(t *testing.T) {
+	cmd := NewAuthCmd()
+
+	var keyCmd *cobra.Command
+	for _, sub := range cmd.Commands() {
+		if sub.Name() == "key" {
+			keyCmd = sub
+		}
+	}
+
+	require.NotNil(t, keyCmd, "expected `key` subcommand under `auth`")
+
+	got := make(map[string]bool)
+	for _, sub := range keyCmd.Commands() {
+		got[sub.Name()] = true
+	}
+
+	require.True(t, got["create"], "expected create subcommand")
+	require.True(t, got["list"], "expected list subcommand")
+	require.True(t, got["revoke"], "expected revoke subcommand")
+}
+
+// --- cq auth key create -----------------------------------------------------
+
+// TestAuthKeyCreate_HappyPath_StdoutTokenStderrBanner pins the exact
+// terminal output a successful `cq auth key create` produces. Stdout
+// carries only the plaintext token (one trailing newline) so a shell
+// can capture it cleanly with command substitution. Stderr carries the
+// human banner with the key's ID, prefix, labels, expiry, and the
+// "shown only once" warning.
+func TestAuthKeyCreate_HappyPath_StdoutTokenStderrBanner(t *testing.T) {
+	expires := time.Date(2026, 8, 6, 12, 0, 0, 0, time.UTC)
+	created := auth.CreatedAPIKey{
+		APIKey: auth.APIKey{
+			ID:        "00000000-0000-0000-0000-000000000001",
+			Name:      "claude-cursor",
+			Labels:    []string{"ci", "laptop"},
+			Prefix:    "cqa12345",
+			TTL:       "90d",
+			ExpiresAt: expires,
+			IsActive:  true,
+		},
+		Token: "cqa.v1.0123.secret",
+	}
+
+	var gotJWT string
+	var gotReq auth.CreateAPIKeyRequest
+
+	client := &stubAuthClient{
+		createAPIKey: func(_ context.Context, jwt string, req auth.CreateAPIKeyRequest) (auth.CreatedAPIKey, error) {
+			gotJWT = jwt
+			gotReq = req
+
+			return created, nil
+		},
+	}
+
+	stdout, stderr, err := runKey(t, client, signedInStore(t),
+		"create", "--name", "claude-cursor", "--ttl", "90d", "--labels", "ci,laptop",
+	)
+	require.NoError(t, err)
+	require.Equal(t, "test-jwt", gotJWT)
+	require.Equal(t, "claude-cursor", gotReq.Name)
+	require.Equal(t, "90d", gotReq.TTL)
+	require.Equal(t, []string{"ci", "laptop"}, gotReq.Labels)
+
+	require.Equal(t, "cqa.v1.0123.secret\n", stdout)
+	require.Equal(t,
+		"Created API key 'claude-cursor' (id=00000000-0000-0000-0000-000000000001 prefix=cqa12345 labels=ci,laptop expires=2026-08-06T12:00:00Z).\n"+
+			"The API key above is shown only once. Save it now (e.g. export CQ_API_KEY=...).\n",
+		stderr,
+	)
+}
+
+// TestAuthKeyCreate_NoLabels_BannerRendersDashSentinel pins the banner
+// shape when no --labels are supplied: the labels= field renders as a
+// literal "-" so the column does not collapse.
+func TestAuthKeyCreate_NoLabels_BannerRendersDashSentinel(t *testing.T) {
+	client := &stubAuthClient{
+		createAPIKey: func(context.Context, string, auth.CreateAPIKeyRequest) (auth.CreatedAPIKey, error) {
+			return auth.CreatedAPIKey{
+				APIKey: auth.APIKey{
+					ID:        "id-1",
+					Name:      "no-label-key",
+					Prefix:    "cqaPPPP",
+					TTL:       "30d",
+					ExpiresAt: time.Date(2026, 6, 7, 0, 0, 0, 0, time.UTC),
+				},
+				Token: "cqa.v1.token",
+			}, nil
+		},
+	}
+
+	stdout, stderr, err := runKey(t, client, signedInStore(t), "create", "--name", "no-label-key", "--ttl", "30d")
+	require.NoError(t, err)
+	require.Equal(t, "cqa.v1.token\n", stdout)
+	require.Equal(t,
+		"Created API key 'no-label-key' (id=id-1 prefix=cqaPPPP labels=- expires=2026-06-07T00:00:00Z).\n"+
+			"The API key above is shown only once. Save it now (e.g. export CQ_API_KEY=...).\n",
+		stderr,
+	)
+}
+
+// TestAuthKeyCreate_RequiresTTL pins the missing-TTL shape: the user
+// must spell out the lifetime themselves; there is no default. cobra's
+// MarkFlagRequired runs before RunE and emits a single Error: line.
+func TestAuthKeyCreate_RequiresTTL(t *testing.T) {
+	client := &stubAuthClient{}
+
+	_, stderr, err := runKey(t, client, signedInStore(t), "create", "--name", "k")
+	require.EqualError(t, err, `required flag(s) "ttl" not set`)
+	require.Equal(t, "Error: required flag(s) \"ttl\" not set\n", stderr)
+}
+
+// TestAuthKeyCreate_TTLAcceptedCaseInsensitively confirms that the CLI
+// accepts mixed-case duration units on input and forwards the canonical
+// lower-case form to the platform (the platform validator is
+// case-sensitive today).
+func TestAuthKeyCreate_TTLAcceptedCaseInsensitively(t *testing.T) {
+	var gotTTL string
+
+	client := &stubAuthClient{
+		createAPIKey: func(_ context.Context, _ string, req auth.CreateAPIKeyRequest) (auth.CreatedAPIKey, error) {
+			gotTTL = req.TTL
+
+			return auth.CreatedAPIKey{Token: "x"}, nil
+		},
+	}
+
+	_, _, err := runKey(t, client, signedInStore(t), "create", "--name", "k", "--ttl", "3D")
+	require.NoError(t, err)
+	require.Equal(t, "3d", gotTTL)
+}
+
+// TestAuthKeyCreate_TTLRejectsInvalidGrammar pins the parseability
+// error message a user sees when the value does not match the
+// platform's grammar. The CLI fails fast without a network round-trip.
+func TestAuthKeyCreate_TTLRejectsInvalidGrammar(t *testing.T) {
+	client := &stubAuthClient{}
+
+	_, stderr, err := runKey(t, client, signedInStore(t), "create", "--name", "k", "--ttl", "1w")
+	require.EqualError(t, err, `--ttl "1w" is not a valid duration: expected <integer><s|m|h|d>, e.g. 30d, 12h`)
+	require.Equal(t, "Error: --ttl \"1w\" is not a valid duration: expected <integer><s|m|h|d>, e.g. 30d, 12h\n", stderr)
+}
+
+// TestAuthKeyCreate_RequiresName_EmitsCobraMissingFlagError asserts
+// the missing-required-flag shape when only --name is missing: a
+// single "Error:" line on stderr, no usage banner. cobra produces
+// this verbatim from MarkFlagRequired before RunE runs.
+func TestAuthKeyCreate_RequiresName_EmitsCobraMissingFlagError(t *testing.T) {
+	client := &stubAuthClient{}
+
+	_, stderr, err := runKey(t, client, signedInStore(t), "create", "--ttl", "30d")
+	require.EqualError(t, err, `required flag(s) "name" not set`)
+	require.Equal(t, "Error: required flag(s) \"name\" not set\n", stderr)
+}
+
+// TestAuthKeyCreate_NotSignedIn_HintsCqAuthLogin pins the user-visible
+// stderr when the credstore has no entry. The error is operational
+// (not a syntax problem) so cobra suppresses the usage banner; only
+// the "Error: ..." line is shown.
+func TestAuthKeyCreate_NotSignedIn_HintsCqAuthLogin(t *testing.T) {
+	client := &stubAuthClient{}
+
+	_, stderr, err := runKey(t, client, &memStore{}, "create", "--name", "k", "--ttl", "30d")
+	require.EqualError(t, err, `not signed in. Run "cq auth login <provider>" first`)
+	require.Equal(t, "Error: not signed in. Run \"cq auth login <provider>\" first\n", stderr)
+}
+
+// TestAuthKeyCreate_SessionExpired_PromptsToReLogin pins the stderr
+// for the case where the credstore had a JWT but the platform refuses
+// it (HTTP 401 from the platform's auth gate).
+func TestAuthKeyCreate_SessionExpired_PromptsToReLogin(t *testing.T) {
+	client := &stubAuthClient{
+		createAPIKey: func(context.Context, string, auth.CreateAPIKeyRequest) (auth.CreatedAPIKey, error) {
+			return auth.CreatedAPIKey{}, auth.ErrSessionExpired
+		},
+	}
+
+	_, stderr, err := runKey(t, client, signedInStore(t), "create", "--name", "k", "--ttl", "30d")
+	require.EqualError(t, err, `session expired or invalid. Run "cq auth login <provider>" to sign in again`)
+	require.Equal(t, "Error: session expired or invalid. Run \"cq auth login <provider>\" to sign in again\n", stderr)
+}
+
+// TestAuthKeyCreate_LimitReached_SurfacesPlatformDetail pins the
+// stderr for HTTP 409 from the platform when the active-key cap is
+// hit. The platform's detail string is reproduced verbatim so the
+// user sees the exact reason.
+func TestAuthKeyCreate_LimitReached_SurfacesPlatformDetail(t *testing.T) {
+	client := &stubAuthClient{
+		createAPIKey: func(context.Context, string, auth.CreateAPIKeyRequest) (auth.CreatedAPIKey, error) {
+			return auth.CreatedAPIKey{}, &auth.APIKeyLimitReachedError{Detail: "Maximum of 20 active API keys per user"}
+		},
+	}
+
+	_, stderr, err := runKey(t, client, signedInStore(t), "create", "--name", "k", "--ttl", "30d")
+	require.EqualError(t, err, "cannot create key: Maximum of 20 active API keys per user")
+	require.Equal(t, "Error: cannot create key: Maximum of 20 active API keys per user\n", stderr)
+}
+
+// TestAuthKeyCreate_ValidationError_SurfacesDetail pins the stderr for
+// a platform-side HTTP 422 (e.g. name too long, too many labels) on a
+// request whose TTL passed client-side parseability. Same
+// verbatim-detail contract as the cap-reached case.
+func TestAuthKeyCreate_ValidationError_SurfacesDetail(t *testing.T) {
+	client := &stubAuthClient{
+		createAPIKey: func(context.Context, string, auth.CreateAPIKeyRequest) (auth.CreatedAPIKey, error) {
+			return auth.CreatedAPIKey{}, &auth.APIKeyValidationError{Detail: "name exceeds maximum length"}
+		},
+	}
+
+	_, stderr, err := runKey(t, client, signedInStore(t), "create", "--name", "k", "--ttl", "30d")
+	require.EqualError(t, err, "invalid request: name exceeds maximum length")
+	require.Equal(t, "Error: invalid request: name exceeds maximum length\n", stderr)
+}
+
+// --- cq auth key list -------------------------------------------------------
+
+// TestAuthKeyList_PlainTextEmpty_StderrMessageStdoutEmpty pins the
+// no-keys output. Stdout stays empty so `KEYS=$(cq auth key list)`
+// returns "" cleanly; humans still see "No API keys." on stderr.
+func TestAuthKeyList_PlainTextEmpty_StderrMessageStdoutEmpty(t *testing.T) {
+	client := &stubAuthClient{
+		listAPIKeys: func(context.Context, string) ([]auth.APIKey, error) {
+			return nil, nil
+		},
+	}
+
+	stdout, stderr, err := runKey(t, client, signedInStore(t), "list")
+	require.NoError(t, err)
+	require.Empty(t, stdout)
+	require.Equal(t, "No API keys.\n", stderr)
+}
+
+// TestAuthKeyList_PlainTextRendersTabSeparatedRows pins the row format:
+// id, prefix, status, expiry (RFC3339 UTC), name, labels (or "-"),
+// tab-separated, one row per key. Status is one of {active, expired,
+// revoked, inactive}; the example covers active and revoked.
+func TestAuthKeyList_PlainTextRendersTabSeparatedRows(t *testing.T) {
+	revoked := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+
+	client := &stubAuthClient{
+		listAPIKeys: func(context.Context, string) ([]auth.APIKey, error) {
+			return []auth.APIKey{
+				{
+					ID:        "id-a",
+					Name:      "alpha",
+					Labels:    []string{"ci", "laptop"},
+					Prefix:    "cqaAAAA",
+					ExpiresAt: time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC),
+					IsActive:  true,
+				},
+				{
+					ID:        "id-b",
+					Name:      "beta",
+					Prefix:    "cqaBBBB",
+					ExpiresAt: time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC),
+					RevokedAt: &revoked,
+				},
+			}, nil
+		},
+	}
+
+	stdout, stderr, err := runKey(t, client, signedInStore(t), "list")
+	require.NoError(t, err)
+	require.Empty(t, stderr)
+	require.Equal(t,
+		"id-a\tcqaAAAA\tactive\t2026-08-01T00:00:00Z\talpha\tci,laptop\n"+
+			"id-b\tcqaBBBB\trevoked\t2026-06-01T00:00:00Z\tbeta\t-\n",
+		stdout,
+	)
+}
+
+// TestAuthKeyList_JSONRendersIndentedEnvelope pins the --json output:
+// a `{data, count}` envelope, two-space indent, with a trailing
+// newline from the encoder.
+func TestAuthKeyList_JSONRendersIndentedEnvelope(t *testing.T) {
+	client := &stubAuthClient{
+		listAPIKeys: func(context.Context, string) ([]auth.APIKey, error) {
+			return []auth.APIKey{
+				{
+					ID:        "id-a",
+					Name:      "alpha",
+					Labels:    []string{"ci"},
+					Prefix:    "cqaAAAA",
+					TTL:       "30d",
+					ExpiresAt: time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC),
+					CreatedAt: time.Date(2026, 7, 2, 0, 0, 0, 0, time.UTC),
+					IsActive:  true,
+				},
+			}, nil
+		},
+	}
+
+	stdout, stderr, err := runKey(t, client, signedInStore(t), "list", "--json")
+	require.NoError(t, err)
+	require.Empty(t, stderr)
+	require.Equal(t,
+		"{\n"+
+			"  \"data\": [\n"+
+			"    {\n"+
+			"      \"id\": \"id-a\",\n"+
+			"      \"name\": \"alpha\",\n"+
+			"      \"labels\": [\n"+
+			"        \"ci\"\n"+
+			"      ],\n"+
+			"      \"key_prefix\": \"cqaAAAA\",\n"+
+			"      \"ttl\": \"30d\",\n"+
+			"      \"expires_at\": \"2026-08-01T00:00:00Z\",\n"+
+			"      \"created_at\": \"2026-07-02T00:00:00Z\",\n"+
+			"      \"is_expired\": false,\n"+
+			"      \"is_active\": true\n"+
+			"    }\n"+
+			"  ],\n"+
+			"  \"count\": 1\n"+
+			"}\n",
+		stdout,
+	)
+}
+
+// TestAuthKeyList_NotSignedIn_HintsCqAuthLogin pins the same operational
+// "not signed in" UX for the list path.
+func TestAuthKeyList_NotSignedIn_HintsCqAuthLogin(t *testing.T) {
+	client := &stubAuthClient{}
+
+	_, stderr, err := runKey(t, client, &memStore{}, "list")
+	require.EqualError(t, err, `not signed in. Run "cq auth login <provider>" first`)
+	require.Equal(t, "Error: not signed in. Run \"cq auth login <provider>\" first\n", stderr)
+}
+
+// TestAuthKeyList_SessionExpired_PromptsToReLogin pins the same
+// operational "session expired" UX for the list path.
+func TestAuthKeyList_SessionExpired_PromptsToReLogin(t *testing.T) {
+	client := &stubAuthClient{
+		listAPIKeys: func(context.Context, string) ([]auth.APIKey, error) {
+			return nil, auth.ErrSessionExpired
+		},
+	}
+
+	_, stderr, err := runKey(t, client, signedInStore(t), "list")
+	require.EqualError(t, err, `session expired or invalid. Run "cq auth login <provider>" to sign in again`)
+	require.Equal(t, "Error: session expired or invalid. Run \"cq auth login <provider>\" to sign in again\n", stderr)
+}
+
+// --- cq auth key revoke -----------------------------------------------------
+
+// TestAuthKeyRevoke_HappyPath_ConfirmationOnStderrStdoutEmpty pins the
+// success output: stdout is silent, stderr carries a one-line
+// confirmation.
+func TestAuthKeyRevoke_HappyPath_ConfirmationOnStderrStdoutEmpty(t *testing.T) {
+	var gotKeyID string
+
+	client := &stubAuthClient{
+		revokeAPIKey: func(_ context.Context, _, keyID string) error {
+			gotKeyID = keyID
+
+			return nil
+		},
+	}
+
+	stdout, stderr, err := runKey(t, client, signedInStore(t), "revoke", "abc-123")
+	require.NoError(t, err)
+	require.Equal(t, "abc-123", gotKeyID)
+	require.Empty(t, stdout)
+	require.Equal(t, "Revoked API key abc-123.\n", stderr)
+}
+
+// TestAuthKeyRevoke_RequiresKeyID asserts the missing-positional-arg
+// shape from the Args validator: a single "Error:" line with the
+// hint about `cq auth key list`. cobra does not print a usage banner
+// for args-validator failures by default.
+func TestAuthKeyRevoke_RequiresKeyID(t *testing.T) {
+	client := &stubAuthClient{}
+
+	_, stderr, err := runKey(t, client, signedInStore(t), "revoke")
+	require.EqualError(t, err, `key ID required. Run "cq auth key list" to find one`)
+	require.Equal(t, "Error: key ID required. Run \"cq auth key list\" to find one\n", stderr)
+}
+
+// TestAuthKeyRevoke_NotFound_EchoesKeyIDInError pins the per-key
+// "not found" message: the user sees the exact key ID they asked for.
+func TestAuthKeyRevoke_NotFound_EchoesKeyIDInError(t *testing.T) {
+	client := &stubAuthClient{
+		revokeAPIKey: func(context.Context, string, string) error {
+			return &auth.APIKeyNotFoundError{KeyID: "missing"}
+		},
+	}
+
+	_, stderr, err := runKey(t, client, signedInStore(t), "revoke", "missing")
+	require.EqualError(t, err, "API key missing not found")
+	require.Equal(t, "Error: API key missing not found\n", stderr)
+}
+
+// TestAuthKeyRevoke_SessionExpired_PromptsToReLogin pins the same
+// operational "session expired" UX for the revoke path.
+func TestAuthKeyRevoke_SessionExpired_PromptsToReLogin(t *testing.T) {
+	client := &stubAuthClient{
+		revokeAPIKey: func(context.Context, string, string) error {
+			return auth.ErrSessionExpired
+		},
+	}
+
+	_, stderr, err := runKey(t, client, signedInStore(t), "revoke", "any")
+	require.EqualError(t, err, `session expired or invalid. Run "cq auth login <provider>" to sign in again`)
+	require.Equal(t, "Error: session expired or invalid. Run \"cq auth login <provider>\" to sign in again\n", stderr)
+}
+
+// TestAuthKeyRevoke_PropagatesUnexpectedError preserves the existing
+// "untyped errors pass through" contract. When a transport-level or
+// otherwise unmapped error reaches the revoke command, its message is
+// surfaced verbatim with cobra's "Error:" prefix.
+func TestAuthKeyRevoke_PropagatesUnexpectedError(t *testing.T) {
+	want := errors.New("upstream boom")
+	client := &stubAuthClient{
+		revokeAPIKey: func(context.Context, string, string) error { return want },
+	}
+
+	_, stderr, err := runKey(t, client, signedInStore(t), "revoke", "any")
+	require.ErrorIs(t, err, want)
+	require.True(t, strings.HasPrefix(stderr, "Error: upstream boom\n"))
+}

--- a/cli/cmd/auth_key_test.go
+++ b/cli/cmd/auth_key_test.go
@@ -69,6 +69,10 @@ func TestParseTTL(t *testing.T) {
 		{name: "upper-case days canonicalised", input: "3D", want: "3d"},
 		{name: "upper-case hours canonicalised", input: "2H", want: "2h"},
 		{name: "leading and trailing whitespace trimmed", input: "  90d  ", want: "90d"},
+		{name: "max boundary 365d accepted", input: "365d", want: "365d"},
+		{name: "max boundary 8760h accepted", input: "8760h", want: "8760h"},
+		{name: "max boundary 525600m accepted", input: "525600m", want: "525600m"},
+		{name: "max boundary 31536000s accepted", input: "31536000s", want: "31536000s"},
 		{name: "empty rejected", input: "", wantErr: "--ttl is required"},
 		{name: "whitespace-only rejected", input: "   ", wantErr: "--ttl is required"},
 		{name: "weeks rejected", input: "1w", wantErr: `--ttl "1w" is not a valid duration`},
@@ -78,6 +82,11 @@ func TestParseTTL(t *testing.T) {
 		{name: "decimal rejected", input: "3.5d", wantErr: `--ttl "3.5d" is not a valid duration`},
 		{name: "negative rejected", input: "-1d", wantErr: `--ttl "-1d" is not a valid duration`},
 		{name: "compound rejected", input: "1d2h", wantErr: `--ttl "1d2h" is not a valid duration`},
+		{name: "366d rejected as exceeding cap", input: "366d", wantErr: `--ttl "366d" exceeds the maximum of 365d`},
+		{name: "8761h rejected as exceeding cap", input: "8761h", wantErr: `--ttl "8761h" exceeds the maximum of 365d`},
+		{name: "525601m rejected as exceeding cap", input: "525601m", wantErr: `--ttl "525601m" exceeds the maximum of 365d`},
+		{name: "31536001s rejected as exceeding cap", input: "31536001s", wantErr: `--ttl "31536001s" exceeds the maximum of 365d`},
+		{name: "huge value out of int64 range rejected", input: "99999999999999999999d", wantErr: `--ttl "99999999999999999999d" exceeds the maximum of 365d`},
 	}
 
 	for _, tc := range cases {

--- a/cli/cmd/auth_test.go
+++ b/cli/cmd/auth_test.go
@@ -56,6 +56,9 @@ func (s *memStore) Delete() error {
 // unexpected calls are obvious.
 type stubAuthClient struct {
 	oauthProviders func(ctx context.Context) ([]auth.Provider, error)
+	createAPIKey   func(ctx context.Context, jwt string, req auth.CreateAPIKeyRequest) (auth.CreatedAPIKey, error)
+	listAPIKeys    func(ctx context.Context, jwt string) ([]auth.APIKey, error)
+	revokeAPIKey   func(ctx context.Context, jwt string, keyID string) error
 }
 
 func (s *stubAuthClient) OAuthProviders(ctx context.Context) ([]auth.Provider, error) {
@@ -80,6 +83,30 @@ func (s *stubAuthClient) Me(context.Context, string) (auth.User, error) {
 
 func (s *stubAuthClient) ClaimUsername(context.Context, string, string) (auth.User, error) {
 	panic("ClaimUsername not stubbed")
+}
+
+func (s *stubAuthClient) CreateAPIKey(ctx context.Context, jwt string, req auth.CreateAPIKeyRequest) (auth.CreatedAPIKey, error) {
+	if s.createAPIKey == nil { // pragma: allowlist secret
+		panic("CreateAPIKey not stubbed")
+	}
+
+	return s.createAPIKey(ctx, jwt, req)
+}
+
+func (s *stubAuthClient) ListAPIKeys(ctx context.Context, jwt string) ([]auth.APIKey, error) {
+	if s.listAPIKeys == nil { // pragma: allowlist secret
+		panic("ListAPIKeys not stubbed")
+	}
+
+	return s.listAPIKeys(ctx, jwt)
+}
+
+func (s *stubAuthClient) RevokeAPIKey(ctx context.Context, jwt string, keyID string) error {
+	if s.revokeAPIKey == nil { // pragma: allowlist secret
+		panic("RevokeAPIKey not stubbed")
+	}
+
+	return s.revokeAPIKey(ctx, jwt, keyID)
 }
 
 // stubStore returns a WithCredStore option that always yields store.

--- a/cli/internal/auth/api_keys.go
+++ b/cli/internal/auth/api_keys.go
@@ -1,0 +1,78 @@
+package auth
+
+import "time"
+
+// APIKey is the public projection of a stored API key. It never
+// carries the API key itself; the API key is returned exactly once,
+// on CreatedAPIKey, and never persisted server-side.
+type APIKey struct {
+	// ID is the platform's UUID for the key.
+	ID string `json:"id"`
+
+	// Name is the user-supplied display name for the key.
+	Name string `json:"name"`
+
+	// Labels is the user-supplied list of free-form labels. Always
+	// non-nil after a successful round-trip; the platform decodes a
+	// missing field as the empty list.
+	Labels []string `json:"labels"`
+
+	// Prefix is the first eight characters of the API key, captured
+	// at creation time and shown in listings to help users identify a
+	// key without exposing the full value.
+	Prefix string `json:"key_prefix"`
+
+	// TTL is the requested time-to-live in the canonical platform
+	// duration grammar (e.g. "30d", "12h").
+	TTL string `json:"ttl"`
+
+	// ExpiresAt is the absolute time at which the platform will refuse
+	// the key, regardless of revocation state.
+	ExpiresAt time.Time `json:"expires_at"`
+
+	// CreatedAt is the creation timestamp.
+	CreatedAt time.Time `json:"created_at"`
+
+	// LastUsedAt is the most recent successful authentication with the
+	// key. Nil until first use.
+	LastUsedAt *time.Time `json:"last_used_at,omitempty"`
+
+	// RevokedAt is the time the key was revoked. Nil while the key is
+	// still active.
+	RevokedAt *time.Time `json:"revoked_at,omitempty"`
+
+	// IsExpired is the platform-computed comparison of ExpiresAt against
+	// the server's wall clock at response time. Clients must not cache
+	// it as durable state.
+	IsExpired bool `json:"is_expired"`
+
+	// IsActive is true when the key has not been revoked and has not yet
+	// expired. Clients must not cache it as durable state.
+	IsActive bool `json:"is_active"`
+}
+
+// CreateAPIKeyRequest carries the inputs required to create a new API
+// key. Labels is optional; the platform normalises the list (trims,
+// drops empties, deduplicates) before persisting it.
+type CreateAPIKeyRequest struct {
+	// Name is the display name. Required, 1-64 characters after trimming.
+	Name string `json:"name"`
+
+	// TTL is the time-to-live in the platform's duration grammar
+	// (^\d+[smhd]$). Required.
+	TTL string `json:"ttl"`
+
+	// Labels is the optional list of free-form labels.
+	Labels []string `json:"labels,omitempty"`
+}
+
+// CreatedAPIKey is the response returned exactly once when an API key
+// is created. The Token field carries the API key value; this is the
+// only opportunity for the client to capture it.
+type CreatedAPIKey struct {
+	APIKey
+
+	// Token is the API key value (cqa.v1.<id>.<secret>). The platform
+	// never returns it again.
+	Token string `json:"api_key"` // pragma: allowlist secret
+}

--- a/cli/internal/auth/api_keys_test.go
+++ b/cli/internal/auth/api_keys_test.go
@@ -1,0 +1,251 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestClient_CreateAPIKey_SuccessReturnsTokenAndMetadata(t *testing.T) {
+	cap := newCapture()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cap.recordRequest(r)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{
+			"id": "00000000-0000-0000-0000-000000000001",
+			"name": "claude-cursor",
+			"labels": ["ci","laptop"],
+			"key_prefix": "cqa12345",
+			"ttl": "30d",
+			"expires_at": "2026-06-08T12:00:00Z",
+			"created_at": "2026-05-08T12:00:00Z",
+			"last_used_at": null,
+			"revoked_at": null,
+			"is_expired": false,
+			"is_active": true,
+			"api_key": "cqa.v1.0123456789abcdef0123456789abcdef.secret-secret-secret-secret-secret-secret-12345678"
+		}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewClient(server.URL)
+	got, err := client.CreateAPIKey(context.Background(), "test-jwt", CreateAPIKeyRequest{
+		Name:   "claude-cursor",
+		TTL:    "30d",
+		Labels: []string{"ci", "laptop"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "claude-cursor", got.Name)
+	require.Equal(t, []string{"ci", "laptop"}, got.Labels)
+	require.Equal(t, "cqa12345", got.Prefix)
+	require.True(t, got.IsActive)
+	require.False(t, got.IsExpired)
+	require.NotEmpty(t, got.Token)
+
+	c := cap.snapshot()
+	require.Equal(t, http.MethodPost, c.method)
+	require.Equal(t, "/api/v1/auth/me/api-keys", c.path)
+	require.Equal(t, "Bearer test-jwt", c.auth)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(c.body, &body))
+	require.Equal(t, "claude-cursor", body["name"])
+	require.Equal(t, "30d", body["ttl"])
+	require.ElementsMatch(t, []any{"ci", "laptop"}, body["labels"])
+}
+
+func TestClient_CreateAPIKey_SessionExpired_ReturnsSentinel(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"detail":"Not authenticated"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewClient(server.URL)
+	_, err := client.CreateAPIKey(context.Background(), "stale", CreateAPIKeyRequest{Name: "x", TTL: "30d"})
+	require.ErrorIs(t, err, ErrSessionExpired)
+}
+
+func TestClient_CreateAPIKey_LimitReached_ReturnsTypedError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{"detail":"Maximum of 20 active API keys per user"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewClient(server.URL)
+	_, err := client.CreateAPIKey(context.Background(), "jwt", CreateAPIKeyRequest{Name: "x", TTL: "30d"})
+
+	var capReached *APIKeyLimitReachedError
+	require.ErrorAs(t, err, &capReached)
+	require.Contains(t, capReached.Detail, "Maximum of 20")
+}
+
+func TestClient_CreateAPIKey_InvalidTTL_ReturnsValidationError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = w.Write([]byte(`{"detail":"TTL must match ^\\d+[smhd]$"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewClient(server.URL)
+	_, err := client.CreateAPIKey(context.Background(), "jwt", CreateAPIKeyRequest{Name: "x", TTL: "1w"})
+
+	var validation *APIKeyValidationError
+	require.ErrorAs(t, err, &validation)
+	require.Contains(t, validation.Detail, "TTL must match")
+}
+
+func TestClient_ListAPIKeys_DecodesEnvelope(t *testing.T) {
+	cap := newCapture()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cap.recordRequest(r)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"data": [
+				{
+					"id": "id-a",
+					"name": "alpha",
+					"labels": [],
+					"key_prefix": "cqaAAAA",
+					"ttl": "30d",
+					"expires_at": "2026-06-08T00:00:00Z",
+					"created_at": "2026-05-08T00:00:00Z",
+					"last_used_at": null,
+					"revoked_at": null,
+					"is_expired": false,
+					"is_active": true
+				},
+				{
+					"id": "id-b",
+					"name": "beta",
+					"labels": ["ci"],
+					"key_prefix": "cqaBBBB",
+					"ttl": "1d",
+					"expires_at": "2026-05-09T00:00:00Z",
+					"created_at": "2026-05-08T00:00:00Z",
+					"last_used_at": "2026-05-08T01:00:00Z",
+					"revoked_at": "2026-05-08T02:00:00Z",
+					"is_expired": false,
+					"is_active": false
+				}
+			],
+			"count": 2
+		}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewClient(server.URL)
+	got, err := client.ListAPIKeys(context.Background(), "jwt")
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	require.Equal(t, "alpha", got[0].Name)
+	require.True(t, got[0].IsActive)
+	require.Equal(t, "beta", got[1].Name)
+	require.False(t, got[1].IsActive)
+	require.NotNil(t, got[1].RevokedAt)
+	require.Equal(t, time.Date(2026, 5, 8, 2, 0, 0, 0, time.UTC), got[1].RevokedAt.UTC())
+
+	c := cap.snapshot()
+	require.Equal(t, http.MethodGet, c.method)
+	require.Equal(t, "/api/v1/auth/me/api-keys", c.path)
+}
+
+func TestClient_ListAPIKeys_SessionExpired_ReturnsSentinel(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"detail":"Not authenticated"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewClient(server.URL)
+	_, err := client.ListAPIKeys(context.Background(), "stale")
+	require.ErrorIs(t, err, ErrSessionExpired)
+}
+
+func TestClient_RevokeAPIKey_SuccessReturnsNoError(t *testing.T) {
+	cap := newCapture()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cap.recordRequest(r)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"message":"API key revoked."}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewClient(server.URL)
+	require.NoError(t, client.RevokeAPIKey(context.Background(), "jwt", "key-123"))
+
+	c := cap.snapshot()
+	require.Equal(t, http.MethodPost, c.method)
+	require.Equal(t, "/api/v1/auth/me/api-keys/key-123/revoke", c.path)
+	require.Equal(t, "Bearer jwt", c.auth)
+}
+
+func TestClient_RevokeAPIKey_PathEscapesKeyID(t *testing.T) {
+	var rawPath string
+	var mu sync.Mutex
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		rawPath = r.URL.EscapedPath()
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"message":"API key revoked."}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewClient(server.URL)
+	// A pathological keyID with characters the URL grammar reserves;
+	// the client must escape it rather than splice it raw into the URL.
+	require.NoError(t, client.RevokeAPIKey(context.Background(), "jwt", "weird/key id"))
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, "/api/v1/auth/me/api-keys/weird%2Fkey%20id/revoke", rawPath)
+}
+
+func TestClient_RevokeAPIKey_NotFoundReturnsTypedErrorWithKeyID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"detail":"API key not found"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewClient(server.URL)
+	err := client.RevokeAPIKey(context.Background(), "jwt", "missing-id")
+
+	var notFound *APIKeyNotFoundError
+	require.ErrorAs(t, err, &notFound)
+	require.Equal(t, "missing-id", notFound.KeyID)
+}
+
+func TestClient_RevokeAPIKey_SessionExpired_ReturnsSentinel(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"detail":"Not authenticated"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewClient(server.URL)
+	require.ErrorIs(t, client.RevokeAPIKey(context.Background(), "stale", "any"), ErrSessionExpired)
+}

--- a/cli/internal/auth/errors.go
+++ b/cli/internal/auth/errors.go
@@ -19,9 +19,105 @@ var ErrInvalidGrant = errors.New("auth: invalid grant")
 // "run cq auth providers" hint.
 var ErrProviderRequired = errors.New("auth: provider required")
 
+// ErrSessionExpired is returned by JWT-bearing methods when the
+// platform refuses the supplied token (HTTP 401). The CLI surfaces this
+// to users as a hint to re-run cq auth login. The error deliberately
+// collapses missing-token, malformed-token, and expired-token responses
+// into one signal because the platform does not distinguish among them
+// on the wire.
+var ErrSessionExpired = errors.New("auth: session expired or invalid")
+
 // ErrUsernameAlreadySet is returned by ClaimUsername when the user has
 // previously claimed a username and the server refuses a second claim.
 var ErrUsernameAlreadySet = errors.New("auth: username already set")
+
+// APIKeyLimitReachedError is returned by CreateAPIKey when the user
+// already holds the platform's maximum number of active keys (HTTP 409).
+type APIKeyLimitReachedError struct {
+	// Detail is the human-readable explanation supplied by the platform.
+	Detail string
+}
+
+// Error implements the error interface.
+func (e *APIKeyLimitReachedError) Error() string {
+	if e.Detail == "" {
+		return "auth: active API key limit reached"
+	}
+
+	return "auth: active API key limit reached: " + e.Detail
+}
+
+// APIKeyNotFoundError is returned by RevokeAPIKey when the requested
+// key does not exist or is owned by a different user (HTTP 404). The
+// platform deliberately collapses both into one response to avoid
+// leaking key existence across users.
+type APIKeyNotFoundError struct {
+	// KeyID is the identifier the caller supplied. Echoed back so the
+	// CLI can render a useful error message without re-threading the
+	// argument.
+	KeyID string
+}
+
+// Error implements the error interface.
+func (e *APIKeyNotFoundError) Error() string {
+	if e.KeyID == "" {
+		return "auth: API key not found"
+	}
+
+	return "auth: API key '" + e.KeyID + "' not found"
+}
+
+// APIKeyValidationError is returned by CreateAPIKey when the platform
+// rejects the request body (HTTP 422), typically for an invalid TTL,
+// out-of-range name length, or too many labels.
+type APIKeyValidationError struct {
+	// Detail is the platform-supplied explanation. May be empty.
+	Detail string
+}
+
+// Error implements the error interface.
+func (e *APIKeyValidationError) Error() string {
+	if e.Detail == "" {
+		return "auth: API key request invalid"
+	}
+
+	return "auth: API key request invalid: " + e.Detail
+}
+
+// PlatformStatusError is returned for any non-2xx HTTP response that
+// does not match a more specific typed error in mapError. It carries
+// the status code so callers can post-process specific codes (for
+// example, RevokeAPIKey wrapping a 404 with the requested key ID)
+// without resorting to error-string matching.
+type PlatformStatusError struct {
+	// StatusCode is the HTTP status returned by the platform.
+	StatusCode int
+
+	// Detail is the parsed "detail" field from the JSON error body, if
+	// present. Empty when the body did not carry that field.
+	Detail string
+
+	// Errored is the parsed "error" discriminator from the JSON error
+	// body, if present. Empty when the body did not carry that field.
+	Errored string
+
+	// Body is the raw response body, capped at the platform error-body
+	// byte limit. Used as the fallback explanation when Detail and
+	// Errored are both empty.
+	Body string
+}
+
+// Error implements the error interface.
+func (e *PlatformStatusError) Error() string {
+	switch {
+	case e.Errored != "":
+		return fmt.Sprintf("platform returned %d: '%s'", e.StatusCode, e.Errored)
+	case e.Detail != "":
+		return fmt.Sprintf("platform returned %d: %s", e.StatusCode, e.Detail)
+	default:
+		return fmt.Sprintf("platform returned %d: %s", e.StatusCode, e.Body)
+	}
+}
 
 // RateLimitedError is returned when the platform applies a 429 to a
 // request. RetryAfter is the duration the server suggests waiting

--- a/cli/internal/auth/http_client.go
+++ b/cli/internal/auth/http_client.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -55,6 +57,43 @@ func (c *httpClient) ClaimUsername(ctx context.Context, jwt, username string) (U
 	}
 
 	return resp, nil
+}
+
+// CreateAPIKey implements Client.
+func (c *httpClient) CreateAPIKey(ctx context.Context, jwt string, in CreateAPIKeyRequest) (CreatedAPIKey, error) {
+	req, err := c.newRequest(ctx, http.MethodPost, apiVersionPrefix+"/auth/me/api-keys", in)
+	if err != nil {
+		return CreatedAPIKey{}, err
+	}
+
+	req.Header.Set("Authorization", "Bearer "+jwt)
+
+	var resp CreatedAPIKey
+	if err := c.send(req, &resp); err != nil {
+		return CreatedAPIKey{}, err
+	}
+
+	return resp, nil
+}
+
+// ListAPIKeys implements Client.
+func (c *httpClient) ListAPIKeys(ctx context.Context, jwt string) ([]APIKey, error) {
+	req, err := c.newRequest(ctx, http.MethodGet, apiVersionPrefix+"/auth/me/api-keys", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Authorization", "Bearer "+jwt)
+
+	var resp struct {
+		Data  []APIKey `json:"data"`
+		Count int      `json:"count"`
+	}
+	if err := c.send(req, &resp); err != nil {
+		return nil, err
+	}
+
+	return resp.Data, nil
 }
 
 // Me implements Client.
@@ -131,6 +170,34 @@ func (c *httpClient) OAuthProviders(ctx context.Context) ([]Provider, error) {
 	}
 
 	return resp.Providers, nil
+}
+
+// RevokeAPIKey implements Client.
+func (c *httpClient) RevokeAPIKey(ctx context.Context, jwt string, keyID string) error {
+	path := apiVersionPrefix + "/auth/me/api-keys/" + url.PathEscape(keyID) + "/revoke"
+
+	req, err := c.newRequest(ctx, http.MethodPost, path, nil)
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Authorization", "Bearer "+jwt)
+
+	if err := c.send(req, nil); err != nil {
+		// A 404 on the revoke route is the route-level "API key not
+		// found" signal. mapError leaves status-code interpretation to
+		// the caller because the same code can mean "user record gone"
+		// on list/create; here, with a key ID in hand, we know exactly
+		// what to surface.
+		var status *PlatformStatusError
+		if errors.As(err, &status) && status.StatusCode == http.StatusNotFound {
+			return &APIKeyNotFoundError{KeyID: keyID}
+		}
+
+		return err
+	}
+
+	return nil
 }
 
 // newRequest builds a JSON request rooted at httpClient.baseURL. body
@@ -215,6 +282,11 @@ func mapError(resp *http.Response) error {
 			return ErrInvalidGrant
 		}
 
+	case http.StatusUnauthorized:
+		// The platform deliberately collapses missing-token,
+		// malformed-token, and expired-token into one wire response.
+		return ErrSessionExpired
+
 	case http.StatusConflict:
 		switch body.Error {
 		case "username_unavailable":
@@ -224,17 +296,36 @@ func mapError(resp *http.Response) error {
 			return ErrUsernameAlreadySet
 		}
 
+		// API-key cap responses use FastAPI's default "detail" field
+		// without the structured "error" discriminator the username
+		// endpoints supply.
+		if body.Detail != "" {
+			return &APIKeyLimitReachedError{Detail: body.Detail}
+		}
+
 	case http.StatusUnprocessableEntity:
 		if body.Error == "username_invalid_format" {
 			return &UsernameFormatError{Detail: body.Detail}
 		}
+
+		// API-key validation failures (TTL grammar, name/labels length)
+		// arrive as plain FastAPI 422s with "detail" set.
+		if body.Detail != "" {
+			return &APIKeyValidationError{Detail: body.Detail}
+		}
 	}
 
-	if body.Error != "" {
-		return fmt.Errorf("platform returned %d: '%s'", resp.StatusCode, body.Error)
+	// Unmapped status codes return PlatformStatusError so callers that
+	// care about a particular code (for example, RevokeAPIKey wrapping a
+	// 404 with the requested key ID) can match on the type rather than
+	// the rendered message. The rendered message preserves the prior
+	// fmt.Errorf format so existing log surfaces stay stable.
+	return &PlatformStatusError{
+		StatusCode: resp.StatusCode,
+		Detail:     body.Detail,
+		Errored:    body.Error,
+		Body:       string(raw),
 	}
-
-	return fmt.Errorf("platform returned %d: %s", resp.StatusCode, string(raw))
 }
 
 // parseRetryAfter parses the Retry-After header's delta-seconds form.

--- a/cli/internal/auth/onboarding_test.go
+++ b/cli/internal/auth/onboarding_test.go
@@ -22,6 +22,9 @@ type stubAuthClient struct {
 	oauthNativeExchange func(ctx context.Context, req NativeExchangeRequest) (string, error)
 	me                  func(ctx context.Context, jwt string) (User, error)
 	claimUsername       func(ctx context.Context, jwt, username string) (User, error)
+	createAPIKey        func(ctx context.Context, jwt string, req CreateAPIKeyRequest) (CreatedAPIKey, error)
+	listAPIKeys         func(ctx context.Context, jwt string) ([]APIKey, error)
+	revokeAPIKey        func(ctx context.Context, jwt string, keyID string) error
 }
 
 func (s *stubAuthClient) OAuthProviders(ctx context.Context) ([]Provider, error) {
@@ -62,6 +65,30 @@ func (s *stubAuthClient) ClaimUsername(ctx context.Context, jwt, username string
 	}
 
 	return s.claimUsername(ctx, jwt, username)
+}
+
+func (s *stubAuthClient) CreateAPIKey(ctx context.Context, jwt string, req CreateAPIKeyRequest) (CreatedAPIKey, error) {
+	if s.createAPIKey == nil { // pragma: allowlist secret
+		panic("CreateAPIKey not stubbed")
+	}
+
+	return s.createAPIKey(ctx, jwt, req)
+}
+
+func (s *stubAuthClient) ListAPIKeys(ctx context.Context, jwt string) ([]APIKey, error) {
+	if s.listAPIKeys == nil { // pragma: allowlist secret
+		panic("ListAPIKeys not stubbed")
+	}
+
+	return s.listAPIKeys(ctx, jwt)
+}
+
+func (s *stubAuthClient) RevokeAPIKey(ctx context.Context, jwt string, keyID string) error {
+	if s.revokeAPIKey == nil { // pragma: allowlist secret
+		panic("RevokeAPIKey not stubbed")
+	}
+
+	return s.revokeAPIKey(ctx, jwt, keyID)
 }
 
 func TestClaimUsernameInteractively_FirstAttemptSucceeds(t *testing.T) {

--- a/cli/internal/auth/platform_client.go
+++ b/cli/internal/auth/platform_client.go
@@ -18,18 +18,28 @@ const httpDefaultTimeout = 30 * time.Second
 // JWT-bearing methods take the token as an explicit parameter so the
 // Client itself stays stateless and easier to mock.
 //
-// The interface holds five methods, more than the typical "small
-// interface" Go ideal. They are kept together because they form a
-// cohesive auth-control-plane surface with a single in-package
-// consumer (the Login orchestration); splitting into a ProviderLister
-// + OAuthClient + UserClient triad would add indirection without
-// reducing coupling, since every call site already needs all three.
+// The interface holds the methods that make up the auth control plane:
+// OAuth sign-in, identity, and per-user API key management. They live
+// behind one type because every call site uses the same baseURL and
+// transport; splitting them into separate interfaces would force a
+// matching split at every consumer without reducing coupling.
 type Client interface {
 	// ClaimUsername sets the user's username. Returns
 	// *UsernameUnavailableError, *UsernameFormatError,
 	// ErrUsernameAlreadySet, or *RateLimitedError on the typed failure
 	// modes.
 	ClaimUsername(ctx context.Context, jwt, username string) (User, error)
+
+	// CreateAPIKey provisions a new API key for the authenticated user
+	// and returns the API key value exactly once. Returns
+	// ErrSessionExpired (401), *APIKeyLimitReachedError (409), or
+	// *APIKeyValidationError (422) on the typed failure modes.
+	CreateAPIKey(ctx context.Context, jwt string, req CreateAPIKeyRequest) (CreatedAPIKey, error)
+
+	// ListAPIKeys returns the authenticated user's API keys. Revoked
+	// and expired keys are included so callers can render audit
+	// history. Returns ErrSessionExpired (401) when the JWT is invalid.
+	ListAPIKeys(ctx context.Context, jwt string) ([]APIKey, error)
 
 	// Me returns the user identity associated with the supplied JWT.
 	Me(ctx context.Context, jwt string) (User, error)
@@ -44,6 +54,12 @@ type Client interface {
 
 	// OAuthProviders returns the providers configured on the platform.
 	OAuthProviders(ctx context.Context) ([]Provider, error)
+
+	// RevokeAPIKey marks the named key revoked. The operation is
+	// idempotent: revoking an already-revoked key still returns nil.
+	// Returns ErrSessionExpired (401) or *APIKeyNotFoundError (404) on
+	// the typed failure modes.
+	RevokeAPIKey(ctx context.Context, jwt string, keyID string) error
 }
 
 // NewClient returns a Client that talks to the platform at baseURL.


### PR DESCRIPTION
## Summary
- Wires `cq auth key {create,list,revoke}` against the platform's session-JWT-protected `/auth/me/api-keys` endpoints, gated on `cq auth login`.
- Stdout/stderr split is deliberate: `cq auth key create` prints only the API key value on stdout so `KEY=$(cq auth key create --name X --ttl 30d)` captures cleanly; the human banner (id, prefix, labels, expiry, "shown only once" warning) goes to stderr. `cq auth key list` prints tab-separated rows on stdout with the empty-list message on stderr and accepts `--json` for machine-readable output. `cq auth key revoke <id>` is silent on stdout; the confirmation lands on stderr.
- `--ttl` is required (no default; the user owns the lifetime choice), validated client-side against the platform's `<int><s|m|h|d>` grammar, max 365d, with case-insensitive input that is canonicalised to lower-case before sending.
- Adds typed errors (`APIKeyLimitReachedError`, `APIKeyNotFoundError`, `APIKeyValidationError`, `ErrSessionExpired`) and a new `PlatformStatusError` for unmapped non-2xx responses; `RevokeAPIKey` uses the latter to distinguish "the key is gone" from generic 404s without resorting to error-string matching.
- Cobra-level tests pin the exact stdout/stderr that a user sees for every documented scenario.

## Test plan
- [ ] `make lint`
- [ ] `make test`
- [ ] `go test -race -count=10 ./cli/cmd/... ./cli/internal/auth/...`
- [ ] Manual smoke: `cq auth key create --name claude-cursor --ttl 30d` against a running platform — confirm token-only on stdout, banner on stderr, capturable via `KEY=$(...)`
- [ ] Manual smoke: `cq auth key list` empty case — stderr "No API keys.", stdout empty
- [ ] Manual smoke: `cq auth key list` populated — tab-separated rows on stdout, stderr empty
- [ ] Manual smoke: `cq auth key list --json` — indented JSON envelope on stdout
- [ ] Manual smoke: `cq auth key revoke <id>` — confirmation on stderr
- [ ] Manual smoke: not-signed-in path — `Run "cq auth login <provider>" first` hint, exits non-zero