### PR TITLE
Fix: linting shell split issue (Makefile)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -246,18 +246,21 @@ lint-cli:
 
 .PHONY: lint-install
 lint-install:
-	uv run --project scripts/install --locked pre-commit run --files $$(git ls-files --cached --others --exclude-standard -- \
-		'scripts/install/pyproject.toml' \
-		'scripts/install/src/**/*.py' \
-		'scripts/install/tests/*.py' \
-		'scripts/install/uv.lock')
+	git -C scripts/install ls-files -z --cached --others --exclude-standard -- \
+		'*.py' \
+		'pyproject.toml' \
+		'uv.lock' | \
+		xargs -0 -I{} printf 'scripts/install/%s\0' "{}" | \
+		xargs -0 uv run --project scripts/install --locked pre-commit run --files
 
 .PHONY: lint-plugin
 lint-plugin:
-	uv run --project plugins/cq --locked pre-commit run --files $$(git ls-files --cached --others --exclude-standard -- \
-		'plugins/cq/pyproject.toml' \
-		'plugins/cq/scripts/*.py' \
-		'plugins/cq/uv.lock')
+	git -C plugins/cq ls-files -z --cached --others --exclude-standard -- \
+		'*.py' \
+		'pyproject.toml' \
+		'uv.lock' | \
+		xargs -0 -I{} printf 'plugins/cq/%s\0' "{}" | \
+		xargs -0 uv run --project plugins/cq --locked pre-commit run --files
 
 .PHONY: lint-schema-go
 lint-schema-go:
@@ -265,10 +268,12 @@ lint-schema-go:
 
 .PHONY: lint-schema-python
 lint-schema-python: sync-schema
-	uv run --project schema/python --locked pre-commit run --files $$(git ls-files --cached --others --exclude-standard -- \
-		'schema/python/pyproject.toml' \
-		'schema/python/src/**/*.py' \
-		'schema/python/uv.lock')
+	git -C schema/python ls-files -z --cached --others --exclude-standard -- \
+		'*.py' \
+		'pyproject.toml' \
+		'uv.lock' | \
+		xargs -0 -I{} printf 'schema/python/%s\0' "{}" | \
+		xargs -0 uv run --project schema/python --locked pre-commit run --files
 
 .PHONY: lint-schema
 lint-schema: lint-schema-go lint-schema-python
@@ -279,17 +284,21 @@ lint-sdk-go: check-prompts-sync-sdk-go
 
 .PHONY: lint-sdk-python
 lint-sdk-python: check-prompts-sync-sdk-python sync-schema
-	uv run --project sdk/python --locked pre-commit run --files $$(git ls-files --cached --others --exclude-standard -- \
-		'sdk/python/pyproject.toml' \
-		'sdk/python/src/**/*.py' \
-		'sdk/python/uv.lock')
+	git -C sdk/python ls-files -z --cached --others --exclude-standard -- \
+		'*.py' \
+		'pyproject.toml' \
+		'uv.lock' | \
+		xargs -0 -I{} printf 'sdk/python/%s\0' "{}" | \
+		xargs -0 uv run --project sdk/python --locked pre-commit run --files
 
 .PHONY: lint-server-backend
 lint-server-backend:
-	uv run --project server/backend --locked pre-commit run --files $$(git ls-files --cached --others --exclude-standard -- \
-		'server/backend/pyproject.toml' \
-		'server/backend/src/**/*.py' \
-		'server/backend/uv.lock')
+	git -C server/backend ls-files -z --cached --others --exclude-standard -- \
+		'*.py' \
+		'pyproject.toml' \
+		'uv.lock' | \
+		xargs -0 -I{} printf 'server/backend/%s\0' "{}" | \
+		xargs -0 uv run --project server/backend --locked pre-commit run --files
 
 .PHONY: lint-server-frontend
 lint-server-frontend:

