### PR TITLE
Hide created_by from query/confirm/flag API responses

### DIFF
--- a/server/backend/src/cq_server/api/routes/knowledge.py
+++ b/server/backend/src/cq_server/api/routes/knowledge.py
@@ -11,7 +11,7 @@ from ..deps import APIKeyAuthDep, KnowledgeServiceDep
 router = APIRouter(prefix="/knowledge", tags=["knowledge"])
 
 
-@router.get("")
+@router.get("", response_model_exclude={"__all__": {"created_by"}})
 async def query_units(
     domains: Annotated[list[str], Query()],
     knowledge: KnowledgeServiceDep,
@@ -20,7 +20,12 @@ async def query_units(
     pattern: Annotated[str | None, Query()] = None,
     limit: Annotated[int, Query(gt=0)] = 5,
 ) -> list[KnowledgeUnit]:
-    """Search knowledge units by domain tags with relevance ranking."""
+    """Search knowledge units by domain tags with relevance ranking.
+
+    ``created_by`` is excluded from query responses to avoid leaking personal
+    identifiers through the public read path until user-level attribution
+    opt-in semantics are implemented.
+    """
     return await knowledge.query(
         domains=domains,
         languages=languages,
@@ -49,24 +54,32 @@ async def propose_unit(
     )
 
 
-@router.post("/{unit_id}/confirmations", status_code=201)
+@router.post("/{unit_id}/confirmations", status_code=201, response_model_exclude={"created_by"})
 async def confirm_unit(
     unit_id: str,
     _username: APIKeyAuthDep,
     knowledge: KnowledgeServiceDep,
 ) -> KnowledgeUnit:
-    """Confirm a knowledge unit, boosting its confidence."""
+    """Confirm a knowledge unit, boosting its confidence.
+
+    ``created_by`` is excluded to avoid exposing proposer identity through
+    API responses until explicit attribution opt-in exists.
+    """
     return await knowledge.confirm(unit_id)
 
 
-@router.post("/{unit_id}/flags", status_code=201)
+@router.post("/{unit_id}/flags", status_code=201, response_model_exclude={"created_by"})
 async def flag_unit(
     unit_id: str,
     request: FlagRequest,
     _username: APIKeyAuthDep,
     knowledge: KnowledgeServiceDep,
 ) -> KnowledgeUnit:
-    """Flag a knowledge unit, reducing its confidence."""
+    """Flag a knowledge unit, reducing its confidence.
+
+    ``created_by`` is excluded to avoid exposing proposer identity through
+    API responses until explicit attribution opt-in exists.
+    """
     return await knowledge.flag(unit_id, request.reason)
 
 

--- a/server/backend/tests/test_app.py
+++ b/server/backend/tests/test_app.py
@@ -226,6 +226,7 @@ class TestConfirm:
         resp = client.post(f"/api/v1/knowledge/{created['id']}/confirmations")
         assert resp.status_code == 201
         body = resp.json()
+        assert "created_by" not in body
         assert body["evidence"]["confirmations"] == 2
         assert body["evidence"]["confidence"] > 0.5
 
@@ -247,6 +248,7 @@ class TestFlag:
         resp = client.post(f"/api/v1/knowledge/{created['id']}/flags", json={"reason": "stale"})
         assert resp.status_code == 201
         body = resp.json()
+        assert "created_by" not in body
         assert body["evidence"]["confidence"] < 0.5
         assert len(body["flags"]) == 1
 
@@ -511,6 +513,23 @@ class TestApiKeyEnforcement:
     def test_query_stays_open_under_enforcement(self, enforced_client: TestClient) -> None:
         resp = enforced_client.get("/api/v1/knowledge", params={"domains": ["anything"]})
         assert resp.status_code == 200
+
+    def test_query_omits_created_by_from_response(self, enforced_client: TestClient) -> None:
+        jwt_token = _seed_user_and_login(enforced_client, username="alice")
+        api_token = _create_api_key_plaintext(enforced_client, jwt_token)
+        propose = enforced_client.post(
+            "/api/v1/knowledge",
+            json=_propose_payload(domains=["privacy"]),
+            headers={"Authorization": f"Bearer {api_token}"},
+        )
+        assert propose.status_code == 201
+        _approve_unit(enforced_client, propose.json()["id"])
+
+        query = enforced_client.get("/api/v1/knowledge", params={"domains": ["privacy"]})
+        assert query.status_code == 200
+        body = query.json()
+        assert len(body) == 1
+        assert "created_by" not in body[0]
 
     def test_stats_stays_open_under_enforcement(self, enforced_client: TestClient) -> None:
         resp = enforced_client.get("/api/v1/knowledge/stats")


### PR DESCRIPTION
## Summary
- Exclude `created_by` from `/api/v1/knowledge` query responses via route-level response projection, including list-item handling.
- Exclude `created_by` from `/api/v1/knowledge/{unit_id}/confirmations` and `/api/v1/knowledge/{unit_id}/flags` responses.
- Add/adjust API tests to verify proposer identity is omitted on read-side routes while remaining present on propose responses.

## Why
This prevents unintentional personal data leakage via public/read-oriented API paths until user attribution opt-in semantics are implemented.

Closes #344 