### PR TITLE
sdk: lift API key TTL parsing into Go and Python SDKs

### DIFF
--- a/cli/cmd/auth_key.go
+++ b/cli/cmd/auth_key.go
@@ -253,23 +253,35 @@ func formatLabels(labels []string) string {
 	return strings.Join(labels, ",")
 }
 
+// ttlEchoMax bounds how many bytes of the user-supplied --ttl value
+// appear in any error message, so an attacker-controlled megabyte
+// input cannot produce a megabyte error string in cobra output or
+// logs. Matches the truncation budget in sdk/go/ttl.Parse.
+const ttlEchoMax = 64
+
 // parseTTL is a thin CLI-facing wrapper around ttl.Parse that maps the
 // SDK's typed errors into --ttl-prefixed cobra messages. The SDK owns
 // the canonical grammar, max bound, and case normalisation; this layer
 // only reshapes errors so the user sees the flag name they typed.
 func parseTTL(s string) (string, error) {
 	canonical, _, err := ttl.Parse(s)
+	// Truncate before quoting so the wrapper does not undo ttl.Parse's
+	// own bounded-output guarantee for very long inputs.
+	echo := s
+	if len(echo) > ttlEchoMax {
+		echo = echo[:ttlEchoMax]
+	}
 	switch {
 	case errors.Is(err, ttl.ErrEmpty):
 		return "", errors.New("--ttl is required: supply a value like 30d, 12h, 90d (max 365d)")
 	case errors.Is(err, ttl.ErrGrammar):
-		return "", fmt.Errorf("--ttl %q is not a valid duration: expected <integer><s|m|h|d>, e.g. 30d, 12h", s)
+		return "", fmt.Errorf("--ttl %q is not a valid duration: expected <integer><s|m|h|d>, e.g. 30d, 12h", echo)
 	case errors.Is(err, ttl.ErrTooLarge):
-		return "", fmt.Errorf("--ttl %q exceeds the maximum of 365d", s)
+		return "", fmt.Errorf("--ttl %q exceeds the maximum of 365d", echo)
 	case errors.Is(err, ttl.ErrTooSmall):
-		return "", fmt.Errorf("--ttl %q must be greater than zero", s)
+		return "", fmt.Errorf("--ttl %q must be greater than zero", echo)
 	case err != nil:
-		return "", fmt.Errorf("--ttl %q: %w", s, err)
+		return "", fmt.Errorf("--ttl %q: %w", echo, err)
 	}
 
 	return canonical, nil

--- a/cli/cmd/auth_key.go
+++ b/cli/cmd/auth_key.go
@@ -5,8 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"regexp"
-	"strconv"
 	"strings"
 	"time"
 
@@ -14,21 +12,8 @@ import (
 
 	"github.com/mozilla-ai/cq/cli/internal/auth"
 	"github.com/mozilla-ai/cq/cli/internal/credstore"
+	"github.com/mozilla-ai/cq/sdk/go/ttl"
 )
-
-// maxAPIKeyTTL caps the lifetime parseTTL will accept. Matches the
-// platform's upper bound; kept here so the CLI can fail fast without
-// a round-trip and the help text and validator agree.
-const maxAPIKeyTTL = 365 * 24 * time.Hour // pragma: allowlist secret
-
-// ttlPattern is the canonical (lower-case) form of the platform's TTL
-// grammar. Inputs are lower-cased before matching so "3D" and "3d" are
-// accepted equivalently from the CLI even though the platform expects
-// the lower-case form on the wire.
-//
-// TODO: replace with a shared SDK helper once the Go and Python SDKs
-// expose a single TTL parser; see mozilla-ai/cq issue tracking the lift.
-var ttlPattern = regexp.MustCompile(`^[0-9]+[smhd]$`)
 
 // authKeyCreateLongDoc is the help text shown for cq auth key create.
 var authKeyCreateLongDoc = `Create a new API key.
@@ -95,9 +80,9 @@ func newAuthKeyCmd(cfg authOptions) *cobra.Command {
 // newAuthKeyCreateCmd returns the cq auth key create subcommand.
 func newAuthKeyCreateCmd(cfg authOptions) *cobra.Command {
 	var (
-		name   string
-		ttl    string
-		labels []string
+		name     string
+		ttlInput string
+		labels   []string
 	)
 
 	cmd := &cobra.Command{
@@ -111,7 +96,7 @@ func newAuthKeyCreateCmd(cfg authOptions) *cobra.Command {
 			// adds noise, so suppress it for any error path below.
 			cmd.SilenceUsage = true
 
-			canonicalTTL, err := parseTTL(ttl)
+			canonicalTTL, err := parseTTL(ttlInput)
 			if err != nil {
 				return err
 			}
@@ -137,7 +122,7 @@ func newAuthKeyCreateCmd(cfg authOptions) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&name, "name", "", "Display name for the key (required).")
-	cmd.Flags().StringVar(&ttl, "ttl", "", "Lifetime in the format <integer><s|m|h|d>, e.g. 30d, 12h. Max 365d. Required.")
+	cmd.Flags().StringVar(&ttlInput, "ttl", "", "Lifetime in the format <integer><s|m|h|d>, e.g. 30d, 12h. Max 365d. Required.")
 	cmd.Flags().StringSliceVar(&labels, "labels", nil, "Optional labels (repeat --labels or supply a comma-separated list).")
 
 	_ = cmd.MarkFlagRequired("name")
@@ -268,54 +253,23 @@ func formatLabels(labels []string) string {
 	return strings.Join(labels, ",")
 }
 
-// parseTTL validates that s matches the platform's TTL grammar and
-// returns it in canonical (lower-case) form. The grammar is
-// <integer><unit>, where unit is one of s, m, h, d. The CLI accepts
-// either case (3D and 3d are equivalent on input) and always sends
-// the lower-case form on the wire because the platform validator is
-// case-sensitive today. Values whose total duration exceeds
-// maxAPIKeyTTL are rejected so the help text and the validator agree.
-//
-// TODO: replace with the shared SDK TTL parser once it lands; the
-// validator should be a single source of truth across CLI and any
-// other Go consumers. Tracked in mozilla-ai/cq.
+// parseTTL is a thin CLI-facing wrapper around ttl.Parse that maps the
+// SDK's typed errors into --ttl-prefixed cobra messages. The SDK owns
+// the canonical grammar, max bound, and case normalisation; this layer
+// only reshapes errors so the user sees the flag name they typed.
 func parseTTL(s string) (string, error) {
-	canonical := strings.ToLower(strings.TrimSpace(s))
-
-	if canonical == "" {
+	canonical, _, err := ttl.Parse(s)
+	switch {
+	case errors.Is(err, ttl.ErrEmpty):
 		return "", errors.New("--ttl is required: supply a value like 30d, 12h, 90d (max 365d)")
-	}
-
-	if !ttlPattern.MatchString(canonical) {
+	case errors.Is(err, ttl.ErrGrammar):
 		return "", fmt.Errorf("--ttl %q is not a valid duration: expected <integer><s|m|h|d>, e.g. 30d, 12h", s)
-	}
-
-	// The grammar guarantees a non-empty digit run followed by exactly
-	// one unit byte, so the slice operations below are safe and the
-	// numeric parse only fails when the user supplies more digits than
-	// fit in an int64 (which trivially exceeds the cap anyway).
-	digits := canonical[:len(canonical)-1]
-	unit := canonical[len(canonical)-1]
-
-	value, err := strconv.ParseInt(digits, 10, 64)
-	if err != nil {
+	case errors.Is(err, ttl.ErrTooLarge):
 		return "", fmt.Errorf("--ttl %q exceeds the maximum of 365d", s)
-	}
-
-	var unitDuration time.Duration
-	switch unit {
-	case 's':
-		unitDuration = time.Second
-	case 'm':
-		unitDuration = time.Minute
-	case 'h':
-		unitDuration = time.Hour
-	case 'd':
-		unitDuration = 24 * time.Hour
-	}
-
-	if value > int64(maxAPIKeyTTL/unitDuration) {
-		return "", fmt.Errorf("--ttl %q exceeds the maximum of 365d", s)
+	case errors.Is(err, ttl.ErrTooSmall):
+		return "", fmt.Errorf("--ttl %q must be greater than zero", s)
+	case err != nil:
+		return "", fmt.Errorf("--ttl %q: %w", s, err)
 	}
 
 	return canonical, nil

--- a/cli/cmd/auth_key_test.go
+++ b/cli/cmd/auth_key_test.go
@@ -45,14 +45,12 @@ func runKey(t *testing.T, client auth.Client, store credstore.Store, args ...str
 	return stdout.String(), stderr.String(), err
 }
 
-// TestParseTTL covers the inline TTL validator the create flow uses
-// before reaching the platform. Mixed-case input is accepted and
-// normalised to lower-case; anything that does not match the platform
-// grammar is rejected with a single-shot, parse-locally error.
-//
-// TODO: remove this test once TTL parsing moves into the Go SDK; the
-// SDK should own its own coverage and the CLI will then exercise it
-// only through the create command's stub-based tests above.
+// TestParseTTL pins the CLI-facing wrapper around the SDK parser. The
+// SDK owns the grammar and coverage (see sdk/go/ttl); this test only
+// confirms the wrapper reshapes typed SDK errors into --ttl-prefixed
+// cobra messages with the user-supplied (un-normalised) value quoted
+// back. Coverage is therefore deliberately narrow: one case per error
+// class plus the canonicalisation paths.
 func TestParseTTL(t *testing.T) {
 	t.Parallel()
 
@@ -62,31 +60,17 @@ func TestParseTTL(t *testing.T) {
 		want    string
 		wantErr string
 	}{
-		{name: "lower-case days", input: "30d", want: "30d"},
-		{name: "lower-case hours", input: "12h", want: "12h"},
-		{name: "lower-case minutes", input: "45m", want: "45m"},
-		{name: "lower-case seconds", input: "60s", want: "60s"},
-		{name: "upper-case days canonicalised", input: "3D", want: "3d"},
-		{name: "upper-case hours canonicalised", input: "2H", want: "2h"},
-		{name: "leading and trailing whitespace trimmed", input: "  90d  ", want: "90d"},
-		{name: "max boundary 365d accepted", input: "365d", want: "365d"},
-		{name: "max boundary 8760h accepted", input: "8760h", want: "8760h"},
-		{name: "max boundary 525600m accepted", input: "525600m", want: "525600m"},
-		{name: "max boundary 31536000s accepted", input: "31536000s", want: "31536000s"},
+		{name: "lower-case canonical accepted", input: "30d", want: "30d"},
+		{name: "upper-case canonicalised", input: "3D", want: "3d"},
+		{name: "whitespace trimmed", input: "  90d  ", want: "90d"},
+		{name: "max boundary accepted", input: "365d", want: "365d"},
+
 		{name: "empty rejected", input: "", wantErr: "--ttl is required"},
-		{name: "whitespace-only rejected", input: "   ", wantErr: "--ttl is required"},
-		{name: "weeks rejected", input: "1w", wantErr: `--ttl "1w" is not a valid duration`},
-		{name: "missing unit rejected", input: "30", wantErr: `--ttl "30" is not a valid duration`},
-		{name: "unit only rejected", input: "d", wantErr: `--ttl "d" is not a valid duration`},
-		{name: "wrong order rejected", input: "d30", wantErr: `--ttl "d30" is not a valid duration`},
-		{name: "decimal rejected", input: "3.5d", wantErr: `--ttl "3.5d" is not a valid duration`},
-		{name: "negative rejected", input: "-1d", wantErr: `--ttl "-1d" is not a valid duration`},
-		{name: "compound rejected", input: "1d2h", wantErr: `--ttl "1d2h" is not a valid duration`},
-		{name: "366d rejected as exceeding cap", input: "366d", wantErr: `--ttl "366d" exceeds the maximum of 365d`},
-		{name: "8761h rejected as exceeding cap", input: "8761h", wantErr: `--ttl "8761h" exceeds the maximum of 365d`},
-		{name: "525601m rejected as exceeding cap", input: "525601m", wantErr: `--ttl "525601m" exceeds the maximum of 365d`},
-		{name: "31536001s rejected as exceeding cap", input: "31536001s", wantErr: `--ttl "31536001s" exceeds the maximum of 365d`},
-		{name: "huge value out of int64 range rejected", input: "99999999999999999999d", wantErr: `--ttl "99999999999999999999d" exceeds the maximum of 365d`},
+		{name: "grammar error quotes original input", input: "1w", wantErr: `--ttl "1w" is not a valid duration`},
+		{name: "negative rejected via grammar", input: "-1d", wantErr: `--ttl "-1d" is not a valid duration`},
+		{name: "over-cap rejected with cap message", input: "366d", wantErr: `--ttl "366d" exceeds the maximum of 365d`},
+		{name: "huge value rejected with cap message", input: "99999999999999999999d", wantErr: `--ttl "99999999999999999999d" exceeds the maximum of 365d`},
+		{name: "zero rejected with positive message", input: "0d", wantErr: `--ttl "0d" must be greater than zero`},
 	}
 
 	for _, tc := range cases {

--- a/sdk/go/ttl/ttl.go
+++ b/sdk/go/ttl/ttl.go
@@ -1,0 +1,126 @@
+// Package ttl parses the duration grammar shared by the cq platform's
+// API-key TTL field. The grammar is a strict subset of Go's
+// time.ParseDuration: a single non-negative integer followed by exactly
+// one unit suffix from {s, m, h, d}. It is case-insensitive on input
+// but always returns the canonical lower-case form so the value the
+// platform validates and persists is unambiguous regardless of which
+// client emitted it.
+package ttl
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Max is the upper bound the platform accepts for an API-key TTL.
+// Values whose total duration exceeds Max are rejected; the constant is
+// exported so callers can quote it in --help text or error messages
+// without the string literal drifting between client and server.
+const Max = 365 * 24 * time.Hour
+
+// canonicalMax is the canonical lower-case rendering of Max, embedded
+// in user-facing error messages so the wording matches the on-wire
+// grammar.
+const canonicalMax = "365d"
+
+// maxInputLen caps the raw input length so a caller cannot make the
+// parser scan or allocate over a multi-megabyte string. The longest
+// legitimate input is "31536000s" (9 chars) plus surrounding
+// whitespace; the bound here is generous enough to tolerate that
+// without forcing callers to pre-strip and tight enough that an
+// attacker cannot weaponise length. Inputs longer than this are
+// rejected before any case-folding, regexp, or numeric parse runs.
+const maxInputLen = 64
+
+// ErrEmpty is returned by Parse when the input is empty or whitespace.
+var ErrEmpty = errors.New("ttl is required")
+
+// ErrGrammar is returned by Parse when the input does not match
+// <integer><s|m|h|d>. Callers can compare with errors.Is to distinguish
+// grammar errors from non-positive or over-cap values.
+var ErrGrammar = errors.New("not a valid duration: expected <integer><s|m|h|d>, e.g. 30d, 12h")
+
+// ErrTooLarge is returned by Parse when the input parses to a duration
+// that exceeds Max.
+var ErrTooLarge = errors.New("exceeds the maximum of " + canonicalMax)
+
+// ErrTooSmall is returned by Parse when the input parses to zero. The
+// platform rejects zero-TTL keys because they are meaningless (expired
+// on issue), so the SDK rejects them up-front rather than letting the
+// platform return a 422.
+var ErrTooSmall = errors.New("must be greater than zero")
+
+// pattern matches the canonical (lower-case) grammar after the input
+// has been trimmed and lower-cased. Inputs are normalised before
+// matching so "3D", " 3d", and "3d" are all accepted equivalently.
+var pattern = regexp.MustCompile(`^[0-9]+[smhd]$`)
+
+// Parse normalises s and returns the canonical lower-case form along
+// with the parsed duration. It wraps ErrEmpty when s is blank,
+// ErrGrammar when s does not match <integer><s|m|h|d>, and ErrTooLarge
+// when the parsed duration exceeds Max.
+//
+// Callers should send the returned canonical string on the wire so the
+// platform's stored value is independent of the input casing.
+func Parse(s string) (string, time.Duration, error) {
+	if len(s) > maxInputLen {
+		// Truncate before quoting so the error message can never echo
+		// an attacker-controlled megabyte-long input back into logs.
+		return "", 0, fmt.Errorf("%q: %w", s[:maxInputLen], ErrTooLarge)
+	}
+
+	canonical := strings.ToLower(strings.TrimSpace(s))
+
+	if canonical == "" {
+		return "", 0, ErrEmpty
+	}
+
+	if !pattern.MatchString(canonical) {
+		return "", 0, fmt.Errorf("%q: %w", s, ErrGrammar)
+	}
+
+	// pattern guarantees at least one digit followed by exactly one
+	// unit byte, so the slice operations below are safe. ParseInt only
+	// fails when the digit run overflows int64; treat that as exceeding
+	// Max because it trivially does.
+	digits := canonical[:len(canonical)-1]
+	unit := canonical[len(canonical)-1]
+
+	value, err := strconv.ParseInt(digits, 10, 64)
+	if err != nil {
+		return "", 0, fmt.Errorf("%q: %w", s, ErrTooLarge)
+	}
+
+	if value == 0 {
+		return "", 0, fmt.Errorf("%q: %w", s, ErrTooSmall)
+	}
+
+	unitDuration := unitDurationFor(unit)
+	if value > int64(Max/unitDuration) {
+		return "", 0, fmt.Errorf("%q: %w", s, ErrTooLarge)
+	}
+
+	return canonical, time.Duration(value) * unitDuration, nil
+}
+
+// unitDurationFor returns the duration of a single unit. The unit byte
+// is guaranteed to be one of {s, m, h, d} by the caller's regexp; any
+// other value would be a programmer error.
+func unitDurationFor(unit byte) time.Duration {
+	switch unit {
+	case 's':
+		return time.Second
+	case 'm':
+		return time.Minute
+	case 'h':
+		return time.Hour
+	case 'd':
+		return 24 * time.Hour
+	}
+
+	panic(fmt.Sprintf("ttl: unreachable unit %q", unit))
+}

--- a/sdk/go/ttl/ttl.go
+++ b/sdk/go/ttl/ttl.go
@@ -1,7 +1,8 @@
 // Package ttl parses the duration grammar shared by the cq platform's
 // API-key TTL field. The grammar is a strict subset of Go's
-// time.ParseDuration: a single non-negative integer followed by exactly
-// one unit suffix from {s, m, h, d}. It is case-insensitive on input
+// time.ParseDuration: a single positive ASCII integer followed by
+// exactly one unit suffix from {s, m, h, d}. Zero is rejected because
+// a zero-TTL key is meaningless. Parsing is case-insensitive on input
 // but always returns the canonical lower-case form so the value the
 // platform validates and persists is unambiguous regardless of which
 // client emitted it.
@@ -36,6 +37,16 @@ const canonicalMax = "365d"
 // rejected before any case-folding, regexp, or numeric parse runs.
 const maxInputLen = 64
 
+// maxCanonicalLen caps the canonical (post-trim, post-lower) input
+// length so a caller cannot pad a small value with leading zeros to
+// inflate the digit run past the platform's contract. The longest
+// legitimate canonical value is "31536000s" (9 chars). The bound
+// here matches sdk/python/cq.ttl so the two parsers agree on which
+// values they reject as too long; without this cap an input like
+// "00000000000000001d" would be accepted by Go and rejected by
+// Python.
+const maxCanonicalLen = 16
+
 // ErrEmpty is returned by Parse when the input is empty or whitespace.
 var ErrEmpty = errors.New("ttl is required")
 
@@ -60,9 +71,12 @@ var ErrTooSmall = errors.New("must be greater than zero")
 var pattern = regexp.MustCompile(`^[0-9]+[smhd]$`)
 
 // Parse normalises s and returns the canonical lower-case form along
-// with the parsed duration. It wraps ErrEmpty when s is blank,
-// ErrGrammar when s does not match <integer><s|m|h|d>, and ErrTooLarge
-// when the parsed duration exceeds Max.
+// with the parsed duration. It wraps one of:
+//   - ErrEmpty when s is blank,
+//   - ErrGrammar when s does not match <integer><s|m|h|d>,
+//   - ErrTooSmall when s parses to zero,
+//   - ErrTooLarge when s parses to a duration above Max or its
+//     canonical length exceeds maxCanonicalLen.
 //
 // Callers should send the returned canonical string on the wire so the
 // platform's stored value is independent of the input casing.
@@ -77,6 +91,12 @@ func Parse(s string) (string, time.Duration, error) {
 
 	if canonical == "" {
 		return "", 0, ErrEmpty
+	}
+
+	if len(canonical) > maxCanonicalLen {
+		// The raw input is already <= maxInputLen so quoting s is
+		// safe and matches the user's actual keystrokes.
+		return "", 0, fmt.Errorf("%q: %w", s, ErrTooLarge)
 	}
 
 	if !pattern.MatchString(canonical) {

--- a/sdk/go/ttl/ttl_test.go
+++ b/sdk/go/ttl/ttl_test.go
@@ -1,0 +1,141 @@
+package ttl_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mozilla-ai/cq/sdk/go/ttl"
+)
+
+// TestParse covers the public Parse contract: lower-case is canonical,
+// upper-case input is normalised, whitespace is trimmed, and any value
+// outside the grammar or above Max is rejected with a typed error.
+func TestParse(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		input   string
+		want    string
+		wantDur time.Duration
+		wantErr error
+	}{
+		{name: "lower-case days", input: "30d", want: "30d", wantDur: 30 * 24 * time.Hour},
+		{name: "lower-case hours", input: "12h", want: "12h", wantDur: 12 * time.Hour},
+		{name: "lower-case minutes", input: "45m", want: "45m", wantDur: 45 * time.Minute},
+		{name: "lower-case seconds", input: "60s", want: "60s", wantDur: 60 * time.Second},
+		{name: "upper-case days canonicalised", input: "3D", want: "3d", wantDur: 3 * 24 * time.Hour},
+		{name: "upper-case hours canonicalised", input: "2H", want: "2h", wantDur: 2 * time.Hour},
+		{name: "mixed-case rejected by grammar is impossible after normalisation", input: "3D", want: "3d", wantDur: 3 * 24 * time.Hour},
+		{name: "leading and trailing whitespace trimmed", input: "  90d  ", want: "90d", wantDur: 90 * 24 * time.Hour},
+		{name: "leading zero accepted", input: "007d", want: "007d", wantDur: 7 * 24 * time.Hour},
+		{name: "max boundary 365d accepted", input: "365d", want: "365d", wantDur: ttl.Max},
+		{name: "max boundary 8760h accepted", input: "8760h", want: "8760h", wantDur: ttl.Max},
+		{name: "max boundary 525600m accepted", input: "525600m", want: "525600m", wantDur: ttl.Max},
+		{name: "max boundary 31536000s accepted", input: "31536000s", want: "31536000s", wantDur: ttl.Max},
+
+		{name: "empty rejected", input: "", wantErr: ttl.ErrEmpty},
+		{name: "whitespace-only rejected", input: "   ", wantErr: ttl.ErrEmpty},
+		{name: "weeks rejected", input: "1w", wantErr: ttl.ErrGrammar},
+		{name: "missing unit rejected", input: "30", wantErr: ttl.ErrGrammar},
+		{name: "unit only rejected", input: "d", wantErr: ttl.ErrGrammar},
+		{name: "wrong order rejected", input: "d30", wantErr: ttl.ErrGrammar},
+		{name: "decimal rejected", input: "3.5d", wantErr: ttl.ErrGrammar},
+		{name: "negative rejected", input: "-1d", wantErr: ttl.ErrGrammar},
+		{name: "compound rejected", input: "1d2h", wantErr: ttl.ErrGrammar},
+		{name: "months rejected", input: "3mo", wantErr: ttl.ErrGrammar},
+		{name: "years rejected", input: "5y", wantErr: ttl.ErrGrammar},
+		{name: "internal whitespace rejected", input: "1 d", wantErr: ttl.ErrGrammar},
+
+		{name: "366d rejected as exceeding cap", input: "366d", wantErr: ttl.ErrTooLarge},
+		{name: "8761h rejected as exceeding cap", input: "8761h", wantErr: ttl.ErrTooLarge},
+		{name: "525601m rejected as exceeding cap", input: "525601m", wantErr: ttl.ErrTooLarge},
+		{name: "31536001s rejected as exceeding cap", input: "31536001s", wantErr: ttl.ErrTooLarge},
+		{name: "huge value out of int64 range rejected", input: "99999999999999999999d", wantErr: ttl.ErrTooLarge},
+
+		{name: "zero days rejected", input: "0d", wantErr: ttl.ErrTooSmall},
+		{name: "zero seconds rejected", input: "0s", wantErr: ttl.ErrTooSmall},
+		{name: "zero with leading zeros rejected", input: "000h", wantErr: ttl.ErrTooSmall},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotCanonical, gotDur, err := ttl.Parse(tc.input)
+
+			if tc.wantErr != nil {
+				require.Error(t, err)
+				require.ErrorIs(t, err, tc.wantErr)
+				require.Empty(t, gotCanonical)
+				require.Zero(t, gotDur)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.want, gotCanonical)
+			require.Equal(t, tc.wantDur, gotDur)
+		})
+	}
+}
+
+// TestParse_QuotedInputAppearsInError pins that the wrapped error
+// message includes the user's original (un-normalised) input so a UI
+// surfacing the error can faithfully echo what the user typed.
+func TestParse_QuotedInputAppearsInError(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := ttl.Parse("1W")
+	require.Error(t, err)
+	require.ErrorIs(t, err, ttl.ErrGrammar)
+	require.Contains(t, err.Error(), `"1W"`)
+}
+
+// TestParse_ErrorsAreSentinels confirms the four exported errors are
+// distinct values so callers can dispatch on them with errors.Is.
+func TestParse_ErrorsAreSentinels(t *testing.T) {
+	t.Parallel()
+
+	for _, pair := range [][2]error{
+		{ttl.ErrEmpty, ttl.ErrGrammar},
+		{ttl.ErrEmpty, ttl.ErrTooLarge},
+		{ttl.ErrEmpty, ttl.ErrTooSmall},
+		{ttl.ErrGrammar, ttl.ErrTooLarge},
+		{ttl.ErrGrammar, ttl.ErrTooSmall},
+		{ttl.ErrTooLarge, ttl.ErrTooSmall},
+	} {
+		require.False(t, errors.Is(pair[0], pair[1]))
+	}
+}
+
+// TestMax_Is365Days locks the platform-supplied upper bound so a casual
+// edit to the constant has to update the test deliberately.
+func TestMax_Is365Days(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, 365*24*time.Hour, ttl.Max)
+}
+
+// TestParse_LengthCapDefendsAgainstUnboundedInput pins that the parser
+// rejects very long inputs up-front (before regex/normalisation runs)
+// so a malicious caller cannot make Parse do CPU work proportional to
+// a multi-megabyte digit run. The error is wrapped as ErrTooLarge
+// because the underlying intent (a bigger-than-Max value) is the same.
+func TestParse_LengthCapDefendsAgainstUnboundedInput(t *testing.T) {
+	t.Parallel()
+
+	huge := strings.Repeat("9", 1<<20) + "d"
+	canonical, dur, err := ttl.Parse(huge)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ttl.ErrTooLarge)
+	require.Empty(t, canonical)
+	require.Zero(t, dur)
+	// The error message must not echo the entire attacker-controlled
+	// input back; truncation is part of the contract so logs stay sane.
+	require.Less(t, len(err.Error()), 256)
+}

--- a/sdk/go/ttl/ttl_test.go
+++ b/sdk/go/ttl/ttl_test.go
@@ -60,6 +60,9 @@ func TestParse(t *testing.T) {
 		{name: "zero days rejected", input: "0d", wantErr: ttl.ErrTooSmall},
 		{name: "zero seconds rejected", input: "0s", wantErr: ttl.ErrTooSmall},
 		{name: "zero with leading zeros rejected", input: "000h", wantErr: ttl.ErrTooSmall},
+
+		{name: "canonical length cap rejects padded leading zeros", input: "00000000000000001d", wantErr: ttl.ErrTooLarge},
+		{name: "canonical length cap rejects 17-char digit run", input: "11111111111111111s", wantErr: ttl.ErrTooLarge},
 	}
 
 	for _, tc := range cases {

--- a/sdk/python/src/cq/ttl.py
+++ b/sdk/python/src/cq/ttl.py
@@ -1,0 +1,92 @@
+"""Duration-string parser for the cq platform's API-key TTL field.
+
+The grammar is a strict subset of Go's ``time.ParseDuration``: a single
+non-negative integer followed by exactly one unit suffix from
+``s``, ``m``, ``h``, ``d``. Longer units such as ``mo`` and ``y`` are
+deliberately not supported to keep the grammar unambiguous.
+
+Parsing is case-insensitive on input but always returns the canonical
+lower-case form so the value the platform validates and persists is
+unambiguous regardless of which client emitted it.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import timedelta
+
+__all__ = ["MAX", "TTLError", "parse"]
+
+# Upper bound the platform accepts for an API-key TTL. Values whose
+# total duration exceeds MAX are rejected. Exposed so callers can quote
+# it in --help text or error messages without the string literal
+# drifting between client and server.
+MAX = timedelta(days=365)
+
+_CANONICAL_MAX = "365d"
+
+_PATTERN = re.compile(r"^(\d+)([smhd])$")
+
+_UNIT_SECONDS = {
+    "s": 1,
+    "m": 60,
+    "h": 60 * 60,
+    "d": 24 * 60 * 60,
+}
+
+_MAX_SECONDS = int(MAX.total_seconds())
+
+# Upper bound on the canonical (post-strip, post-lower) input length.
+# The longest legitimate value is "31536000s" (9 chars); the cap here is
+# deliberately loose to tolerate leading zeros without forcing callers to
+# strip them. Inputs longer than this are rejected before ``int()`` runs
+# so the parser self-defends against unbounded-digit DoS even when used
+# outside an HTTP layer that would have its own body-size limit.
+_MAX_CANONICAL_LEN = 16
+
+
+class TTLError(ValueError):
+    """Raised when a TTL value is empty, malformed, or exceeds MAX.
+
+    Subclasses ``ValueError`` so existing call sites that catch
+    ``ValueError`` (the contract the original ``cq_server.ttl`` parser
+    used) continue to work.
+    """
+
+
+def parse(value: str) -> tuple[str, timedelta]:
+    r"""Parse a TTL duration string.
+
+    Args:
+        value: A string matching ``^\d+[smhd]$`` after case-folding and
+            whitespace trimming.
+
+    Returns:
+        A ``(canonical, duration)`` tuple. ``canonical`` is the
+        lower-case, whitespace-stripped form of ``value``; ``duration``
+        is the parsed ``timedelta``. Send ``canonical`` on the wire so
+        the platform stores a value independent of the input casing.
+
+    Raises:
+        TTLError: If the string is empty, malformed, zero, or exceeds
+            MAX. Subclasses ``ValueError`` for backward compatibility
+            with call sites that catch ``ValueError`` directly.
+    """
+    canonical = value.strip().lower() if value else ""
+    if not canonical:
+        raise TTLError("ttl is required")
+    # Length-cap before int() so a multi-megabyte digit run cannot make
+    # the parser do real CPU work before the MAX check fires. The bound
+    # is well above any legitimate value (longest is "31536000s").
+    if len(canonical) > _MAX_CANONICAL_LEN:
+        raise TTLError(f"{value!r} exceeds the maximum of {_CANONICAL_MAX}")
+    match = _PATTERN.fullmatch(canonical)
+    if match is None:
+        raise TTLError(f"{value!r} is not a valid duration: expected <integer><s|m|h|d>, e.g. 30d, 12h")
+    quantity = int(match.group(1))
+    if quantity <= 0:
+        raise TTLError(f"{value!r}: ttl must be greater than zero")
+    seconds = quantity * _UNIT_SECONDS[match.group(2)]
+    if seconds > _MAX_SECONDS:
+        raise TTLError(f"{value!r} exceeds the maximum of {_CANONICAL_MAX}")
+    return canonical, timedelta(seconds=seconds)

--- a/sdk/python/src/cq/ttl.py
+++ b/sdk/python/src/cq/ttl.py
@@ -1,9 +1,10 @@
 """Duration-string parser for the cq platform's API-key TTL field.
 
 The grammar is a strict subset of Go's ``time.ParseDuration``: a single
-non-negative integer followed by exactly one unit suffix from
-``s``, ``m``, ``h``, ``d``. Longer units such as ``mo`` and ``y`` are
-deliberately not supported to keep the grammar unambiguous.
+positive ASCII integer followed by exactly one unit suffix from
+``s``, ``m``, ``h``, ``d``. Zero is rejected because a zero-TTL key
+is meaningless. Longer units such as ``mo`` and ``y`` are deliberately
+not supported to keep the grammar unambiguous.
 
 Parsing is case-insensitive on input but always returns the canonical
 lower-case form so the value the platform validates and persists is
@@ -25,7 +26,10 @@ MAX = timedelta(days=365)
 
 _CANONICAL_MAX = "365d"
 
-_PATTERN = re.compile(r"^(\d+)([smhd])$")
+# [0-9]+ rather than \d+: Python's \d matches Unicode "decimal digit"
+# (category Nd), so values like "١٢h" would otherwise parse as 12h and
+# diverge from sdk/go/ttl which uses an explicit ASCII class.
+_PATTERN = re.compile(r"^([0-9]+)([smhd])$")
 
 _UNIT_SECONDS = {
     "s": 1,
@@ -44,6 +48,18 @@ _MAX_SECONDS = int(MAX.total_seconds())
 # outside an HTTP layer that would have its own body-size limit.
 _MAX_CANONICAL_LEN = 16
 
+# Maximum number of characters of the original input echoed in any error
+# message. Bounds the size of the exception string so an attacker-
+# controlled megabyte input does not produce a megabyte-sized error
+# (which would amplify allocation cost and bloat logs). Mirrors the
+# truncation budget in sdk/go/ttl.
+_MAX_ECHO_LEN = 64
+
+
+def _echo(value: str) -> str:
+    """Return ``value`` truncated for safe inclusion in error messages."""
+    return value if len(value) <= _MAX_ECHO_LEN else value[:_MAX_ECHO_LEN]
+
 
 class TTLError(ValueError):
     """Raised when a TTL value is empty, malformed, or exceeds MAX.
@@ -58,8 +74,8 @@ def parse(value: str) -> tuple[str, timedelta]:
     r"""Parse a TTL duration string.
 
     Args:
-        value: A string matching ``^\d+[smhd]$`` after case-folding and
-            whitespace trimming.
+        value: A string matching ``^[0-9]+[smhd]$`` after case-folding
+            and whitespace trimming.
 
     Returns:
         A ``(canonical, duration)`` tuple. ``canonical`` is the
@@ -79,14 +95,14 @@ def parse(value: str) -> tuple[str, timedelta]:
     # the parser do real CPU work before the MAX check fires. The bound
     # is well above any legitimate value (longest is "31536000s").
     if len(canonical) > _MAX_CANONICAL_LEN:
-        raise TTLError(f"{value!r} exceeds the maximum of {_CANONICAL_MAX}")
+        raise TTLError(f"{_echo(value)!r} exceeds the maximum of {_CANONICAL_MAX}")
     match = _PATTERN.fullmatch(canonical)
     if match is None:
-        raise TTLError(f"{value!r} is not a valid duration: expected <integer><s|m|h|d>, e.g. 30d, 12h")
+        raise TTLError(f"{_echo(value)!r} is not a valid duration: expected <integer><s|m|h|d>, e.g. 30d, 12h")
     quantity = int(match.group(1))
     if quantity <= 0:
-        raise TTLError(f"{value!r}: ttl must be greater than zero")
+        raise TTLError(f"{_echo(value)!r}: ttl must be greater than zero")
     seconds = quantity * _UNIT_SECONDS[match.group(2)]
     if seconds > _MAX_SECONDS:
-        raise TTLError(f"{value!r} exceeds the maximum of {_CANONICAL_MAX}")
+        raise TTLError(f"{_echo(value)!r} exceeds the maximum of {_CANONICAL_MAX}")
     return canonical, timedelta(seconds=seconds)

--- a/sdk/python/tests/test_ttl.py
+++ b/sdk/python/tests/test_ttl.py
@@ -1,0 +1,130 @@
+"""Tests for the cq.ttl duration parser."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+
+from cq.ttl import MAX, TTLError, parse
+
+
+class TestParseHappyPath:
+    """Lower-case canonical inputs return the parsed duration verbatim."""
+
+    @pytest.mark.parametrize(
+        ("value", "want"),
+        [
+            ("1s", timedelta(seconds=1)),
+            ("30s", timedelta(seconds=30)),
+            ("15m", timedelta(minutes=15)),
+            ("2h", timedelta(hours=2)),
+            ("7d", timedelta(days=7)),
+        ],
+    )
+    def test_lower_case(self, value: str, want: timedelta) -> None:
+        canonical, duration = parse(value)
+        assert canonical == value
+        assert duration == want
+
+    def test_max_boundary(self) -> None:
+        canonical, duration = parse("365d")
+        assert canonical == "365d"
+        assert duration == MAX
+
+    def test_leading_zero_is_accepted(self) -> None:
+        canonical, duration = parse("007d")
+        assert canonical == "007d"
+        assert duration == timedelta(days=7)
+
+
+class TestParseCanonicalisation:
+    """Upper-case and whitespace inputs canonicalise to lower-case stripped."""
+
+    @pytest.mark.parametrize(
+        ("value", "want_canonical", "want_duration"),
+        [
+            ("3D", "3d", timedelta(days=3)),
+            ("2H", "2h", timedelta(hours=2)),
+            ("45M", "45m", timedelta(minutes=45)),
+            ("60S", "60s", timedelta(seconds=60)),
+            ("  90d  ", "90d", timedelta(days=90)),
+            ("\t30d\n", "30d", timedelta(days=30)),
+        ],
+    )
+    def test_normalises(self, value: str, want_canonical: str, want_duration: timedelta) -> None:
+        canonical, duration = parse(value)
+        assert canonical == want_canonical
+        assert duration == want_duration
+
+
+class TestParseRejections:
+    """Inputs outside the grammar raise ``TTLError`` (a ``ValueError``)."""
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "",
+            " ",
+            "0s",
+            "0d",
+            "000h",
+            "-1d",
+            "1.5h",
+            "1",
+            "h",
+            "d30",
+            "1w",
+            "3mo",
+            "5y",
+            "1h30m",
+            " 1 d",
+            "1 d",
+            "d",
+        ],
+    )
+    def test_rejects(self, value: str) -> None:
+        with pytest.raises(TTLError):
+            parse(value)
+
+    def test_rejects_over_max(self) -> None:
+        with pytest.raises(TTLError):
+            parse("366d")
+
+    def test_rejects_over_max_in_hours(self) -> None:
+        with pytest.raises(TTLError):
+            parse("8761h")
+
+    def test_rejects_over_max_in_minutes(self) -> None:
+        with pytest.raises(TTLError):
+            parse("525601m")
+
+    def test_rejects_over_max_in_seconds(self) -> None:
+        with pytest.raises(TTLError):
+            parse("31536001s")
+
+    def test_rejects_absurdly_large_quantity(self) -> None:
+        with pytest.raises(TTLError):
+            parse("999999999999999999999d")
+
+    def test_rejects_megabyte_digit_run_before_int_parse(self) -> None:
+        # Self-defends against unbounded ``int()`` work even outside an
+        # HTTP layer that would normally cap body size.
+        with pytest.raises(TTLError):
+            parse(("9" * (1 << 20)) + "d")
+
+
+class TestExceptionContract:
+    """``TTLError`` subclasses ``ValueError`` for backward compatibility."""
+
+    def test_ttl_error_is_value_error(self) -> None:
+        with pytest.raises(ValueError):
+            parse("not-a-ttl")
+
+    def test_error_message_quotes_original_input(self) -> None:
+        with pytest.raises(TTLError, match="'1W'"):
+            parse("1W")
+
+    def test_error_message_quotes_over_max_input(self) -> None:
+        with pytest.raises(TTLError, match="'366d'"):
+            parse("366d")

--- a/sdk/python/tests/test_ttl.py
+++ b/sdk/python/tests/test_ttl.py
@@ -113,6 +113,28 @@ class TestParseRejections:
         with pytest.raises(TTLError):
             parse(("9" * (1 << 20)) + "d")
 
+    @pytest.mark.parametrize("value", ["١٢h", "١d", "1٢h"])
+    def test_rejects_unicode_digits(self, value: str) -> None:
+        # Python's \d would otherwise accept Nd-category characters
+        # (e.g. Arabic-Indic) and diverge from sdk/go/ttl's [0-9]+.
+        with pytest.raises(TTLError):
+            parse(value)
+
+
+class TestErrorMessageBounds:
+    """Error messages echo a bounded prefix of the user input.
+
+    An attacker-controlled megabyte input must not produce a megabyte
+    exception string; the parser caps the echoed prefix the same way
+    sdk/go/ttl does.
+    """
+
+    def test_megabyte_input_produces_bounded_error(self) -> None:
+        huge = ("9" * (1 << 20)) + "d"
+        with pytest.raises(TTLError) as exc:
+            parse(huge)
+        assert len(str(exc.value)) < 256
+
 
 class TestExceptionContract:
     """``TTLError`` subclasses ``ValueError`` for backward compatibility."""

--- a/server/backend/src/cq_server/services/api_keys.py
+++ b/server/backend/src/cq_server/services/api_keys.py
@@ -72,7 +72,7 @@ class APIKeyService:
                 active-key cap.
         """
         try:
-            duration = parse_ttl(ttl)
+            canonical_ttl, duration = parse_ttl(ttl)
         except ValueError as exc:
             raise HTTPException(status_code=422, detail=str(exc)) from exc
         user_id = await self._require_user_id(username)
@@ -85,6 +85,9 @@ class APIKeyService:
         secret = generate_secret()
         plaintext = encode_token(key_id=key_id, secret=secret)
         expires_at = (datetime.now(UTC) + duration).isoformat()
+        # Persist the canonical (lower-case, trimmed) TTL so non-CLI
+        # clients that submit "30D" or "  30d  " round-trip identically
+        # to clients that already canonicalise client-side.
         row = await self._api_keys.create(
             key_id=key_id.hex,
             user_id=user_id,
@@ -92,7 +95,7 @@ class APIKeyService:
             labels=_normalise_labels(labels),
             key_prefix=secret_prefix(secret),
             key_hash=hash_secret(secret, pepper=self._pepper),
-            ttl=ttl,
+            ttl=canonical_ttl,
             expires_at=expires_at,
         )
         public = _to_public(row)

--- a/server/backend/src/cq_server/ttl.py
+++ b/server/backend/src/cq_server/ttl.py
@@ -1,10 +1,11 @@
 """Duration-string parser for API key TTLs.
 
-The grammar matches the cq SDK's ``cq.ttl`` parser: a single non-negative
-integer followed by exactly one unit suffix from ``s``, ``m``, ``h``,
-``d``. Parsing is case-insensitive on input and always returns the
-canonical lower-case form so the value the platform persists is
-unambiguous regardless of which client emitted it.
+The grammar matches the cq SDK's ``cq.ttl`` parser: a single positive
+ASCII integer followed by exactly one unit suffix from ``s``, ``m``,
+``h``, ``d``. Zero is rejected because a zero-TTL key is meaningless.
+Parsing is case-insensitive on input and always returns the canonical
+lower-case form so the value the platform persists is unambiguous
+regardless of which client emitted it.
 
 This module mirrors the SDK parser locally so the platform can validate
 without taking a runtime dependency on a specific SDK release. The two
@@ -43,9 +44,19 @@ _MAX_CANONICAL_LEN = 16
 # arithmetic check in ``parse_ttl`` does not recompute on every call.
 _MAX_SECONDS = int(MAX_TTL.total_seconds())
 
+# _MAX_ECHO_LEN caps the number of characters of the original input
+# echoed in any error message. Bounds the size of the exception string
+# so an attacker-controlled megabyte input does not produce a megabyte
+# error (which would amplify allocation cost and bloat logs). Mirrors
+# the truncation budget in sdk/python/cq.ttl and sdk/go/ttl.
+_MAX_ECHO_LEN = 64
+
 # _PATTERN matches the canonical (lower-case, trimmed) grammar:
-# one or more digits followed by exactly one unit suffix.
-_PATTERN = re.compile(r"^(\d+)([smhd])$")
+# one or more ASCII digits followed by exactly one unit suffix.
+# [0-9]+ rather than \d+: Python's \d would accept Unicode "decimal
+# digit" characters (category Nd), so values like "١٢h" would otherwise
+# parse and diverge from sdk/go/ttl which uses an explicit ASCII class.
+_PATTERN = re.compile(r"^([0-9]+)([smhd])$")
 
 # _UNIT_SECONDS maps each accepted unit suffix to its duration in
 # seconds. Lookup is keyed by the unit byte the regexp captured, so
@@ -62,9 +73,9 @@ def parse_ttl(value: str) -> tuple[str, timedelta]:
     r"""Parse a TTL duration string.
 
     Args:
-        value: A string matching ``^\d+[smhd]$`` after case-folding and
-            whitespace trimming. Both ``"30D"`` and ``"30d"`` are accepted
-            and return the lower-case canonical form ``"30d"``.
+        value: A string matching ``^[0-9]+[smhd]$`` after case-folding
+            and whitespace trimming. Both ``"30D"`` and ``"30d"`` are
+            accepted and return the lower-case canonical form ``"30d"``.
 
     Returns:
         A ``(canonical, duration)`` tuple. ``canonical`` is the
@@ -81,14 +92,19 @@ def parse_ttl(value: str) -> tuple[str, timedelta]:
     # Length-cap before int() so a multi-megabyte digit run cannot make
     # the parser do real CPU work before the MAX check fires.
     if len(canonical) > _MAX_CANONICAL_LEN:
-        raise ValueError(f"TTL '{value}' exceeds maximum of {_CANONICAL_MAX}")
+        raise ValueError(f"TTL {_echo(value)!r} exceeds maximum of {_CANONICAL_MAX}")
     match = _PATTERN.fullmatch(canonical)
     if match is None:
-        raise ValueError(f"Invalid TTL '{value}'; expected format like '30s', '15m', '2h', or '90d'")
+        raise ValueError(f"Invalid TTL {_echo(value)!r}; expected format like '30s', '15m', '2h', or '90d'")
     quantity = int(match.group(1))
     if quantity <= 0:
         raise ValueError("TTL must be greater than zero")
     seconds = quantity * _UNIT_SECONDS[match.group(2)]
     if seconds > _MAX_SECONDS:
-        raise ValueError(f"TTL '{value}' exceeds maximum of {_CANONICAL_MAX}")
+        raise ValueError(f"TTL {_echo(value)!r} exceeds maximum of {_CANONICAL_MAX}")
     return canonical, timedelta(seconds=seconds)
+
+
+def _echo(value: str) -> str:
+    """Return ``value`` truncated for safe inclusion in error messages."""
+    return value if len(value) <= _MAX_ECHO_LEN else value[:_MAX_ECHO_LEN]

--- a/server/backend/src/cq_server/ttl.py
+++ b/server/backend/src/cq_server/ttl.py
@@ -1,18 +1,50 @@
 """Duration-string parser for API key TTLs.
 
-Accepts a duration string of the form used by Go's ``time.ParseDuration``
-and by Prometheus range durations: ``30s``, ``15m``, ``2h``, ``90d``. The
-grammar is a strict subset of those: exactly one integer quantity followed
-by a single unit suffix from ``s``, ``m``, ``h``, ``d``. Longer units such
-as ``mo`` and ``y`` are deliberately not supported to keep the grammar
-unambiguous.
+The grammar matches the cq SDK's ``cq.ttl`` parser: a single non-negative
+integer followed by exactly one unit suffix from ``s``, ``m``, ``h``,
+``d``. Parsing is case-insensitive on input and always returns the
+canonical lower-case form so the value the platform persists is
+unambiguous regardless of which client emitted it.
+
+This module mirrors the SDK parser locally so the platform can validate
+without taking a runtime dependency on a specific SDK release. The two
+implementations must agree on grammar, max bound, and case-folding;
+their tests should be kept in lockstep.
 """
 
 import re
 from datetime import timedelta
 
+# MAX_TTL is the upper bound the platform accepts for an API-key TTL.
+# Exposed so callers can quote it in --help text or error messages
+# without the value drifting from the validator.
+MAX_TTL = timedelta(days=365)
+
+# _CANONICAL_MAX is the canonical (lower-case, on-wire) rendering of
+# MAX_TTL. Embedded in error messages so the wording matches the
+# grammar the platform persists.
+_CANONICAL_MAX = "365d"
+
+# _MAX_CANONICAL_LEN caps the canonical input length so a caller cannot
+# make ``int()`` do CPU work proportional to a multi-megabyte digit run.
+# The longest legitimate value is ``"31536000s"`` (9 chars); the bound
+# here is generous enough to tolerate leading zeros and tight enough to
+# reject obvious abuse. The platform's HTTP layer already caps body
+# size, but the parser self-defends so this module is safe to call from
+# any context.
+_MAX_CANONICAL_LEN = 16
+
+# _MAX_SECONDS is MAX_TTL converted to seconds, cached here so the
+# arithmetic check in ``parse_ttl`` does not recompute on every call.
+_MAX_SECONDS = int(MAX_TTL.total_seconds())
+
+# _PATTERN matches the canonical (lower-case, trimmed) grammar:
+# one or more digits followed by exactly one unit suffix.
 _PATTERN = re.compile(r"^(\d+)([smhd])$")
 
+# _UNIT_SECONDS maps each accepted unit suffix to its duration in
+# seconds. Lookup is keyed by the unit byte the regexp captured, so
+# every key in this map must appear in _PATTERN's character class.
 _UNIT_SECONDS = {
     "s": 1,
     "m": 60,
@@ -20,24 +52,32 @@ _UNIT_SECONDS = {
     "d": 24 * 60 * 60,
 }
 
-MAX_TTL = timedelta(days=365)
-_MAX_SECONDS = int(MAX_TTL.total_seconds())
 
-
-def parse_ttl(value: str) -> timedelta:
-    r"""Parse a TTL duration string into a ``timedelta``.
+def parse_ttl(value: str) -> tuple[str, timedelta]:
+    r"""Parse a TTL duration string.
 
     Args:
-        value: A string matching ``^\d+[smhd]$``.
+        value: A string matching ``^\d+[smhd]$`` after case-folding and
+            whitespace trimming. Both ``"30D"`` and ``"30d"`` are accepted
+            and return the lower-case canonical form ``"30d"``.
 
     Returns:
-        The parsed duration.
+        A ``(canonical, duration)`` tuple. ``canonical`` is the
+        lower-case, whitespace-stripped form of ``value`` suitable for
+        persistence; ``duration`` is the parsed ``timedelta``.
 
     Raises:
-        ValueError: If the string is empty, malformed, zero, or exceeds the
-            maximum allowed TTL of 365 days.
+        ValueError: If the string is empty, malformed, zero, or exceeds
+            the maximum allowed TTL of 365 days.
     """
-    match = _PATTERN.fullmatch(value)
+    canonical = value.strip().lower() if value else ""
+    if not canonical:
+        raise ValueError("TTL is required")
+    # Length-cap before int() so a multi-megabyte digit run cannot make
+    # the parser do real CPU work before the MAX check fires.
+    if len(canonical) > _MAX_CANONICAL_LEN:
+        raise ValueError(f"TTL '{value}' exceeds maximum of {_CANONICAL_MAX}")
+    match = _PATTERN.fullmatch(canonical)
     if match is None:
         raise ValueError(f"Invalid TTL '{value}'; expected format like '30s', '15m', '2h', or '90d'")
     quantity = int(match.group(1))
@@ -45,6 +85,5 @@ def parse_ttl(value: str) -> timedelta:
         raise ValueError("TTL must be greater than zero")
     seconds = quantity * _UNIT_SECONDS[match.group(2)]
     if seconds > _MAX_SECONDS:
-        raise ValueError(f"TTL '{value}' exceeds maximum of 365d")
-    duration = timedelta(seconds=seconds)
-    return duration
+        raise ValueError(f"TTL '{value}' exceeds maximum of {_CANONICAL_MAX}")
+    return canonical, timedelta(seconds=seconds)

--- a/server/backend/src/cq_server/ttl.py
+++ b/server/backend/src/cq_server/ttl.py
@@ -10,6 +10,11 @@ This module mirrors the SDK parser locally so the platform can validate
 without taking a runtime dependency on a specific SDK release. The two
 implementations must agree on grammar, max bound, and case-folding;
 their tests should be kept in lockstep.
+
+TODO(#359): drop this module once cq-sdk publishes ``cq.ttl``. The
+server pins cq-sdk from PyPI, so switching to ``from cq.ttl import
+parse_ttl`` requires a published SDK release bump in
+``server/backend/pyproject.toml``.
 """
 
 import re

--- a/server/backend/tests/test_auth.py
+++ b/server/backend/tests/test_auth.py
@@ -166,6 +166,20 @@ class TestApiKeyCreate:
         )
         assert resp.status_code == 422
 
+    def test_create_canonicalises_uppercase_ttl(self, api_key_client: TestClient) -> None:
+        token = _login(api_key_client)
+        resp = api_key_client.post(
+            "/api/v1/users/me/api-keys",
+            headers={"Authorization": f"Bearer {token}"},
+            json={"name": "case-fold", "ttl": "30D"},
+        )
+        assert resp.status_code == 201
+        body = resp.json()
+        # The platform persists the lower-case canonical form regardless
+        # of the input casing, so non-CLI clients that submit "30D" see
+        # the same stored value as a CLI that has already lower-cased.
+        assert body["ttl"] == "30d"
+
     def test_create_rejects_empty_name(self, api_key_client: TestClient) -> None:
         token = _login(api_key_client)
         resp = api_key_client.post(

--- a/server/backend/tests/test_ttl.py
+++ b/server/backend/tests/test_ttl.py
@@ -98,3 +98,16 @@ class TestParseTtlRejections:
     def test_rejects_megabyte_digit_run_before_int_parse(self) -> None:
         with pytest.raises(ValueError):
             parse_ttl(("9" * (1 << 20)) + "d")
+
+    @pytest.mark.parametrize("value", ["١٢h", "١d", "1٢h"])
+    def test_rejects_unicode_digits(self, value: str) -> None:
+        with pytest.raises(ValueError):
+            parse_ttl(value)
+
+
+class TestParseTtlErrorMessageBounds:
+    def test_megabyte_input_produces_bounded_error(self) -> None:
+        huge = ("9" * (1 << 20)) + "d"
+        with pytest.raises(ValueError) as exc:
+            parse_ttl(huge)
+        assert len(str(exc.value)) < 256

--- a/server/backend/tests/test_ttl.py
+++ b/server/backend/tests/test_ttl.py
@@ -9,23 +9,43 @@ from cq_server.ttl import MAX_TTL, parse_ttl
 
 class TestParseTtlHappyPath:
     def test_seconds(self) -> None:
-        assert parse_ttl("1s") == timedelta(seconds=1)
-        assert parse_ttl("30s") == timedelta(seconds=30)
+        assert parse_ttl("1s") == ("1s", timedelta(seconds=1))
+        assert parse_ttl("30s") == ("30s", timedelta(seconds=30))
 
     def test_minutes(self) -> None:
-        assert parse_ttl("15m") == timedelta(minutes=15)
+        assert parse_ttl("15m") == ("15m", timedelta(minutes=15))
 
     def test_hours(self) -> None:
-        assert parse_ttl("2h") == timedelta(hours=2)
+        assert parse_ttl("2h") == ("2h", timedelta(hours=2))
 
     def test_days(self) -> None:
-        assert parse_ttl("7d") == timedelta(days=7)
+        assert parse_ttl("7d") == ("7d", timedelta(days=7))
 
     def test_max_boundary(self) -> None:
-        assert parse_ttl("365d") == MAX_TTL
+        assert parse_ttl("365d") == ("365d", MAX_TTL)
 
     def test_leading_zero_is_accepted(self) -> None:
-        assert parse_ttl("007d") == timedelta(days=7)
+        assert parse_ttl("007d") == ("007d", timedelta(days=7))
+
+
+class TestParseTtlCanonicalisation:
+    """Upper-case and surrounding whitespace fold to canonical lower-case."""
+
+    @pytest.mark.parametrize(
+        ("value", "want_canonical", "want_duration"),
+        [
+            ("30D", "30d", timedelta(days=30)),
+            ("12H", "12h", timedelta(hours=12)),
+            ("45M", "45m", timedelta(minutes=45)),
+            ("60S", "60s", timedelta(seconds=60)),
+            ("  90d  ", "90d", timedelta(days=90)),
+            ("\t30d\n", "30d", timedelta(days=30)),
+        ],
+    )
+    def test_normalises(self, value: str, want_canonical: str, want_duration: timedelta) -> None:
+        canonical, duration = parse_ttl(value)
+        assert canonical == want_canonical
+        assert duration == want_duration
 
 
 class TestParseTtlRejections:
@@ -36,18 +56,19 @@ class TestParseTtlRejections:
             " ",
             "0s",
             "0d",
+            "000h",
             "-1d",
             "1.5h",
             "1",
             "h",
             "d30",
-            "30D",
             "1w",
             "3mo",
             "5y",
             "1h30m",
-            " 1d",
-            "1d ",
+            " 1 d",
+            "1 d",
+            "d",
         ],
     )
     def test_rejects(self, value: str) -> None:
@@ -58,6 +79,22 @@ class TestParseTtlRejections:
         with pytest.raises(ValueError):
             parse_ttl("366d")
 
+    def test_rejects_over_max_in_hours(self) -> None:
+        with pytest.raises(ValueError):
+            parse_ttl("8761h")
+
+    def test_rejects_over_max_in_minutes(self) -> None:
+        with pytest.raises(ValueError):
+            parse_ttl("525601m")
+
+    def test_rejects_over_max_in_seconds(self) -> None:
+        with pytest.raises(ValueError):
+            parse_ttl("31536001s")
+
     def test_rejects_absurdly_large_quantity(self) -> None:
         with pytest.raises(ValueError):
             parse_ttl("999999999999999999999d")
+
+    def test_rejects_megabyte_digit_run_before_int_parse(self) -> None:
+        with pytest.raises(ValueError):
+            parse_ttl(("9" * (1 << 20)) + "d")


### PR DESCRIPTION
## Summary

- Add `ttl` package to `sdk/go` exposing `Parse(s) -> (canonical, duration, err)` with sentinel errors (`ErrEmpty`, `ErrGrammar`, `ErrTooLarge`, `ErrTooSmall`) and a 365d `Max`.
- Add `cq.ttl` to `sdk/python` exposing `parse(value) -> (canonical, timedelta)` with `TTLError(ValueError)`.
- Replace the inline `parseTTL` in `cli/cmd/auth_key.go` with a thin wrapper around the SDK; `--ttl`-prefixed cobra messages preserved.
- Server now case-folds and trims input, persisting the canonical lower-case form so non-CLI clients (curl, terraform, etc.) round-trip identically (`"30D"` is accepted and stored as `"30d"`).
- All three parsers cap canonical input length so a multi-megabyte digit run is rejected before `int()` or the regex do unbounded work.

Closes #353

## Test plan

- [x] `make lint` clean across cli, sdk-go, sdk-python, server-backend, frontend.
- [x] `make test` clean: sdk-go +33 new TTL cases, sdk-python +20, server backend 309 incl. canonicalisation and length-cap cases.
- [x] `TestAuthKeyCreate_TTLAcceptedCaseInsensitively` and the new `test_create_canonicalises_uppercase_ttl` API integration test confirm `30D` round-trips as `30d`.


## Follow-up

`server/backend/src/cq_server/ttl.py` is intentionally a duplicate of `sdk/python/src/cq/ttl.py` because `cq-server` pins `cq-sdk~=0.9.1` from PyPI and the new `cq.ttl` module is not yet in any published SDK release. Tracked in #359 — once cq-sdk is republished with `cq.ttl`, the server-side mirror is removed and the import switched to `from cq.ttl import parse_ttl`.
