### PR TITLE
refactor(backend): move service-layer HTTP errors to API boundary mapping

### DIFF
--- a/server/backend/src/cq_server/api/deps.py
+++ b/server/backend/src/cq_server/api/deps.py
@@ -18,6 +18,7 @@ from fastapi import BackgroundTasks, Depends, HTTPException, Request
 from ..auth import verify_token
 from ..core.config import Settings
 from ..core.db import Database
+from ..exceptions import APIKeyInvalidError
 from ..repositories import APIKeyRepository, KnowledgeRepository, ReviewRepository, UserRepository
 from ..services import APIKeyService, AuthService, KnowledgeService, ReviewService
 
@@ -150,7 +151,7 @@ async def require_api_key(
 
     The ``Authorization: Bearer <token>`` header must carry a valid,
     unrevoked, unexpired key. ``APIKeyService.authenticate`` performs the
-    HMAC-compare and schedules the ``last_used_at`` background update.
+    HMAC compare. This dependency schedules the ``last_used_at`` update.
 
     Args:
         request: The incoming FastAPI request.
@@ -166,7 +167,12 @@ async def require_api_key(
     header = request.headers.get("Authorization")
     if not header or not header.startswith("Bearer "):
         raise HTTPException(status_code=401, detail="Invalid API key")
-    return await api_keys.authenticate(header.removeprefix("Bearer "), background_tasks)
+    try:
+        username, key_id = await api_keys.authenticate(header.removeprefix("Bearer "))
+    except APIKeyInvalidError:
+        raise HTTPException(status_code=401, detail="Invalid API key") from None
+    background_tasks.add_task(api_keys.touch_last_used, key_id)
+    return username
 
 
 APIKeyAuthDep = Annotated[str, Depends(require_api_key)]

--- a/server/backend/src/cq_server/api/routes/auth.py
+++ b/server/backend/src/cq_server/api/routes/auth.py
@@ -1,11 +1,19 @@
 """Auth routes: session lifecycle (login today; refresh/logout forward-looking)."""
 
-from fastapi import APIRouter
+from fastapi import APIRouter, status
 
+from ...exceptions import InvalidCredentialsError, ServiceError
 from ...models.auth import LoginRequest, LoginResponse
 from ..deps import AuthServiceDep
 
 router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+def auth_exception_mappings() -> dict[type[ServiceError], int]:
+    """Return service-exception to HTTP-status mappings for auth routes."""
+    return {
+        InvalidCredentialsError: status.HTTP_401_UNAUTHORIZED,
+    }
 
 
 @router.post("/login")
@@ -20,7 +28,6 @@ async def login(request: LoginRequest, auth: AuthServiceDep) -> LoginResponse:
         A LoginResponse with a signed JWT and the username.
 
     Raises:
-        HTTPException: With status 401 if credentials are invalid (raised
-            from inside ``AuthService.login``).
+        InvalidCredentialsError: If credentials are invalid.
     """
     return await auth.login(request.username, request.password)

--- a/server/backend/src/cq_server/api/routes/knowledge.py
+++ b/server/backend/src/cq_server/api/routes/knowledge.py
@@ -3,12 +3,21 @@
 from typing import Annotated
 
 from cq.models import KnowledgeUnit
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Query, status
 
+from ...exceptions import InvalidDomainError, KnowledgeUnitNotFoundError, ServiceError
 from ...models.knowledge import FlagRequest, ProposeRequest, StatsResponse
 from ..deps import APIKeyAuthDep, KnowledgeServiceDep
 
 router = APIRouter(prefix="/knowledge", tags=["knowledge"])
+
+
+def knowledge_exception_mappings() -> dict[type[ServiceError], int]:
+    """Return service-exception to HTTP-status mappings for knowledge routes."""
+    return {
+        InvalidDomainError: status.HTTP_422_UNPROCESSABLE_CONTENT,
+        KnowledgeUnitNotFoundError: status.HTTP_404_NOT_FOUND,
+    }
 
 
 @router.get("", response_model_exclude={"__all__": {"created_by"}})

--- a/server/backend/src/cq_server/api/routes/review.py
+++ b/server/backend/src/cq_server/api/routes/review.py
@@ -1,7 +1,8 @@
 """Review queue endpoints for the review API."""
 
-from fastapi import APIRouter
+from fastapi import APIRouter, status
 
+from ...exceptions import KnowledgeUnitAlreadyReviewedError, KnowledgeUnitNotFoundError, ServiceError
 from ...models.review import (
     ReviewDecisionResponse,
     ReviewItem,
@@ -11,6 +12,14 @@ from ...models.review import (
 from ..deps import CurrentUserDep, ReviewServiceDep
 
 router = APIRouter(prefix="/review", tags=["review"])
+
+
+def review_exception_mappings() -> dict[type[ServiceError], int]:
+    """Return service-exception to HTTP-status mappings for review routes."""
+    return {
+        KnowledgeUnitAlreadyReviewedError: status.HTTP_409_CONFLICT,
+        KnowledgeUnitNotFoundError: status.HTTP_404_NOT_FOUND,
+    }
 
 
 @router.get("/queue")

--- a/server/backend/src/cq_server/api/routes/users.py
+++ b/server/backend/src/cq_server/api/routes/users.py
@@ -1,7 +1,14 @@
 """User-owned resources: the current user record and their API keys."""
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, status
 
+from ...exceptions import (
+    APIKeyActiveLimitReachedError,
+    APIKeyNotFoundError,
+    APIKeyTTLInvalidError,
+    ServiceError,
+    UserNotFoundError,
+)
 from ...models.users import (
     ApiKeysPublic,
     CreateApiKeyRequest,
@@ -12,6 +19,16 @@ from ...models.users import (
 from ..deps import APIKeyServiceDep, CurrentUserDep, UserRepositoryDep
 
 router = APIRouter(prefix="/users", tags=["users"])
+
+
+def user_exception_mappings() -> dict[type[ServiceError], int]:
+    """Return service-exception to HTTP-status mappings for user routes."""
+    return {
+        APIKeyActiveLimitReachedError: status.HTTP_409_CONFLICT,
+        APIKeyNotFoundError: status.HTTP_404_NOT_FOUND,
+        APIKeyTTLInvalidError: status.HTTP_422_UNPROCESSABLE_CONTENT,
+        UserNotFoundError: status.HTTP_404_NOT_FOUND,
+    }
 
 
 @router.get("/me")

--- a/server/backend/src/cq_server/app.py
+++ b/server/backend/src/cq_server/app.py
@@ -6,16 +6,19 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 
 import uvicorn
-from fastapi import APIRouter, FastAPI, HTTPException
+from fastapi import APIRouter, FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 from starlette.responses import FileResponse
 
+from .api.routes.auth import auth_exception_mappings
 from .api.routes.auth import router as auth_router
 from .api.routes.knowledge import router as knowledge_router
 from .api.routes.review import router as review_router
 from .api.routes.users import router as users_router
 from .core.config import Settings
 from .core.db import Database
+from .exceptions import ServiceError
 from .migrations import run_migrations
 
 _STATIC_DIR = Path(__file__).parent / "static"
@@ -72,6 +75,18 @@ def health() -> dict[str, str]:
 # --- Application assembly. ---
 
 app = FastAPI(title="cq Server", version="0.1.0", lifespan=lifespan)
+
+_exception_mappings: dict[type[ServiceError], int] = {
+    **auth_exception_mappings(),
+}
+
+
+@app.exception_handler(ServiceError)
+async def service_error_handler(_request: Request, exc: ServiceError) -> JSONResponse:
+    """Translate known service exceptions into HTTP responses."""
+    status_code = _exception_mappings.get(type(exc), 500)
+    return JSONResponse(status_code=status_code, content={"detail": exc.message})
+
 
 # Mount API routes only at /api/v1; the previous root mount has been
 # removed so versioning is unambiguous and clients always route through

--- a/server/backend/src/cq_server/app.py
+++ b/server/backend/src/cq_server/app.py
@@ -13,7 +13,9 @@ from starlette.responses import FileResponse
 
 from .api.routes.auth import auth_exception_mappings
 from .api.routes.auth import router as auth_router
+from .api.routes.knowledge import knowledge_exception_mappings
 from .api.routes.knowledge import router as knowledge_router
+from .api.routes.review import review_exception_mappings
 from .api.routes.review import router as review_router
 from .api.routes.users import router as users_router
 from .api.routes.users import user_exception_mappings
@@ -79,6 +81,8 @@ app = FastAPI(title="cq Server", version="0.1.0", lifespan=lifespan)
 
 _exception_mappings: dict[type[ServiceError], int] = {
     **auth_exception_mappings(),
+    **knowledge_exception_mappings(),
+    **review_exception_mappings(),
     **user_exception_mappings(),
 }
 

--- a/server/backend/src/cq_server/app.py
+++ b/server/backend/src/cq_server/app.py
@@ -16,6 +16,7 @@ from .api.routes.auth import router as auth_router
 from .api.routes.knowledge import router as knowledge_router
 from .api.routes.review import router as review_router
 from .api.routes.users import router as users_router
+from .api.routes.users import user_exception_mappings
 from .core.config import Settings
 from .core.db import Database
 from .exceptions import ServiceError
@@ -78,6 +79,7 @@ app = FastAPI(title="cq Server", version="0.1.0", lifespan=lifespan)
 
 _exception_mappings: dict[type[ServiceError], int] = {
     **auth_exception_mappings(),
+    **user_exception_mappings(),
 }
 
 

--- a/server/backend/src/cq_server/exceptions/__init__.py
+++ b/server/backend/src/cq_server/exceptions/__init__.py
@@ -1,13 +1,25 @@
 """Exception hierarchy used by the service layer."""
 
+from .api_keys import (
+    APIKeyActiveLimitReachedError,
+    APIKeyInvalidError,
+    APIKeyNotFoundError,
+    APIKeyTTLInvalidError,
+)
 from .auth import InvalidCredentialsError
 from .base import ConflictError, NotFoundError, ServiceError, UnauthorizedError, ValidationError
+from .users import UserNotFoundError
 
 __all__ = [
+    "APIKeyActiveLimitReachedError",
+    "APIKeyInvalidError",
+    "APIKeyNotFoundError",
+    "APIKeyTTLInvalidError",
     "ConflictError",
     "InvalidCredentialsError",
     "NotFoundError",
     "ServiceError",
     "UnauthorizedError",
+    "UserNotFoundError",
     "ValidationError",
 ]

--- a/server/backend/src/cq_server/exceptions/__init__.py
+++ b/server/backend/src/cq_server/exceptions/__init__.py
@@ -1,0 +1,13 @@
+"""Exception hierarchy used by the service layer."""
+
+from .auth import InvalidCredentialsError
+from .base import ConflictError, NotFoundError, ServiceError, UnauthorizedError, ValidationError
+
+__all__ = [
+    "ConflictError",
+    "InvalidCredentialsError",
+    "NotFoundError",
+    "ServiceError",
+    "UnauthorizedError",
+    "ValidationError",
+]

--- a/server/backend/src/cq_server/exceptions/__init__.py
+++ b/server/backend/src/cq_server/exceptions/__init__.py
@@ -8,6 +8,8 @@ from .api_keys import (
 )
 from .auth import InvalidCredentialsError
 from .base import ConflictError, NotFoundError, ServiceError, UnauthorizedError, ValidationError
+from .knowledge import InvalidDomainError, KnowledgeUnitNotFoundError
+from .review import KnowledgeUnitAlreadyReviewedError
 from .users import UserNotFoundError
 
 __all__ = [
@@ -17,6 +19,9 @@ __all__ = [
     "APIKeyTTLInvalidError",
     "ConflictError",
     "InvalidCredentialsError",
+    "InvalidDomainError",
+    "KnowledgeUnitAlreadyReviewedError",
+    "KnowledgeUnitNotFoundError",
     "NotFoundError",
     "ServiceError",
     "UnauthorizedError",

--- a/server/backend/src/cq_server/exceptions/api_keys.py
+++ b/server/backend/src/cq_server/exceptions/api_keys.py
@@ -1,0 +1,37 @@
+"""Exceptions raised by API key services."""
+
+from __future__ import annotations
+
+from .base import ConflictError, NotFoundError, UnauthorizedError, ValidationError
+
+
+class APIKeyInvalidError(UnauthorizedError):
+    """Signal that an API key token is invalid."""
+
+    def __init__(self) -> None:
+        """Create a stable invalid-API-key service error."""
+        super().__init__("Invalid API key")
+
+
+class APIKeyTTLInvalidError(ValidationError):
+    """Signal that an API key TTL value is invalid."""
+
+    def __init__(self, message: str) -> None:
+        """Create a TTL validation error with parser detail."""
+        super().__init__(message)
+
+
+class APIKeyActiveLimitReachedError(ConflictError):
+    """Signal that a user has reached the active API key limit."""
+
+    def __init__(self, limit: int) -> None:
+        """Create a limit-reached error with the configured max."""
+        super().__init__(f"Maximum of {limit} active API keys per user")
+
+
+class APIKeyNotFoundError(NotFoundError):
+    """Signal that an API key does not exist for the caller."""
+
+    def __init__(self) -> None:
+        """Create a stable not-found error for missing API keys."""
+        super().__init__("API key not found")

--- a/server/backend/src/cq_server/exceptions/auth.py
+++ b/server/backend/src/cq_server/exceptions/auth.py
@@ -1,0 +1,13 @@
+"""Exceptions raised by authentication services."""
+
+from __future__ import annotations
+
+from .base import UnauthorizedError
+
+
+class InvalidCredentialsError(UnauthorizedError):
+    """Signal that username/password credentials are invalid."""
+
+    def __init__(self) -> None:
+        """Create a stable invalid-credentials service error."""
+        super().__init__("Invalid username or password")

--- a/server/backend/src/cq_server/exceptions/base.py
+++ b/server/backend/src/cq_server/exceptions/base.py
@@ -1,0 +1,28 @@
+"""Base exception hierarchy for service-layer errors."""
+
+from __future__ import annotations
+
+
+class ServiceError(Exception):
+    """Signal that a service-layer operation failed."""
+
+    def __init__(self, message: str) -> None:
+        """Create a service error with a user-safe message."""
+        super().__init__(message)
+        self.message = message
+
+
+class UnauthorizedError(ServiceError):
+    """Signal that credentials are missing, invalid, or not permitted."""
+
+
+class NotFoundError(ServiceError):
+    """Signal that a requested resource does not exist."""
+
+
+class ConflictError(ServiceError):
+    """Signal that a request conflicts with current resource state."""
+
+
+class ValidationError(ServiceError):
+    """Signal that request data is semantically invalid."""

--- a/server/backend/src/cq_server/exceptions/knowledge.py
+++ b/server/backend/src/cq_server/exceptions/knowledge.py
@@ -1,0 +1,21 @@
+"""Exceptions raised by knowledge services."""
+
+from __future__ import annotations
+
+from .base import NotFoundError, ValidationError
+
+
+class KnowledgeUnitNotFoundError(NotFoundError):
+    """Signal that a knowledge unit does not exist."""
+
+    def __init__(self) -> None:
+        """Create a stable not-found error for missing knowledge units."""
+        super().__init__("Knowledge unit not found")
+
+
+class InvalidDomainError(ValidationError):
+    """Signal that domain tags are missing or invalid."""
+
+    def __init__(self) -> None:
+        """Create a stable validation error for invalid domain input."""
+        super().__init__("At least one non-empty domain is required")

--- a/server/backend/src/cq_server/exceptions/review.py
+++ b/server/backend/src/cq_server/exceptions/review.py
@@ -1,0 +1,13 @@
+"""Exceptions raised by review services."""
+
+from __future__ import annotations
+
+from .base import ConflictError
+
+
+class KnowledgeUnitAlreadyReviewedError(ConflictError):
+    """Signal that a review decision was already recorded for a unit."""
+
+    def __init__(self, status: str) -> None:
+        """Create a conflict error with the existing review status."""
+        super().__init__(f"Knowledge unit already {status}")

--- a/server/backend/src/cq_server/exceptions/users.py
+++ b/server/backend/src/cq_server/exceptions/users.py
@@ -1,0 +1,13 @@
+"""Exceptions raised by user-related services."""
+
+from __future__ import annotations
+
+from .base import NotFoundError
+
+
+class UserNotFoundError(NotFoundError):
+    """Signal that a referenced user does not exist."""
+
+    def __init__(self) -> None:
+        """Create a stable not-found error for missing users."""
+        super().__init__("User not found")

--- a/server/backend/src/cq_server/services/api_keys.py
+++ b/server/backend/src/cq_server/services/api_keys.py
@@ -9,9 +9,15 @@ from typing import Any
 
 from cq.ttl import TTLError
 from cq.ttl import parse as parse_ttl
-from fastapi import BackgroundTasks, HTTPException
 
 from ..api_keys import decode_token, encode_token, generate_secret, hash_secret, secret_prefix
+from ..exceptions import (
+    APIKeyActiveLimitReachedError,
+    APIKeyInvalidError,
+    APIKeyNotFoundError,
+    APIKeyTTLInvalidError,
+    UserNotFoundError,
+)
 from ..models.users import (
     ApiKeyPublic,
     ApiKeysPublic,
@@ -38,25 +44,26 @@ class APIKeyService:
         self._users = users
         self._pepper = pepper
 
-    async def authenticate(self, token: str, background_tasks: BackgroundTasks) -> str:
-        """Validate ``token`` and return the owner username; touches last_used.
+    async def authenticate(self, token: str) -> tuple[str, str]:
+        """Validate ``token`` and return ``(username, key_id)``.
 
         Raises:
-            HTTPException: 401 on any decode/lookup/HMAC failure. The error
-                detail is uniform — it never reveals which step failed —
-                so callers cannot use it as an enumeration oracle.
+            APIKeyInvalidError: On any decode/lookup/HMAC failure.
         """
         try:
             key_id, secret = decode_token(token)
         except ValueError as exc:
-            raise HTTPException(status_code=401, detail="Invalid API key") from exc
+            raise APIKeyInvalidError() from exc
         row = await self._api_keys.get_active_by_id(key_id.hex)
         if row is None:
-            raise HTTPException(status_code=401, detail="Invalid API key")
+            raise APIKeyInvalidError()
         if not hmac.compare_digest(row["key_hash"], hash_secret(secret, pepper=self._pepper)):
-            raise HTTPException(status_code=401, detail="Invalid API key")
-        background_tasks.add_task(self._api_keys.touch_last_used, row["id"])
-        return row["username"]
+            raise APIKeyInvalidError()
+        return row["username"], row["id"]
+
+    async def touch_last_used(self, key_id: str) -> None:
+        """Record that API key ``key_id`` was used."""
+        await self._api_keys.touch_last_used(key_id)
 
     async def create(
         self,
@@ -69,19 +76,16 @@ class APIKeyService:
         """Issue a new API key for ``username`` and return it with plaintext.
 
         Raises:
-            HTTPException: 422 on a malformed TTL, 409 when the user is at the
-                active-key cap.
+            APIKeyTTLInvalidError: If the TTL is malformed.
+            APIKeyActiveLimitReachedError: If the user is already at the active-key cap.
         """
         try:
             canonical_ttl, duration = parse_ttl(ttl)
         except TTLError as exc:
-            raise HTTPException(status_code=422, detail=str(exc)) from exc
+            raise APIKeyTTLInvalidError(str(exc)) from exc
         user_id = await self._require_user_id(username)
         if await self._api_keys.count_active_for_user(user_id) >= MAX_ACTIVE_API_KEYS_PER_USER:
-            raise HTTPException(
-                status_code=409,
-                detail=f"Maximum of {MAX_ACTIVE_API_KEYS_PER_USER} active API keys per user",
-            )
+            raise APIKeyActiveLimitReachedError(MAX_ACTIVE_API_KEYS_PER_USER)
         key_id = uuid.uuid4()
         secret = generate_secret()
         plaintext = encode_token(key_id=key_id, secret=secret)
@@ -116,14 +120,14 @@ class APIKeyService:
         """
         user_id = await self._require_user_id(username)
         if await self._api_keys.get_for_user(user_id=user_id, key_id=key_id) is None:
-            raise HTTPException(status_code=404, detail="API key not found")
+            raise APIKeyNotFoundError()
         await self._api_keys.revoke(user_id=user_id, key_id=key_id)
         return Message(message="API key revoked.")
 
     async def _require_user_id(self, username: str) -> int:
         user = await self._users.get(username)
         if user is None:
-            raise HTTPException(status_code=404, detail="User not found")
+            raise UserNotFoundError()
         return int(user["id"])
 
 

--- a/server/backend/src/cq_server/services/auth.py
+++ b/server/backend/src/cq_server/services/auth.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-from fastapi import HTTPException
-
 from ..auth import create_token, verify_password
+from ..exceptions import InvalidCredentialsError
 from ..models.auth import LoginResponse
 from ..repositories import UserRepository
 
@@ -21,10 +20,10 @@ class AuthService:
         """Authenticate ``username``/``password`` and return a fresh ``LoginResponse``.
 
         Raises:
-            HTTPException: 401 if credentials don't match a user.
+            InvalidCredentialsError: If credentials do not match a user.
         """
         user = await self._users.get(username)
         if user is None or not verify_password(password, user["password_hash"]):
-            raise HTTPException(status_code=401, detail="Invalid username or password")
+            raise InvalidCredentialsError()
         token = create_token(username, secret=self._jwt_secret)
         return LoginResponse(token=token, username=username)

--- a/server/backend/src/cq_server/services/knowledge.py
+++ b/server/backend/src/cq_server/services/knowledge.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 from cq.models import Context, FlagReason, Insight, KnowledgeUnit, Tier, create_knowledge_unit
-from fastapi import HTTPException
 
+from ..exceptions import InvalidDomainError, KnowledgeUnitNotFoundError
 from ..models.knowledge import StatsResponse
 from ..repositories import KnowledgeRepository, normalize_domains
 from ..scoring import apply_confirmation, apply_flag
@@ -21,11 +21,11 @@ class KnowledgeService:
         """Apply a confirmation to ``unit_id``, persist, and return it.
 
         Raises:
-            HTTPException: 404 if the unit is unknown or not yet approved.
+            KnowledgeUnitNotFoundError: If the unit is unknown or not approved.
         """
         unit = await self._knowledge.get(unit_id)
         if unit is None:
-            raise HTTPException(status_code=404, detail="Knowledge unit not found")
+            raise KnowledgeUnitNotFoundError()
         confirmed = apply_confirmation(unit)
         await self._knowledge.update(confirmed)
         return confirmed
@@ -34,11 +34,11 @@ class KnowledgeService:
         """Apply a flag to ``unit_id``, persist, and return the updated unit.
 
         Raises:
-            HTTPException: 404 if the unit is unknown or not yet approved.
+            KnowledgeUnitNotFoundError: If the unit is unknown or not approved.
         """
         unit = await self._knowledge.get(unit_id)
         if unit is None:
-            raise HTTPException(status_code=404, detail="Knowledge unit not found")
+            raise KnowledgeUnitNotFoundError()
         flagged = apply_flag(unit, reason)
         await self._knowledge.update(flagged)
         return flagged
@@ -57,11 +57,11 @@ class KnowledgeService:
         authoritative username from the credential, never client input.
 
         Raises:
-            HTTPException: 422 if all supplied domains are empty/whitespace.
+            InvalidDomainError: If all supplied domains are empty/whitespace.
         """
         normalized = normalize_domains(domains)
         if not normalized:
-            raise HTTPException(status_code=422, detail="At least one non-empty domain is required")
+            raise InvalidDomainError()
         unit = create_knowledge_unit(
             domains=normalized,
             insight=insight,

--- a/server/backend/src/cq_server/services/reviews.py
+++ b/server/backend/src/cq_server/services/reviews.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from fastapi import HTTPException
-
+from ..exceptions import KnowledgeUnitAlreadyReviewedError, KnowledgeUnitNotFoundError
 from ..models.review import (
     DailyCount,
     ReviewDecisionResponse,
@@ -36,7 +35,7 @@ class ReviewService:
         """Return a single unit + review metadata; raises 404 if unknown."""
         ku = await self._knowledge.get_any(unit_id)
         if ku is None:
-            raise HTTPException(status_code=404, detail="Knowledge unit not found")
+            raise KnowledgeUnitNotFoundError()
         review = await self._reviews.get_status(unit_id)
         assert review is not None  # Unit exists; get_any just returned it.
         return ReviewItem(
@@ -117,9 +116,10 @@ class ReviewService:
         """Apply ``status`` (``"approved"`` / ``"rejected"``) to a pending unit."""
         existing = await self._reviews.get_status(unit_id)
         if existing is None:
-            raise HTTPException(status_code=404, detail="Knowledge unit not found")
-        if existing["status"] != "pending":
-            raise HTTPException(status_code=409, detail=f"Knowledge unit already {existing['status']}")
+            raise KnowledgeUnitNotFoundError()
+        existing_status = existing["status"] or "pending"
+        if existing_status != "pending":
+            raise KnowledgeUnitAlreadyReviewedError(existing_status)
         await self._reviews.set_status(unit_id, status, reviewer)
         updated = await self._reviews.get_status(unit_id)
         assert updated is not None  # Unit exists; we just wrote to it.

--- a/server/backend/tests/test_auth_service.py
+++ b/server/backend/tests/test_auth_service.py
@@ -1,0 +1,50 @@
+"""Unit tests for ``AuthService`` service-layer behavior."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from cq_server.auth import hash_password
+from cq_server.exceptions import InvalidCredentialsError
+from cq_server.services.auth import AuthService
+
+
+class _StubUserRepo:
+    """Minimal user repository stub for ``AuthService`` tests."""
+
+    def __init__(self, row: dict[str, Any] | None) -> None:
+        self._row = row
+
+    async def get(self, username: str) -> dict[str, Any] | None:
+        if self._row is None:
+            return None
+        if self._row["username"] != username:
+            return None
+        return self._row
+
+
+class TestAuthServiceLogin:
+    async def test_login_returns_token_for_valid_credentials(self) -> None:
+        repo = _StubUserRepo({"username": "alice", "password_hash": hash_password("secret123")})
+        service = AuthService(users=repo, jwt_secret="test-secret")  # type: ignore[arg-type]
+
+        response = await service.login("alice", "secret123")
+
+        assert response.username == "alice"
+        assert isinstance(response.token, str)
+        assert response.token
+
+    async def test_login_raises_invalid_credentials_for_unknown_user(self) -> None:
+        service = AuthService(users=_StubUserRepo(None), jwt_secret="test-secret")  # type: ignore[arg-type]
+
+        with pytest.raises(InvalidCredentialsError):
+            await service.login("nobody", "secret123")
+
+    async def test_login_raises_invalid_credentials_for_wrong_password(self) -> None:
+        repo = _StubUserRepo({"username": "alice", "password_hash": hash_password("secret123")})
+        service = AuthService(users=repo, jwt_secret="test-secret")  # type: ignore[arg-type]
+
+        with pytest.raises(InvalidCredentialsError):
+            await service.login("alice", "wrong")

--- a/server/backend/tests/test_deps.py
+++ b/server/backend/tests/test_deps.py
@@ -1,4 +1,4 @@
-"""Tests for ``APIKeyService.authenticate`` (formerly the body of ``require_api_key``)."""
+"""Tests for ``APIKeyService.authenticate`` and API-key usage touch behavior."""
 
 from __future__ import annotations
 
@@ -7,9 +7,9 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import pytest
-from fastapi import BackgroundTasks, HTTPException
 
 from cq_server.api_keys import encode_token, generate_secret, hash_secret
+from cq_server.exceptions import APIKeyInvalidError
 from cq_server.services.api_keys import APIKeyService
 
 PEPPER = "test-pepper"
@@ -71,27 +71,25 @@ def _make_service(repo: _StubAPIKeyRepo, *, pepper: str = PEPPER) -> APIKeyServi
 
 
 class TestAuthenticateHappyPath:
-    async def test_valid_token_returns_username(self) -> None:
+    async def test_valid_token_returns_username_and_key_id(self) -> None:
         key_id = uuid.uuid4()
         secret = generate_secret()
         repo = _StubAPIKeyRepo({key_id.hex: _row(key_id=key_id, secret=secret)})
         token = encode_token(key_id=key_id, secret=secret)
         service = _make_service(repo)
 
-        result = await service.authenticate(token, BackgroundTasks())
+        username, touched_key_id = await service.authenticate(token)
 
-        assert result == "alice"
+        assert username == "alice"
+        assert touched_key_id == key_id.hex
 
-    async def test_valid_token_schedules_touch(self) -> None:
+    async def test_touch_last_used_updates_repository(self) -> None:
         key_id = uuid.uuid4()
         secret = generate_secret()
         repo = _StubAPIKeyRepo({key_id.hex: _row(key_id=key_id, secret=secret)})
-        token = encode_token(key_id=key_id, secret=secret)
         service = _make_service(repo)
-        background = BackgroundTasks()
 
-        await service.authenticate(token, background)
-        await background()  # run scheduled callbacks
+        await service.touch_last_used(key_id.hex)
 
         assert repo.touched == [key_id.hex]
 
@@ -100,22 +98,19 @@ class TestAuthenticateRejections:
     async def test_wrong_namespace(self) -> None:
         service = _make_service(_StubAPIKeyRepo())
         token = f"sk.v1.{uuid.uuid4().hex}.sekret"
-        with pytest.raises(HTTPException) as excinfo:
-            await service.authenticate(token, BackgroundTasks())
-        assert excinfo.value.status_code == 401
+        with pytest.raises(APIKeyInvalidError):
+            await service.authenticate(token)
 
     async def test_malformed_token(self) -> None:
         service = _make_service(_StubAPIKeyRepo())
-        with pytest.raises(HTTPException) as excinfo:
-            await service.authenticate("cqa_legacy", BackgroundTasks())
-        assert excinfo.value.status_code == 401
+        with pytest.raises(APIKeyInvalidError):
+            await service.authenticate("cqa_legacy")
 
     async def test_unknown_key_id(self) -> None:
         service = _make_service(_StubAPIKeyRepo())
         token = encode_token(key_id=uuid.uuid4(), secret=generate_secret())
-        with pytest.raises(HTTPException) as excinfo:
-            await service.authenticate(token, BackgroundTasks())
-        assert excinfo.value.status_code == 401
+        with pytest.raises(APIKeyInvalidError):
+            await service.authenticate(token)
 
     async def test_wrong_secret(self) -> None:
         key_id = uuid.uuid4()
@@ -123,9 +118,8 @@ class TestAuthenticateRejections:
         repo = _StubAPIKeyRepo({key_id.hex: _row(key_id=key_id, secret=stored_secret)})
         presented = encode_token(key_id=key_id, secret=generate_secret())
         service = _make_service(repo)
-        with pytest.raises(HTTPException) as excinfo:
-            await service.authenticate(presented, BackgroundTasks())
-        assert excinfo.value.status_code == 401
+        with pytest.raises(APIKeyInvalidError):
+            await service.authenticate(presented)
 
     async def test_revoked_token(self) -> None:
         key_id = uuid.uuid4()
@@ -133,9 +127,8 @@ class TestAuthenticateRejections:
         repo = _StubAPIKeyRepo({key_id.hex: _row(key_id=key_id, secret=secret, revoked_at=datetime.now(UTC))})
         token = encode_token(key_id=key_id, secret=secret)
         service = _make_service(repo)
-        with pytest.raises(HTTPException) as excinfo:
-            await service.authenticate(token, BackgroundTasks())
-        assert excinfo.value.status_code == 401
+        with pytest.raises(APIKeyInvalidError):
+            await service.authenticate(token)
 
     async def test_expired_token(self) -> None:
         key_id = uuid.uuid4()
@@ -144,6 +137,5 @@ class TestAuthenticateRejections:
         repo = _StubAPIKeyRepo({key_id.hex: row})
         token = encode_token(key_id=key_id, secret=secret)
         service = _make_service(repo)
-        with pytest.raises(HTTPException) as excinfo:
-            await service.authenticate(token, BackgroundTasks())
-        assert excinfo.value.status_code == 401
+        with pytest.raises(APIKeyInvalidError):
+            await service.authenticate(token)


### PR DESCRIPTION
## Summary
- Introduce a service-layer exception hierarchy and domain exceptions for auth, API keys, knowledge, review, and users.
- Remove `fastapi.HTTPException` usage from backend services and raise service/domain errors instead.
- Map service exceptions to HTTP status codes at route/app boundary, including centralized handling in `cq_server.app`.

## Validation
- `make lint`
- `make test`