### PR TITLE
cli: harden OAuth loopback callback with per-login token path

### DIFF
--- a/cli/internal/auth/listener.go
+++ b/cli/internal/auth/listener.go
@@ -2,24 +2,43 @@ package auth
 
 import (
 	"context"
+	"crypto/rand"
 	_ "embed"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"net"
 	"net/http"
+	"regexp"
 	"sync"
 	"time"
 )
 
 const (
-	// callbackPath is the only HTTP path the loopback listener accepts.
-	// Anything else returns 404.
-	callbackPath = "/cb"
+	// callbackPrefix is the static prefix of the loopback callback path.
+	// The full path served per listener is callbackPrefix + a random
+	// token generated at startListener time, so a same-host process
+	// cannot race the redirect by guessing the path.
+	callbackPrefix = "/cb/"
 
 	// callbackShutdownGrace is the time the listener spends draining the
 	// success-page response before shutting down its server.
 	callbackShutdownGrace = 500 * time.Millisecond
+
+	// callbackTokenBytes is the number of random bytes drawn for the
+	// per-listener callback token. 16 bytes encode to 22 base64url
+	// characters (no padding), placing the entropy floor at ~128 bits
+	// and matching the lower bound the platform validator accepts.
+	callbackTokenBytes = 16
 )
+
+// callbackPathPattern is the shape the loopback callback path must
+// take: the static callbackPrefix followed by a URL-safe random token
+// of 22-64 characters. The platform's redirect_uri validator enforces
+// the same regex; carrying it in CLI code lets startListener fail fast
+// if the token length is ever changed in a way the platform would
+// reject, rather than surfacing as a sign-in failure at exchange time.
+var callbackPathPattern = regexp.MustCompile(`^/cb/[A-Za-z0-9_-]{22,64}$`)
 
 // callbackSuccessPage is the HTML returned to the browser after a
 // successful callback. The content lives in callback_success.html so
