### PR TITLE
fix: Makefile shell expansion issue for linting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -246,11 +246,18 @@ lint-cli:
 
 .PHONY: lint-install
 lint-install:
-	cd scripts/install && uv run --locked pre-commit run --files src/**/*.py tests/*.py pyproject.toml uv.lock
+	uv run --project scripts/install --locked pre-commit run --files $$(git ls-files --cached --others --exclude-standard -- \
+		'scripts/install/pyproject.toml' \
+		'scripts/install/src/**/*.py' \
+		'scripts/install/tests/*.py' \
+		'scripts/install/uv.lock')
 
 .PHONY: lint-plugin
 lint-plugin:
-	cd plugins/cq && uv run --locked pre-commit run --files scripts/*.py pyproject.toml uv.lock
+	uv run --project plugins/cq --locked pre-commit run --files $$(git ls-files --cached --others --exclude-standard -- \
+		'plugins/cq/pyproject.toml' \
+		'plugins/cq/scripts/*.py' \
+		'plugins/cq/uv.lock')
 
 .PHONY: lint-schema-go
 lint-schema-go:
@@ -258,7 +265,10 @@ lint-schema-go:
 
 .PHONY: lint-schema-python
 lint-schema-python: sync-schema
-	cd schema/python && uv run --locked pre-commit run --files src/**/*.py pyproject.toml uv.lock
+	uv run --project schema/python --locked pre-commit run --files $$(git ls-files --cached --others --exclude-standard -- \
+		'schema/python/pyproject.toml' \
+		'schema/python/src/**/*.py' \
+		'schema/python/uv.lock')
 
 .PHONY: lint-schema
 lint-schema: lint-schema-go lint-schema-python
@@ -269,11 +279,17 @@ lint-sdk-go: check-prompts-sync-sdk-go
 
 .PHONY: lint-sdk-python
 lint-sdk-python: check-prompts-sync-sdk-python sync-schema
-	cd sdk/python && uv run --locked pre-commit run --files src/**/*.py pyproject.toml uv.lock
+	uv run --project sdk/python --locked pre-commit run --files $$(git ls-files --cached --others --exclude-standard -- \
+		'sdk/python/pyproject.toml' \
+		'sdk/python/src/**/*.py' \
+		'sdk/python/uv.lock')
 
 .PHONY: lint-server-backend
 lint-server-backend:
-	cd server/backend && uv run --locked pre-commit run --files src/**/*.py pyproject.toml uv.lock
+	uv run --project server/backend --locked pre-commit run --files $$(git ls-files --cached --others --exclude-standard -- \
+		'server/backend/pyproject.toml' \
+		'server/backend/src/**/*.py' \
+		'server/backend/uv.lock')
 
 .PHONY: lint-server-frontend
 lint-server-frontend:

--- a/scripts/lint-frontend.sh
+++ b/scripts/lint-frontend.sh
@@ -5,7 +5,6 @@
 # `git diff --exit-code` check so unformatted commits cannot land.
 
 set -euo pipefail
-set -x
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." &>/dev/null && pwd)"


### PR DESCRIPTION
This PR fixes scoped monorepo linting so targets no longer miss files due to non-portable shell glob expansion in make recipes.

It updates Python `lint` targets to run `pre-commit` via `uv run --project <component> --locked` and to feed explicit component-scoped file lists from `git ls-files` (multiline, sorted for readability), and removes noisy shell xtrace output from `scripts/lint-frontend.sh` so lint logs are clean.