### PR TITLE
cli, sdk: remove Markdown backticks from terminal-bound strings and Go doc comments

### DIFF
--- a/cli/cmd/auth.go
+++ b/cli/cmd/auth.go
@@ -12,7 +12,7 @@ import (
 	"github.com/mozilla-ai/cq/cli/internal/credstore"
 )
 
-// authLoginLongDoc is the help text shown for `cq auth login`.
+// authLoginLongDoc is the help text shown for "cq auth login".
 var authLoginLongDoc = fmt.Sprintf(`Sign in via a browser-based OIDC flow.
 
 cq starts a short-lived listener on 127.0.0.1, asks the platform for an
@@ -33,7 +33,7 @@ Notes:
 	envVarAPIKey,
 )
 
-// authLogoutLongDoc is the help text shown for `cq auth logout`.
+// authLogoutLongDoc is the help text shown for "cq auth logout".
 var authLogoutLongDoc = `Clear locally-stored sign-in credentials.
 
 logout is currently local-only: it removes the session JWT and cached
@@ -41,7 +41,7 @@ identity from the credential store but does not invalidate the session
 on the server side. Server-side revocation will land under a future
 --revoke flag once the platform exposes the necessary endpoint.`
 
-// authLongDoc is the help text shown for the `cq auth` parent command.
+// authLongDoc is the help text shown for the "cq auth" parent command.
 var authLongDoc = fmt.Sprintf(`Manage interactive sign-in for the cq platform.
 
 cq auth covers control-plane operations: signing in via your identity
@@ -53,13 +53,13 @@ via the %s environment variable; cq auth never stores or prints them.`,
 	envVarAPIKey,
 )
 
-// authProvidersLongDoc is the help text shown for `cq auth providers`.
+// authProvidersLongDoc is the help text shown for "cq auth providers".
 var authProvidersLongDoc = `List the OIDC providers enabled on the configured platform.
 
 Output is one machine-readable provider name per line, ready to be passed
 straight to "cq auth login" or piped into another command.`
 
-// authStatusLongDoc is the help text shown for `cq auth status`.
+// authStatusLongDoc is the help text shown for "cq auth status".
 var authStatusLongDoc = `Show the current sign-in state.
 
 Reports the configured server, the cached identity from the last
@@ -89,7 +89,7 @@ type authOptions struct {
 // over the defaults wired to the production credstore and auth client.
 type AuthOption func(*authOptions)
 
-// NewAuthCmd returns the `cq auth` parent command and its login,
+// NewAuthCmd returns the "cq auth" parent command and its login,
 // logout, providers, and status subcommands. Variadic AuthOptions
 // override the defaults wired to credstore.New and auth.NewClient.
 func NewAuthCmd(opts ...AuthOption) *cobra.Command {
@@ -139,7 +139,7 @@ func WithCredStore(fn func() (credstore.Store, error)) AuthOption {
 	return func(o *authOptions) { o.newStore = fn }
 }
 
-// newAuthLoginCmd returns the `cq auth login` subcommand.
+// newAuthLoginCmd returns the "cq auth login" subcommand.
 func newAuthLoginCmd(cfg authOptions) *cobra.Command {
 	return &cobra.Command{
 		Use:   "login <provider>",
@@ -174,7 +174,7 @@ func newAuthLoginCmd(cfg authOptions) *cobra.Command {
 	}
 }
 
-// newAuthLogoutCmd returns the `cq auth logout` subcommand.
+// newAuthLogoutCmd returns the "cq auth logout" subcommand.
 func newAuthLogoutCmd(cfg authOptions) *cobra.Command {
 	return &cobra.Command{
 		Use:   "logout",
@@ -195,9 +195,9 @@ func newAuthLogoutCmd(cfg authOptions) *cobra.Command {
 	}
 }
 
-// newAuthProvidersCmd returns the `cq auth providers` subcommand: a
+// newAuthProvidersCmd returns the "cq auth providers" subcommand: a
 // read-only query of the platform's enabled OIDC providers, intended
-// to make `cq auth login <provider>` discoverable without forcing the
+// to make "cq auth login <provider>" discoverable without forcing the
 // user to trigger an error first.
 func newAuthProvidersCmd(cfg authOptions) *cobra.Command {
 	return &cobra.Command{
@@ -235,7 +235,7 @@ func newAuthProvidersCmd(cfg authOptions) *cobra.Command {
 	}
 }
 
-// newAuthStatusCmd returns the `cq auth status` subcommand.
+// newAuthStatusCmd returns the "cq auth status" subcommand.
 func newAuthStatusCmd(cfg authOptions) *cobra.Command {
 	return &cobra.Command{
 		Use:   "status",
@@ -254,7 +254,7 @@ func newAuthStatusCmd(cfg authOptions) *cobra.Command {
 				Out:    cmd.OutOrStdout(),
 			})
 			if errors.Is(err, credstore.ErrNotFound) {
-				// `auth.Status` already wrote a user-friendly message;
+				// auth.Status already wrote a user-friendly message;
 				// suppress cobra's default error rendering and let the
 				// non-zero exit do the talking for shell scripts.
 				cmd.SilenceErrors = true

--- a/cli/internal/auth/doc.go
+++ b/cli/internal/auth/doc.go
@@ -1,6 +1,6 @@
 // Package auth implements the interactive sign-in flow used by
-// `cq auth login`, the local-state inspection used by `cq auth status`,
-// and the local-credential cleanup used by `cq auth logout`.
+// "cq auth login", the local-state inspection used by "cq auth status",
+// and the local-credential cleanup used by "cq auth logout".
 //
 // The package wires together five concerns:
 //

--- a/cli/internal/auth/listener.go
+++ b/cli/internal/auth/listener.go
@@ -135,7 +135,7 @@ func (l *listener) Wait(ctx context.Context) (string, error) {
 //
 // The HTTP response mirrors the parsed result: a 200 success page when
 // the provider redirected with an exchange_code, and a 400 error page
-// when it redirected with `error=` or omitted both. Without the split,
+// when it redirected with "error=" or omitted both. Without the split,
 // the user would see "signed in" in the browser while the CLI reports
 // a failure in the terminal.
 func (l *listener) handle(w http.ResponseWriter, r *http.Request) {
@@ -167,8 +167,8 @@ func (l *listener) handle(w http.ResponseWriter, r *http.Request) {
 }
 
 // parseCallback extracts the result from the redirect query string.
-// The OAuth provider supplies either `exchange_code=...` (success) or
-// `error=...&error_description=...` (failure).
+// The OAuth provider supplies either "exchange_code=..." (success) or
+// "error=...&error_description=..." (failure).
 func parseCallback(r *http.Request) callbackResult {
 	q := r.URL.Query()
 

--- a/cli/internal/auth/login.go
+++ b/cli/internal/auth/login.go
@@ -115,7 +115,7 @@ func Login(ctx context.Context, c LoginConfig) error {
 	}
 
 	// One scanner shared between the press-Enter prompt and the
-	// onboarding-username prompt so input from `c.In` is buffered in
+	// onboarding-username prompt so input from c.In is buffered in
 	// exactly one place.
 	scanner := bufio.NewScanner(c.In)
 

--- a/cli/internal/auth/logout.go
+++ b/cli/internal/auth/logout.go
@@ -21,7 +21,7 @@ type LogoutConfig struct {
 // Logout removes any locally-stored session credentials.
 //
 // Logout is currently local-only: server-side session revocation is
-// tracked separately. A `--revoke` flag will be added once the platform
+// tracked separately. A --revoke flag will be added once the platform
 // exposes a logout endpoint.
 func Logout(_ context.Context, p LogoutConfig) error {
 	out := p.Out

--- a/cli/internal/auth/pkce.go
+++ b/cli/internal/auth/pkce.go
@@ -21,7 +21,7 @@ type pkce struct {
 	verifier string
 
 	// challenge is base64url-encoded SHA-256 of the verifier (no padding),
-	// sent on the authorization request as `code_challenge`.
+	// sent on the authorization request as "code_challenge".
 	challenge string
 }
 

--- a/cli/internal/credstore/credstore.go
+++ b/cli/internal/credstore/credstore.go
@@ -32,7 +32,7 @@ type Credentials struct {
 	SessionExpiresAt time.Time `json:"session_expires_at,omitzero"`
 
 	// Username is the platform-side username at the time of last login,
-	// cached so `cq auth status` can render identity without a network call.
+	// cached so "cq auth status" can render identity without a network call.
 	Username string `json:"username"`
 }
 

--- a/cli/internal/credstore/doc.go
+++ b/cli/internal/credstore/doc.go
@@ -3,5 +3,5 @@
 //
 // The package never stores long-lived API keys: those belong on the agent side
 // via the CQ_API_KEY environment variable. credstore deals only with the
-// short-lived session state created by an interactive `cq auth login`.
+// short-lived session state created by an interactive "cq auth login".
 package credstore

--- a/sdk/go/prompts/prompts.go
+++ b/sdk/go/prompts/prompts.go
@@ -1,6 +1,6 @@
 // Package prompts provides the canonical cq agent prompts embedded from
 // the plugin authoring sources. Each prompt is synced into this package via
-// `make sync-prompts` so SDK consumers can surface the same text that the
+// "make sync-prompts" so SDK consumers can surface the same text that the
 // Claude Code and OpenCode slash commands use.
 package prompts
 


### PR DESCRIPTION
## Summary

godoc/pkg.go.dev and the terminal both render backticks as literal punctuation, not as code spans. This sweep replaces backtick-wrapped tokens in doc comments and Cobra help text with plain identifiers or double-quoted command names, matching the convention already used in `cli/internal/auth` and the `Long:` strings.

- `cli/cmd/auth.go`: 12 doc-comment edits on the `cq auth` family.
- `cli/internal/auth/{doc,listener,login,logout,pkce}.go` and `cli/internal/credstore/{credstore,doc}.go`: package and field doc comments.
- `sdk/go/prompts/prompts.go`: package doc.

No behaviour change; help text and error messages already used double-quoted command names, so only doc comments and a handful of inline comments were affected.

Fixes #354

## Test plan

- [x] `make lint` passes (0 issues).
- [x] `make test` passes.
- [x] `cq auth --help`, `cq auth login --help`, `cq auth logout --help`, `cq auth providers --help`, `cq auth status --help`, `cq auth key{,create,list,revoke} --help`, `cq query --help` all render without literal backticks.
- [x] `grep -rn '^[[:space:]]*//.*\`' cli/ sdk/go/ --include='*.go'` returns no matches in non-test files.