@@ -45,10 +64,12 @@ type callbackResult struct {
 
 // listener is a single-shot HTTP listener bound to an ephemeral port
 // on the loopback interface. It accepts exactly one callback on
-// callbackPath and stores the captured result for Wait().
+// callbackPrefix + a per-instance random token, and stores the
+// captured result for Wait().
 type listener struct {
 	server *http.Server
 	addr   string
+	path   string
 
 	once   sync.Once
 	result chan callbackResult
@@ -58,6 +79,16 @@ type listener struct {
 // starts serving, and returns a listener ready to receive a single
 // OAuth callback. The caller must call Close() to release the port.
 func startListener() (*listener, error) {
+	tokenBytes := make([]byte, callbackTokenBytes)
+	if _, err := rand.Read(tokenBytes); err != nil {
+		return nil, fmt.Errorf("generating callback token: %w", err)
+	}
+
+	path := callbackPrefix + base64.RawURLEncoding.EncodeToString(tokenBytes)
+	if !callbackPathPattern.MatchString(path) {
+		return nil, fmt.Errorf("generated callback path '%s' does not match expected pattern", path)
+	}
+
 	// RFC 8252 §7.3: native OAuth clients should bind to the loopback
 	// IP literal rather than "localhost". On dual-stack hosts
 	// "localhost" can resolve to ::1, which would not match a 127.0.0.1
@@ -70,11 +101,12 @@ func startListener() (*listener, error) {
 
 	l := &listener{
 		addr:   netListener.Addr().String(),
+		path:   path,
 		result: make(chan callbackResult, 1),
 	}
 
 	mux := http.NewServeMux()
-	mux.HandleFunc(callbackPath, l.handle)
+	mux.HandleFunc(l.path, l.handle)
 
 	l.server = &http.Server{
 		Handler:           mux,
@@ -114,7 +146,7 @@ func (l *listener) Close() error {
 // confidentiality boundary is the PKCE code_verifier held only in this
 // process.
 func (l *listener) URL() string {
-	return "http://" + l.addr + callbackPath
+	return "http://" + l.addr + l.path
 }
 
 // Wait blocks until either an OAuth callback is captured, the supplied
@@ -129,9 +161,9 @@ func (l *listener) Wait(ctx context.Context) (string, error) {
 	}
 }
 
-// handle is the only HTTP handler registered, scoped to callbackPath.
-// Subsequent calls after the first are ignored to satisfy the
-// single-shot contract.
+// handle is the only HTTP handler registered, scoped to the listener's
+// tokenised callback path. Subsequent calls after the first are ignored
+// to satisfy the single-shot contract.
 //
 // The HTTP response mirrors the parsed result: a 200 success page when
 // the provider redirected with an exchange_code, and a 400 error page

--- a/cli/internal/auth/listener_test.go
+++ b/cli/internal/auth/listener_test.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"strings"
 	"testing"
 	"time"
 
@@ -27,7 +26,26 @@ func TestListener_URL_BindsLocalhostOnly(t *testing.T) {
 	ip := net.ParseIP(host)
 	require.NotNil(t, ip, "expected an IP address, got %s", host)
 	require.True(t, ip.IsLoopback(), "expected loopback address, got %s", ip)
-	require.Equal(t, "/cb", u.Path)
+	require.Regexp(t, callbackPathPattern, u.Path,
+		"callback path must match %s", callbackPathPattern)
+}
+
+func TestListener_URL_PathDiffersAcrossInvocations(t *testing.T) {
+	first, err := startListener()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = first.Close() })
+
+	second, err := startListener()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = second.Close() })
+
+	firstURL, err := url.Parse(first.URL())
+	require.NoError(t, err)
+	secondURL, err := url.Parse(second.URL())
+	require.NoError(t, err)
+
+	require.NotEqual(t, firstURL.Path, secondURL.Path,
+		"each listener must bind a fresh random callback token")
 }
 
 func TestListener_Wait_ReturnsExchangeCodeOnCallback(t *testing.T) {
@@ -95,12 +113,25 @@ func TestListener_NonCallbackPathReturns404(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = l.Close() })
 
-	base := strings.TrimSuffix(l.URL(), "/cb")
-	resp, err := http.Get(base + "/somewhere-else")
+	u, err := url.Parse(l.URL())
 	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
 
-	require.Equal(t, http.StatusNotFound, resp.StatusCode)
+	// Any request that doesn't hit the listener's exact tokenised path
+	// must fall through to the mux's default 404. /cb on its own (the
+	// pre-hardening contract) and /cb/<wrong-token> are the cases an
+	// attacker would try; both must miss.
+	bases := []string{"/somewhere-else", "/cb", "/cb/", "/cb/not-the-real-token"}
+	for _, path := range bases {
+		probe := *u
+		probe.Path = path
+
+		resp, err := http.Get(probe.String())
+		require.NoError(t, err)
+		require.NoError(t, resp.Body.Close())
+
+		require.Equalf(t, http.StatusNotFound, resp.StatusCode,
+			"path %s must return 404", path)
+	}
 }
 
 func TestListener_Wait_IgnoresSubsequentCallbacks(t *testing.T) {


### PR DESCRIPTION
Closes #348.

## Summary

- `cq auth login` listener now binds `127.0.0.1:<port>/cb/<token>` instead of `/cb`, where the token is 16 bytes of `crypto/rand` base64url-encoded (22 chars, ~128-bit entropy floor). A same-host process can no longer race the redirect.
- A production `callbackPathPattern` regex documents the accepted path shape (`/cb/<22-64 URL-safe chars>`); `startListener` asserts the generated path matches before binding, so a future change to the token length can't silently produce non-conforming paths.
- Tests reference the same regex and prove the per-login token differs across invocations.

## Test plan

- [x] `make lint` — 0 issues
- [x] `make test` — full suite passes
- [x] `go test -race -count=100 ./internal/auth/...` — passes