--- a/Makefile
+++ b/Makefile
@@ -246,21 +246,11 @@ lint-cli:
 
 .PHONY: lint-install
 lint-install:
-	git -C scripts/install ls-files -z --cached --others --exclude-standard -- \
-		'*.py' \
-		'pyproject.toml' \
-		'uv.lock' | \
-		xargs -0 -I{} printf 'scripts/install/%s\0' "{}" | \
-		xargs -0 uv run --project scripts/install --locked pre-commit run --files
+	bash scripts/lint-python-component.sh scripts/install
 
 .PHONY: lint-plugin
 lint-plugin:
-	git -C plugins/cq ls-files -z --cached --others --exclude-standard -- \
-		'*.py' \
-		'pyproject.toml' \
-		'uv.lock' | \
-		xargs -0 -I{} printf 'plugins/cq/%s\0' "{}" | \
-		xargs -0 uv run --project plugins/cq --locked pre-commit run --files
+	bash scripts/lint-python-component.sh plugins/cq
 
 .PHONY: lint-schema-go
 lint-schema-go:
@@ -268,12 +258,7 @@ lint-schema-go:
 
 .PHONY: lint-schema-python
 lint-schema-python: sync-schema
-	git -C schema/python ls-files -z --cached --others --exclude-standard -- \
-		'*.py' \
-		'pyproject.toml' \
-		'uv.lock' | \
-		xargs -0 -I{} printf 'schema/python/%s\0' "{}" | \
-		xargs -0 uv run --project schema/python --locked pre-commit run --files
+	bash scripts/lint-python-component.sh schema/python
 
 .PHONY: lint-schema
 lint-schema: lint-schema-go lint-schema-python
@@ -284,21 +269,11 @@ lint-sdk-go: check-prompts-sync-sdk-go
 
 .PHONY: lint-sdk-python
 lint-sdk-python: check-prompts-sync-sdk-python sync-schema
-	git -C sdk/python ls-files -z --cached --others --exclude-standard -- \
-		'*.py' \
-		'pyproject.toml' \
-		'uv.lock' | \
-		xargs -0 -I{} printf 'sdk/python/%s\0' "{}" | \
-		xargs -0 uv run --project sdk/python --locked pre-commit run --files
+	bash scripts/lint-python-component.sh sdk/python
 
 .PHONY: lint-server-backend
 lint-server-backend:
-	git -C server/backend ls-files -z --cached --others --exclude-standard -- \
-		'*.py' \
-		'pyproject.toml' \
-		'uv.lock' | \
-		xargs -0 -I{} printf 'server/backend/%s\0' "{}" | \
-		xargs -0 uv run --project server/backend --locked pre-commit run --files
+	bash scripts/lint-python-component.sh server/backend
 
 .PHONY: lint-server-frontend
 lint-server-frontend:

--- a/scripts/lint-python-component.sh
+++ b/scripts/lint-python-component.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <component-dir>" >&2
+  exit 1
+fi
+
+component_dir="$1"
+
+if [[ ! -d "$component_dir" ]]; then
+  echo "Component directory not found: $component_dir" >&2
+  exit 1
+fi
+
+git -C "$component_dir" ls-files -z --cached --others --exclude-standard -- \
+  '*.py' \
+  'pyproject.toml' \
+  'uv.lock' | \
+  xargs -0 -I{} printf '%s/%s\0' "$component_dir" "{}" | \
+  xargs -0 uv run --project "$component_dir" --locked pre-commit run --files


### PR DESCRIPTION
This PR fixes the lint-target regression from the previous shell-expansion change (#369) by making Python file selection shell-agnostic and consistent across environments (bash, zsh, CI).

It centralises scoped Python lint execution in `scripts/lint-python-component.sh`, which uses `git ls-files -z + xargs -0` and repo-root path prefixing before `pre-commit --files`, then updates all Python lint-* Make targets to call that shared script so behavior is correct, repeatable, and easier to maintain.