### PR TITLE
plugin: bump minimum CLI version to v0.7.0

### DIFF
--- a/plugins/cq/scripts/bootstrap.json
+++ b/plugins/cq/scripts/bootstrap.json
@@ -1,3 +1,3 @@
 {
-  "cli_min_version": "0.5.0"
+  "cli_min_version": "0.7.0"
 }


### PR DESCRIPTION
Claude marketplace JSON and pyproject versions already bumped in https://github.com/mozilla-ai/cq/pull/324.

This PR tags the minimum version of the CLI required for the plugin to v0.7.0.

Ready for tag `plugin/0.8.0` after merge.
