### PR TITLE
refactor(api): unify list endpoints on {data} envelope

### DIFF
--- a/cli/cmd/cmd_test.go
+++ b/cli/cmd/cmd_test.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"path/filepath"
 	"testing"
 )
@@ -28,4 +30,15 @@ func setFlag(t *testing.T, target *string, value string) {
 	*target = value
 
 	t.Cleanup(func() { *target = prev })
+}
+
+// withFakeRemote starts a fake remote API on a test server, points the
+// CLI's --addr flag at it, and registers cleanup. Callers that need an
+// API key on the wire should setFlag(&flagAPIKey, ...) separately.
+func withFakeRemote(t *testing.T, handler http.Handler) {
+	t.Helper()
+
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	setFlag(t, &flagAddr, srv.URL)
 }

--- a/cli/cmd/drain_test.go
+++ b/cli/cmd/drain_test.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"bytes"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -62,21 +61,6 @@ func TestDrainDryRunJSONFormat(t *testing.T) {
 func TestDrainPushesUnits(t *testing.T) {
 	testSetup(t)
 
-	var pushCount int
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/api/v1/knowledge" && r.Method == "POST" {
-			pushCount++
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusCreated)
-			_, _ = w.Write([]byte(`{"id":"ku_00000000000000000000000000000001","version":1,"domains":["test"],"insight":{"summary":"s","detail":"d","action":"a"},"context":{"languages":[],"frameworks":[],"pattern":""},"evidence":{"confidence":0.5,"confirmations":1},"tier":"local","flags":[]}`))
-
-			return
-		}
-
-		w.WriteHeader(http.StatusServiceUnavailable)
-	}))
-	defer srv.Close()
-
 	// Propose locally first (no remote configured).
 	propose := NewProposeCmd()
 	propose.SetArgs([]string{
@@ -88,7 +72,19 @@ func TestDrainPushesUnits(t *testing.T) {
 	require.NoError(t, propose.Execute())
 
 	// Point at remote, then drain.
-	setFlag(t, &flagAddr, srv.URL)
+	var pushCount int
+	withFakeRemote(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/knowledge" && r.Method == "POST" {
+			pushCount++
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"id":"ku_00000000000000000000000000000001","version":1,"domains":["test"],"insight":{"summary":"s","detail":"d","action":"a"},"context":{"languages":[],"frameworks":[],"pattern":""},"evidence":{"confidence":0.5,"confirmations":1},"tier":"local","flags":[]}`))
+
+			return
+		}
+
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
 
 	drain := NewDrainCmd()
 	var buf bytes.Buffer
@@ -101,19 +97,6 @@ func TestDrainPushesUnits(t *testing.T) {
 func TestDrainJSONFormat(t *testing.T) {
 	testSetup(t)
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/api/v1/knowledge" && r.Method == "POST" {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusCreated)
-			_, _ = w.Write([]byte(`{"id":"ku_00000000000000000000000000000001","version":1,"domains":["test"],"insight":{"summary":"s","detail":"d","action":"a"},"context":{"languages":[],"frameworks":[],"pattern":""},"evidence":{"confidence":0.5,"confirmations":1},"tier":"local","flags":[]}`))
-
-			return
-		}
-
-		w.WriteHeader(http.StatusServiceUnavailable)
-	}))
-	defer srv.Close()
-
 	// Propose locally first (no remote configured).
 	propose := NewProposeCmd()
 	propose.SetArgs([]string{
@@ -125,7 +108,17 @@ func TestDrainJSONFormat(t *testing.T) {
 	require.NoError(t, propose.Execute())
 
 	// Point at remote, then drain.
-	setFlag(t, &flagAddr, srv.URL)
+	withFakeRemote(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/knowledge" && r.Method == "POST" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"id":"ku_00000000000000000000000000000001","version":1,"domains":["test"],"insight":{"summary":"s","detail":"d","action":"a"},"context":{"languages":[],"frameworks":[],"pattern":""},"evidence":{"confidence":0.5,"confirmations":1},"tier":"local","flags":[]}`))
+
+			return
+		}
+
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
 
 	drain := NewDrainCmd()
 	var buf bytes.Buffer
@@ -161,21 +154,6 @@ func TestDrainAddrFromEnv(t *testing.T) {
 func TestDrainAddrFlagOverridesEnv(t *testing.T) {
 	testSetup(t)
 
-	var pushCount int
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/api/v1/knowledge" && r.Method == "POST" {
-			pushCount++
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusCreated)
-			_, _ = w.Write([]byte(`{"id":"ku_00000000000000000000000000000001","version":1,"domains":["test"],"insight":{"summary":"s","detail":"d","action":"a"},"context":{"languages":[],"frameworks":[],"pattern":""},"evidence":{"confidence":0.5,"confirmations":1},"tier":"local","flags":[]}`))
-
-			return
-		}
-
-		w.WriteHeader(http.StatusServiceUnavailable)
-	}))
-	defer srv.Close()
-
 	// Propose locally first (no remote configured).
 	propose := NewProposeCmd()
 	propose.SetArgs([]string{
@@ -188,7 +166,19 @@ func TestDrainAddrFlagOverridesEnv(t *testing.T) {
 
 	// Env says one thing, but the flag (simulating --addr) says another.
 	t.Setenv(envVarAddr, "http://env-addr:8742")
-	setFlag(t, &flagAddr, srv.URL)
+	var pushCount int
+	withFakeRemote(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/knowledge" && r.Method == "POST" {
+			pushCount++
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"id":"ku_00000000000000000000000000000001","version":1,"domains":["test"],"insight":{"summary":"s","detail":"d","action":"a"},"context":{"languages":[],"frameworks":[],"pattern":""},"evidence":{"confidence":0.5,"confirmations":1},"tier":"local","flags":[]}`))
+
+			return
+		}
+
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
 
 	drain := NewDrainCmd()
 	var buf bytes.Buffer

--- a/cli/cmd/query.go
+++ b/cli/cmd/query.go
@@ -50,6 +50,10 @@ func NewQueryCmd() *cobra.Command {
 				return err
 			}
 
+			for _, w := range qr.Warnings {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: %s\n", w)
+			}
+
 			if format == "json" {
 				enc := json.NewEncoder(cmd.OutOrStdout())
 				enc.SetIndent("", jsonIndent)

--- a/cli/cmd/query_test.go
+++ b/cli/cmd/query_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -125,6 +126,32 @@ func TestQueryUnsupportedFormat(t *testing.T) {
 	query := NewQueryCmd()
 	query.SetArgs([]string{"--domain", "api", "--format", "xml"})
 	require.Error(t, query.Execute())
+}
+
+func TestQueryPrintsRemoteWarningsToStderr(t *testing.T) {
+	testSetup(t)
+
+	// Fake remote that returns a bare JSON array instead of the {data: [...]}
+	// envelope. The SDK should fail to decode and surface a warning, which
+	// the CLI must print to stderr.
+	withFakeRemote(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("[]"))
+	}))
+
+	query := NewQueryCmd()
+	var out, errBuf bytes.Buffer
+	query.SetOut(&out)
+	query.SetErr(&errBuf)
+	query.SetArgs([]string{"--domain", "api"})
+	require.NoError(t, query.Execute())
+
+	// The warning must be specifically about the decode failure; a generic
+	// "warning:" line could come from any future warning source and would
+	// mask a regression where the decode error stops surfacing.
+	stderr := errBuf.String()
+	require.Contains(t, stderr, "warning:")
+	require.Contains(t, stderr, "decoding")
 }
 
 func TestQueryPatternFlag(t *testing.T) {

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -36,4 +36,4 @@ require (
 
 // Monorepo: the SDK is consumed locally. Re-pin to a published version
 // when the SDK is released alongside the CLI.
-//replace github.com/mozilla-ai/cq/sdk/go => ../sdk/go
+replace github.com/mozilla-ai/cq/sdk/go => ../sdk/go

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -31,8 +31,6 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mozilla-ai/cq/schema v0.0.1 h1:jPoZAYbU7/b3R3CEghmwuG0A3NrqczWsMkIWjXeFI94=
 github.com/mozilla-ai/cq/schema v0.0.1/go.mod h1:trKUR0o8hGYkQ26XAb3HFVHcQOct7lP/cS8beS5v2eE=
-github.com/mozilla-ai/cq/sdk/go v0.7.0 h1:JJO2tjqEHSv0zrSQwUwYhjE1XJIS9s82J4nElsI4Glg=
-github.com/mozilla-ai/cq/sdk/go v0.7.0/go.mod h1:0lsVnbeeJS76z9Q2AYMBndYPhuYDtZdovLAAvmZDA74=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -458,3 +458,51 @@ The ecosystem convergence on MCP and Agent Skills means cq does not need to conv
 Non-Claude-Code hosts (Cursor, Windsurf, OpenCode) are installed via a host-agnostic Python installer at `scripts/install/`. It is a stdlib-only uv-managed project whose CLI (`python -m cq_install install --target <host>`) resolves a per-host target directory, writes the host-specific MCP config, and installs the shared skill commons to `~/.agents/skills/cq/` (or a project-scoped equivalent). Adding a new host is a single file under `scripts/install/src/cq_install/hosts/`: the primitive library in `common.py` (merge-not-replace JSON, hook entry, manifest-tracked file copies, markdown blocks) handles the shared mechanics. Claude Code remains on its own native marketplace via a thin wrapper host that shells out to `claude plugin marketplace`.
 
 > **Domain scope:** The initial implementation targets coding agents — the domain where agent tooling is most mature and adoption is fastest. The underlying mechanism (structured knowledge sharing via MCP with tiered trust) generalizes to arbitrary domains: DevOps, security, data engineering, and beyond.
+
+---
+
+## 6. HTTP API Conventions
+
+Reference for endpoint authors and SDK implementers. The HTTP surface follows two response-shape conventions for list-returning endpoints and a small set of cross-cutting rules.
+
+### List vs Page
+
+Every list-returning endpoint emits one of two shapes. The model name suffix tells the caller which one to expect.
+
+**`FooList`** — unpaginated. The response is the whole set or a server-clamped top-N. Callers treat it as "what you got, full stop."
+
+```json
+{
+  "data": [Foo, Foo, ...]
+}
+```
+
+**`FooPage`** — cursor-paginated. The response is a slice of an ordered stream, with an opaque token to fetch the next slice.
+
+```json
+{
+  "data": [Foo, Foo, ...],
+  "next_cursor": "opaque-token-or-null"
+}
+```
+
+Callers paginate by passing `next_cursor` back as a query parameter on the next request. `next_cursor: null` (or omitted) means end of stream. The cursor is server-encoded and opaque to clients; clients must not parse or construct it.
+
+### Why cursor over offset
+
+Cursor (a.k.a. keyset) pagination anchors to a position in the sort order rather than a numeric offset. Concurrent inserts or deletes in the filtered set do not cause skips or duplicates between page fetches. This matters most for mutable filtered streams like review queues or recent-activity feeds; for stable browse sets either shape works, but `Page` is the more honest contract once a list is large enough that any client might want to paginate it. Offset pagination is not used.
+
+### Rules
+
+- **`data` is always the root key for the items**, in both `List` and `Page`. Consumers always start with the same first level of JSON regardless of which shape they hit. There is no third shape.
+- **Suffix discipline.** A model name ending in `List` means unpaginated; ending in `Page` means cursor-paginated. The suffix is the contract; do not invent new ones.
+- **No `count`, no `total`, no `offset` in either envelope.** A `count` field that equals `len(data)` carries no information and pre-commits the field name to a meaning that conflicts with a future "total-matches-before-limit" value. If a caller genuinely needs the total count of matches, expose it as a separate endpoint or a dedicated `/count` sub-resource rather than smuggling it into the list response.
+- **JSON wire fields stay snake_case** in every language. Class and type names follow each language's native idiom; the wire shape does not.
+- **Class naming across languages.** Python (Pydantic models) and TypeScript use `ApiKeyList`, `KnowledgeUnitList`, etc., with camelCase initialisms — this keeps wire-facing types symmetric across the two languages. Go uses `APIKeyList`, `KnowledgeUnitList` with all-caps initialisms per standard Go convention. All three names serialize to and from the same JSON.
+
+### Today
+
+- `GET /api/v1/knowledge` returns `KnowledgeUnitList`.
+- `GET /api/v1/users/me/api-keys` returns `ApiKeyList`.
+
+No cursor-paginated endpoints exist yet; the first one to land will follow the `FooPage` shape above.

--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -378,12 +378,17 @@ func (c *Client) Query(ctx context.Context, params QueryParams) (QueryResult, er
 
 	normalised := params
 	normalised.Limit = limit
-	remoteResults := c.remote.query(ctx, normalised)
+	remoteResults, remoteErr := c.remote.query(ctx, normalised)
+
+	warnings := storeResult.Warnings
+	if remoteErr != nil {
+		warnings = append(warnings, remoteErr)
+	}
 
 	return QueryResult{
 		Units:    mergeResults(localResults, remoteResults, limit),
 		Source:   SourceRemote,
-		Warnings: storeResult.Warnings,
+		Warnings: warnings,
 	}, nil
 }
 

--- a/sdk/go/client_test.go
+++ b/sdk/go/client_test.go
@@ -432,7 +432,9 @@ func TestQueryMergesLocalAndRemote(t *testing.T) {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode([]map[string]any{testRemoteKUJSON("ku_00000000000000000000000000000003")})
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": []map[string]any{testRemoteKUJSON("ku_00000000000000000000000000000003")},
+		})
 	}))
 	ctx := context.Background()
 
@@ -470,7 +472,9 @@ func TestQuerySourceRemoteWhenOnlyRemoteReturnsResults(t *testing.T) {
 
 	c := newTestClientWithRemote(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode([]map[string]any{testRemoteKUJSON("ku_00000000000000000000000000000005")})
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": []map[string]any{testRemoteKUJSON("ku_00000000000000000000000000000005")},
+		})
 	}))
 
 	qr, err := c.Query(context.Background(), QueryParams{Domains: []string{"api"}})
@@ -489,6 +493,22 @@ func TestQuerySourceRemoteWhenRemoteFails(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, qr.Units)
 	require.Equal(t, SourceRemote, qr.Source)
+	require.NotEmpty(t, qr.Warnings, "remote failure should surface as a warning")
+}
+
+func TestQueryWarnsOnRemoteDecodeFailure(t *testing.T) {
+
+	c := newTestClientWithRemote(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Bare array; the SDK now expects the {data: [...]} envelope.
+		_, _ = w.Write([]byte(`[{"id":"ku_00000000000000000000000000000099"}]`))
+	}))
+
+	qr, err := c.Query(context.Background(), QueryParams{Domains: []string{"api"}})
+	require.NoError(t, err)
+	require.Empty(t, qr.Units)
+	require.NotEmpty(t, qr.Warnings)
+	require.Contains(t, qr.Warnings[0].Error(), "decoding")
 }
 
 func TestConfirmLocalUnit(t *testing.T) {

--- a/sdk/go/remote.go
+++ b/sdk/go/remote.go
@@ -239,14 +239,20 @@ func (r *remoteClient) query(ctx context.Context, params QueryParams) ([]Knowled
 		return nil, fmt.Errorf("%w: HTTP %d", errUnreachable, resp.StatusCode)
 	}
 
+	// Pointer field distinguishes an absent or null "data" key (env.Data == nil)
+	// from an empty array (env.Data != nil, *env.Data == []).
 	var env struct {
-		Data []KnowledgeUnit `json:"data"`
+		Data *[]KnowledgeUnit `json:"data"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
 		return nil, fmt.Errorf("decoding remote knowledge response: %w", err)
 	}
 
-	return env.Data, nil
+	if env.Data == nil {
+		return nil, fmt.Errorf("decoding remote knowledge response: missing or null data field")
+	}
+
+	return *env.Data, nil
 }
 
 // remoteStatsResponse holds the server's /api/v1/knowledge/stats response.

--- a/sdk/go/remote.go
+++ b/sdk/go/remote.go
@@ -200,9 +200,9 @@ func (r *remoteClient) propose(ctx context.Context, ku KnowledgeUnit) (Knowledge
 	return result, nil
 }
 
-// query fetches knowledge units from the remote API.
-// Returns nil on transport or HTTP errors for graceful degradation.
-func (r *remoteClient) query(ctx context.Context, params QueryParams) []KnowledgeUnit {
+// query fetches knowledge units from the remote API matching params.
+// Returns errUnreachable on transport/non-200 HTTP failure.
+func (r *remoteClient) query(ctx context.Context, params QueryParams) ([]KnowledgeUnit, error) {
 	qv := url.Values{}
 	for _, d := range params.Domains {
 		qv.Add("domains", d)
@@ -226,32 +226,33 @@ func (r *remoteClient) query(ctx context.Context, params QueryParams) []Knowledg
 
 	base, err := r.url("/api/v1/knowledge")
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("%w: %w", errUnreachable, err)
 	}
 
 	resp, err := r.do(ctx, http.MethodGet, base+"?"+qv.Encode(), nil)
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("%w: %w", errUnreachable, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil
+		return nil, fmt.Errorf("%w: HTTP %d", errUnreachable, resp.StatusCode)
 	}
 
-	var units []KnowledgeUnit
-	if err := json.NewDecoder(resp.Body).Decode(&units); err != nil {
-		// Query degrades gracefully; log-worthy but not a hard error.
-		return nil
+	var env struct {
+		Data []KnowledgeUnit `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		return nil, fmt.Errorf("decoding remote knowledge response: %w", err)
 	}
 
-	return units
+	return env.Data, nil
 }
 
 // remoteStatsResponse holds the server's /api/v1/knowledge/stats response.
 type remoteStatsResponse struct {
-	TotalUnits int          `json:"total_units"`
-	Tiers      map[Tier]int `json:"tiers"`
+	TotalUnits int            `json:"total_units"`
+	Tiers      map[Tier]int   `json:"tiers"`
 	Domains    map[string]int `json:"domains"`
 }
 

--- a/sdk/go/remote_test.go
+++ b/sdk/go/remote_test.go
@@ -77,6 +77,36 @@ func TestRemoteQueryRejectsBareArrayResponse(t *testing.T) {
 	require.Contains(t, err.Error(), "decoding")
 }
 
+func TestRemoteQueryRejectsMissingDataKey(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"results": []}`))
+	}))
+	defer srv.Close()
+
+	rc := newRemoteClient(srv.URL, "", 5*time.Second)
+	units, err := rc.query(context.Background(), QueryParams{Domains: []string{"api"}})
+	require.Nil(t, units)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "data")
+}
+
+func TestRemoteQueryRejectsNullDataField(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data": null}`))
+	}))
+	defer srv.Close()
+
+	rc := newRemoteClient(srv.URL, "", 5*time.Second)
+	units, err := rc.query(context.Background(), QueryParams{Domains: []string{"api"}})
+	require.Nil(t, units)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "data")
+}
+
 func TestRemoteQueryRejectsMalformedBody(t *testing.T) {
 	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/sdk/go/remote_test.go
+++ b/sdk/go/remote_test.go
@@ -20,12 +20,15 @@ func TestRemoteQuery(t *testing.T) {
 		require.Equal(t, []string{"api", "testing"}, r.URL.Query()["domains"])
 
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode([]map[string]any{testRemoteKUJSON("ku_00000000000000000000000000000002")})
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": []map[string]any{testRemoteKUJSON("ku_00000000000000000000000000000002")},
+		})
 	}))
 	defer srv.Close()
 
 	rc := newRemoteClient(srv.URL, "", 5*time.Second)
-	units := rc.query(context.Background(), QueryParams{Domains: []string{"api", "testing"}})
+	units, err := rc.query(context.Background(), QueryParams{Domains: []string{"api", "testing"}})
+	require.NoError(t, err)
 	require.Len(t, units, 1)
 	require.Equal(t, "ku_00000000000000000000000000000002", units[0].ID)
 	require.Equal(t, "S", units[0].Insight.Summary)
@@ -36,12 +39,13 @@ func TestRemoteQueryWithAuth(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode([]map[string]any{})
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": []map[string]any{}})
 	}))
 	defer srv.Close()
 
 	rc := newRemoteClient(srv.URL, "test-token", 5*time.Second)
-	units := rc.query(context.Background(), QueryParams{Domains: []string{"api"}})
+	units, err := rc.query(context.Background(), QueryParams{Domains: []string{"api"}})
+	require.NoError(t, err)
 	require.Empty(t, units)
 }
 
@@ -53,8 +57,46 @@ func TestRemoteQueryServerError(t *testing.T) {
 	defer srv.Close()
 
 	rc := newRemoteClient(srv.URL, "", 5*time.Second)
-	units := rc.query(context.Background(), QueryParams{Domains: []string{"api"}})
+	units, err := rc.query(context.Background(), QueryParams{Domains: []string{"api"}})
 	require.Nil(t, units)
+	require.ErrorIs(t, err, errUnreachable)
+}
+
+func TestRemoteQueryRejectsBareArrayResponse(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]map[string]any{testRemoteKUJSON("ku_00000000000000000000000000000002")})
+	}))
+	defer srv.Close()
+
+	rc := newRemoteClient(srv.URL, "", 5*time.Second)
+	units, err := rc.query(context.Background(), QueryParams{Domains: []string{"api"}})
+	require.Nil(t, units)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "decoding")
+}
+
+func TestRemoteQueryRejectsMalformedBody(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("not json"))
+	}))
+	defer srv.Close()
+
+	rc := newRemoteClient(srv.URL, "", 5*time.Second)
+	units, err := rc.query(context.Background(), QueryParams{Domains: []string{"api"}})
+	require.Nil(t, units)
+	require.Error(t, err)
+}
+
+func TestRemoteQueryTransportError(t *testing.T) {
+	t.Parallel()
+	rc := newRemoteClient("http://127.0.0.1:1", "", 1*time.Second)
+	units, err := rc.query(context.Background(), QueryParams{Domains: []string{"api"}})
+	require.Nil(t, units)
+	require.ErrorIs(t, err, errUnreachable)
 }
 
 func TestRemotePropose(t *testing.T) {
@@ -185,12 +227,12 @@ func TestRemoteQuerySendsPluralParamNames(t *testing.T) {
 			require.Equal(t, []string{"grpc"}, r.URL.Query()["frameworks"])
 
 			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode([]map[string]any{})
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": []map[string]any{}})
 		}))
 		defer srv.Close()
 
 		rc := newRemoteClient(srv.URL, "", 5*time.Second)
-		rc.query(context.Background(), QueryParams{
+		_, _ = rc.query(context.Background(), QueryParams{
 			Domains:    []string{"api"},
 			Languages:  []string{"go"},
 			Frameworks: []string{"grpc"},
@@ -205,12 +247,12 @@ func TestRemoteQuerySendsPluralParamNames(t *testing.T) {
 			require.Equal(t, []string{"grpc", "http"}, r.URL.Query()["frameworks"])
 
 			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode([]map[string]any{})
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": []map[string]any{}})
 		}))
 		defer srv.Close()
 
 		rc := newRemoteClient(srv.URL, "", 5*time.Second)
-		rc.query(context.Background(), QueryParams{
+		_, _ = rc.query(context.Background(), QueryParams{
 			Domains:    []string{"api", "testing"},
 			Languages:  []string{"python", "go"},
 			Frameworks: []string{"grpc", "http"},
@@ -271,12 +313,12 @@ func TestRemoteQueryAddsPatternToURL(t *testing.T) {
 		capturedURL = r.URL.String()
 		mu.Unlock()
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`[]`))
+		_, _ = w.Write([]byte(`{"data":[]}`))
 	}))
 	t.Cleanup(srv.Close)
 
 	rc := newRemoteClient(srv.URL, "test-key", 5*time.Second)
-	rc.query(context.Background(), QueryParams{
+	_, _ = rc.query(context.Background(), QueryParams{
 		Domains: []string{"api"},
 		Pattern: "api-client",
 	})
@@ -298,12 +340,12 @@ func TestRemoteQueryOmitsEmptyPattern(t *testing.T) {
 		capturedURL = r.URL.String()
 		mu.Unlock()
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`[]`))
+		_, _ = w.Write([]byte(`{"data":[]}`))
 	}))
 	t.Cleanup(srv.Close)
 
 	rc := newRemoteClient(srv.URL, "test-key", 5*time.Second)
-	rc.query(context.Background(), QueryParams{Domains: []string{"api"}})
+	_, _ = rc.query(context.Background(), QueryParams{Domains: []string{"api"}})
 
 	mu.Lock()
 	defer mu.Unlock()

--- a/sdk/python/src/cq/client.py
+++ b/sdk/python/src/cq/client.py
@@ -419,7 +419,10 @@ class Client:
             params["pattern"] = pattern
         resp = self._http.get("/api/v1/knowledge", params=params)
         resp.raise_for_status()
-        return [KnowledgeUnit.model_validate(item) for item in resp.json()]
+        body = resp.json()
+        if not isinstance(body, dict) or "data" not in body:
+            raise ValueError("expected {data: [...]} envelope from /api/v1/knowledge")
+        return [KnowledgeUnit.model_validate(item) for item in body["data"]]
 
     def _remote_propose(self, unit: KnowledgeUnit) -> KnowledgeUnit:
         """Push a unit to the remote API.

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -319,7 +319,7 @@ class TestRemoteIntegration:
         }
         httpx_mock.add_response(
             url=httpx.URL("http://test-remote/api/v1/knowledge", params={"domains": ["api"], "limit": "5"}),
-            json=[remote_unit],
+            json={"data": [remote_unit]},
         )
 
         # Insert a local unit directly (propose with remote skips local store).
@@ -357,7 +357,7 @@ class TestRemoteIntegration:
                 "http://test-remote/api/v1/knowledge",
                 params={"domains": ["api"], "limit": "5", "languages": ["python"], "frameworks": ["django"]},
             ),
-            json=[remote_unit],
+            json={"data": [remote_unit]},
         )
 
         c = Client(addr="http://test-remote", local_db_path=tmp_path / "test.db")
@@ -380,7 +380,7 @@ class TestRemoteIntegration:
                 "http://test-remote/api/v1/knowledge",
                 params={"domains": ["api"], "limit": "5", "pattern": "api-client"},
             ),
-            json=[remote_unit],
+            json={"data": [remote_unit]},
         )
 
         c = Client(addr="http://test-remote", local_db_path=tmp_path / "test.db")
@@ -400,13 +400,40 @@ class TestRemoteIntegration:
         }
         httpx_mock.add_response(
             url=httpx.URL("http://test-remote/api/v1/knowledge", params={"domains": ["api"], "limit": "5"}),
-            json=[remote_unit],
+            json={"data": [remote_unit]},
         )
 
         c = Client(addr="http://test-remote", local_db_path=tmp_path / "test.db")
         result = c.query(["api"])
         assert result.source == "remote"
         assert len(result.units) == 1
+        c.close()
+
+    def test_remote_query_warns_on_bare_array_response(self, tmp_path: Path, httpx_mock):
+        """A server returning a bare JSON array (pre-envelope shape) must surface as a warning,
+        not silently degrade to empty results."""
+        httpx_mock.add_response(
+            url=httpx.URL("http://test-remote/api/v1/knowledge", params={"domains": ["api"], "limit": "5"}),
+            json=[{"id": "ku_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa99"}],
+        )
+
+        c = Client(addr="http://test-remote", local_db_path=tmp_path / "test.db")
+        result = c.query(["api"])
+        assert result.units == []
+        assert any("envelope" in w or "data" in w for w in result.warnings)
+        c.close()
+
+    def test_remote_query_warns_on_missing_data_key(self, tmp_path: Path, httpx_mock):
+        """A server returning a JSON object without a ``data`` key must surface as a warning."""
+        httpx_mock.add_response(
+            url=httpx.URL("http://test-remote/api/v1/knowledge", params={"domains": ["api"], "limit": "5"}),
+            json={"results": []},
+        )
+
+        c = Client(addr="http://test-remote", local_db_path=tmp_path / "test.db")
+        result = c.query(["api"])
+        assert result.units == []
+        assert result.warnings, "missing data key should produce a warning"
         c.close()
 
     def test_propose_returns_server_response_when_remote_accepts(self, tmp_path: Path, httpx_mock):

--- a/server/backend/src/cq_server/api/routes/knowledge.py
+++ b/server/backend/src/cq_server/api/routes/knowledge.py
@@ -6,7 +6,7 @@ from cq.models import KnowledgeUnit
 from fastapi import APIRouter, Query, status
 
 from ...exceptions import InvalidDomainError, KnowledgeUnitNotFoundError, ServiceError
-from ...models.knowledge import FlagRequest, ProposeRequest, StatsResponse
+from ...models.knowledge import FlagRequest, KnowledgeUnitList, ProposeRequest, StatsResponse
 from ..deps import APIKeyAuthDep, KnowledgeServiceDep
 
 router = APIRouter(prefix="/knowledge", tags=["knowledge"])
@@ -20,7 +20,7 @@ def knowledge_exception_mappings() -> dict[type[ServiceError], int]:
     }
 
 
-@router.get("", response_model_exclude={"__all__": {"created_by"}})
+@router.get("", response_model_exclude={"data": {"__all__": {"created_by"}}})
 async def query_units(
     domains: Annotated[list[str], Query()],
     knowledge: KnowledgeServiceDep,
@@ -28,20 +28,21 @@ async def query_units(
     frameworks: Annotated[list[str] | None, Query()] = None,
     pattern: Annotated[str | None, Query()] = None,
     limit: Annotated[int, Query(gt=0)] = 5,
-) -> list[KnowledgeUnit]:
+) -> KnowledgeUnitList:
     """Search knowledge units by domain tags with relevance ranking.
 
     ``created_by`` is excluded from query responses to avoid leaking personal
     identifiers through the public read path until user-level attribution
     opt-in semantics are implemented.
     """
-    return await knowledge.query(
+    units = await knowledge.query(
         domains=domains,
         languages=languages,
         frameworks=frameworks,
         pattern=pattern or "",
         limit=limit,
     )
+    return KnowledgeUnitList(data=units)
 
 
 @router.post("", status_code=201)

--- a/server/backend/src/cq_server/api/routes/users.py
+++ b/server/backend/src/cq_server/api/routes/users.py
@@ -10,7 +10,7 @@ from ...exceptions import (
     UserNotFoundError,
 )
 from ...models.users import (
-    ApiKeysPublic,
+    ApiKeyList,
     CreateApiKeyRequest,
     CreateApiKeyResponse,
     MeResponse,
@@ -73,7 +73,7 @@ async def create_api_key_route(
 async def list_api_keys_route(
     username: CurrentUserDep,
     api_keys: APIKeyServiceDep,
-) -> ApiKeysPublic:
+) -> ApiKeyList:
     """Return the authenticated user's API keys. Never returns plaintext.
 
     Revoked keys are included with ``is_active: false`` so users can audit

--- a/server/backend/src/cq_server/models/knowledge.py
+++ b/server/backend/src/cq_server/models/knowledge.py
@@ -11,10 +11,10 @@ class FlagRequest(BaseModel):
 
 
 class KnowledgeUnitList(BaseModel):
-    """Collection envelope for knowledge unit listings.
+    """Unpaginated collection envelope for knowledge unit listings.
 
-    The envelope shape leaves room for pagination metadata (e.g. a
-    ``next_cursor`` field) without breaking existing clients.
+    NOTE: List is the unpaginated shape (``{data: [...]}``); cursor-paginated
+    endpoints use a separate ``Page`` model. See docs/architecture.md §6.
     """
 
     data: list[KnowledgeUnit]

--- a/server/backend/src/cq_server/models/knowledge.py
+++ b/server/backend/src/cq_server/models/knowledge.py
@@ -1,6 +1,6 @@
 """Pydantic schemas for /knowledge routes."""
 
-from cq.models import Context, FlagReason, Insight
+from cq.models import Context, FlagReason, Insight, KnowledgeUnit
 from pydantic import BaseModel, Field
 
 
@@ -8,6 +8,16 @@ class FlagRequest(BaseModel):
     """Request body for flagging a knowledge unit."""
 
     reason: FlagReason
+
+
+class KnowledgeUnitList(BaseModel):
+    """Collection envelope for knowledge unit listings.
+
+    The envelope shape leaves room for pagination metadata (e.g. a
+    ``next_cursor`` field) without breaking existing clients.
+    """
+
+    data: list[KnowledgeUnit]
 
 
 class ProposeRequest(BaseModel):

--- a/server/backend/src/cq_server/models/users.py
+++ b/server/backend/src/cq_server/models/users.py
@@ -19,8 +19,8 @@ class ApiKeyPublic(BaseModel):
     is_active: bool
 
 
-class ApiKeysPublic(BaseModel):
-    """Collection wrapper for API key listings.
+class ApiKeyList(BaseModel):
+    """Collection envelope for API key listings.
 
     The envelope shape leaves room for pagination metadata (e.g. a
     ``next_cursor`` field) without breaking existing clients.

--- a/server/backend/src/cq_server/models/users.py
+++ b/server/backend/src/cq_server/models/users.py
@@ -27,7 +27,6 @@ class ApiKeyList(BaseModel):
     """
 
     data: list[ApiKeyPublic]
-    count: int
 
 
 class CreateApiKeyRequest(BaseModel):

--- a/server/backend/src/cq_server/models/users.py
+++ b/server/backend/src/cq_server/models/users.py
@@ -20,10 +20,10 @@ class ApiKeyPublic(BaseModel):
 
 
 class ApiKeyList(BaseModel):
-    """Collection envelope for API key listings.
+    """Unpaginated collection envelope for API key listings.
 
-    The envelope shape leaves room for pagination metadata (e.g. a
-    ``next_cursor`` field) without breaking existing clients.
+    NOTE: List is the unpaginated shape (``{data: [...]}``); cursor-paginated
+    endpoints use a separate ``Page`` model. See docs/architecture.md §6.
     """
 
     data: list[ApiKeyPublic]

--- a/server/backend/src/cq_server/services/api_keys.py
+++ b/server/backend/src/cq_server/services/api_keys.py
@@ -19,8 +19,8 @@ from ..exceptions import (
     UserNotFoundError,
 )
 from ..models.users import (
+    ApiKeyList,
     ApiKeyPublic,
-    ApiKeysPublic,
     CreateApiKeyResponse,
     Message,
 )
@@ -106,11 +106,11 @@ class APIKeyService:
         public = _to_public(row)
         return CreateApiKeyResponse(**public.model_dump(), token=plaintext)
 
-    async def list_for_user(self, username: str) -> ApiKeysPublic:
+    async def list_for_user(self, username: str) -> ApiKeyList:
         """Return every API key owned by ``username`` (including revoked rows)."""
         user_id = await self._require_user_id(username)
         data = [_to_public(row) for row in await self._api_keys.list_for_user(user_id)]
-        return ApiKeysPublic(data=data, count=len(data))
+        return ApiKeyList(data=data, count=len(data))
 
     async def revoke(self, *, username: str, key_id: str) -> Message:
         """Revoke ``key_id`` if it belongs to ``username``. Idempotent.

--- a/server/backend/src/cq_server/services/api_keys.py
+++ b/server/backend/src/cq_server/services/api_keys.py
@@ -110,7 +110,7 @@ class APIKeyService:
         """Return every API key owned by ``username`` (including revoked rows)."""
         user_id = await self._require_user_id(username)
         data = [_to_public(row) for row in await self._api_keys.list_for_user(user_id)]
-        return ApiKeyList(data=data, count=len(data))
+        return ApiKeyList(data=data)
 
     async def revoke(self, *, username: str, key_id: str) -> Message:
         """Revoke ``key_id`` if it belongs to ``username``. Idempotent.

--- a/server/backend/tests/test_app.py
+++ b/server/backend/tests/test_app.py
@@ -137,7 +137,7 @@ class TestQuery:
         self._insert_unit(client, domains=["databases"])
         resp = client.get("/api/v1/knowledge", params={"domains": ["databases"]})
         assert resp.status_code == 200
-        results = resp.json()
+        results = resp.json()["data"]
         assert len(results) == 1
         assert results[0]["domains"] == ["databases"]
 
@@ -145,7 +145,15 @@ class TestQuery:
         self._insert_unit(client, domains=["databases"])
         resp = client.get("/api/v1/knowledge", params={"domains": ["networking"]})
         assert resp.status_code == 200
-        assert resp.json() == []
+        assert resp.json() == {"data": []}
+
+    def test_query_response_uses_envelope_shape(self, client: TestClient) -> None:
+        self._insert_unit(client, domains=["envelope-shape"])
+        resp = client.get("/api/v1/knowledge", params={"domains": ["envelope-shape"]})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert set(body.keys()) == {"data"}
+        assert isinstance(body["data"], list)
 
     def test_query_boosts_matching_language(self, client: TestClient) -> None:
         self._insert_unit(
@@ -160,7 +168,7 @@ class TestQuery:
         )
         resp = client.get("/api/v1/knowledge", params={"domains": ["web"], "languages": ["python"]})
         assert resp.status_code == 200
-        results = resp.json()
+        results = resp.json()["data"]
         assert len(results) == 2
         assert "python" in results[0]["context"]["languages"]
 
@@ -185,7 +193,7 @@ class TestQuery:
             params={"domains": ["web"], "languages": ["python", "go"]},
         )
         assert resp.status_code == 200
-        results = resp.json()
+        results = resp.json()["data"]
         assert len(results) == 3
         top_langs = {results[0]["context"]["languages"][0], results[1]["context"]["languages"][0]}
         assert top_langs == {"python", "go"}
@@ -195,7 +203,7 @@ class TestQuery:
             self._insert_unit(client, domains=["api"])
         resp = client.get("/api/v1/knowledge", params={"domains": ["api"], "limit": 2})
         assert resp.status_code == 200
-        assert len(resp.json()) == 2
+        assert len(resp.json()["data"]) == 2
 
     def test_query_rejects_zero_limit(self, client: TestClient) -> None:
         resp = client.get("/api/v1/knowledge", params={"domains": ["api"], "limit": 0})
@@ -214,7 +222,7 @@ class TestQuery:
         )
         resp = client.get("/api/v1/knowledge", params={"domains": ["api"], "pattern": "api-client"})
         assert resp.status_code == 200
-        results = resp.json()
+        results = resp.json()["data"]
         assert len(results) == 2
         assert results[0]["context"]["pattern"] == "api-client"
 
@@ -323,7 +331,7 @@ class TestReviewLifecycleEndToEnd:
 
         # KU is not queryable yet (pending).
         query_resp = client.get("/api/v1/knowledge", params={"domains": ["e2e-test"]})
-        assert len(query_resp.json()) == 0
+        assert len(query_resp.json()["data"]) == 0
 
         # KU appears in review queue.
         queue_resp = client.get("/api/v1/review/queue", headers=headers)
@@ -336,7 +344,7 @@ class TestReviewLifecycleEndToEnd:
 
         # KU is now queryable.
         query_resp = client.get("/api/v1/knowledge", params={"domains": ["e2e-test"]})
-        assert len(query_resp.json()) == 1
+        assert len(query_resp.json()["data"]) == 1
 
         # Queue is empty.
         queue_resp = client.get("/api/v1/review/queue", headers=headers)
@@ -374,22 +382,22 @@ class TestEndToEnd:
             "/api/v1/knowledge",
             params={"domains": ["api", "payments"], "languages": ["python"]},
         )
-        assert len(resp.json()) == 1
-        assert resp.json()[0]["evidence"]["confidence"] == 0.5
+        assert len(resp.json()["data"]) == 1
+        assert resp.json()["data"][0]["evidence"]["confidence"] == 0.5
 
         # Confirm boosts confidence.
         resp = client.post(f"/api/v1/knowledge/{unit_id}/confirmations")
         assert resp.status_code == 201
 
         resp = client.get("/api/v1/knowledge", params={"domains": ["api", "payments"]})
-        assert resp.json()[0]["evidence"]["confidence"] == pytest.approx(0.6)
+        assert resp.json()["data"][0]["evidence"]["confidence"] == pytest.approx(0.6)
 
         # Flag reduces confidence.
         resp = client.post(f"/api/v1/knowledge/{unit_id}/flags", json={"reason": "stale"})
         assert resp.status_code == 201
 
         resp = client.get("/api/v1/knowledge", params={"domains": ["api", "payments"]})
-        result = resp.json()[0]
+        result = resp.json()["data"][0]
         assert result["evidence"]["confidence"] == pytest.approx(0.45)
         assert len(result["flags"]) == 1
 
@@ -527,9 +535,9 @@ class TestApiKeyEnforcement:
 
         query = enforced_client.get("/api/v1/knowledge", params={"domains": ["privacy"]})
         assert query.status_code == 200
-        body = query.json()
-        assert len(body) == 1
-        assert "created_by" not in body[0]
+        results = query.json()["data"]
+        assert len(results) == 1
+        assert "created_by" not in results[0]
 
     def test_stats_stays_open_under_enforcement(self, enforced_client: TestClient) -> None:
         resp = enforced_client.get("/api/v1/knowledge/stats")

--- a/server/backend/tests/test_auth.py
+++ b/server/backend/tests/test_auth.py
@@ -217,10 +217,24 @@ class TestApiKeyList:
         resp = api_key_client.get("/api/v1/users/me/api-keys", headers={"Authorization": f"Bearer {token}"})
         assert resp.status_code == 200
         body = resp.json()
-        assert body["count"] == 1
         assert len(body["data"]) == 1
         assert "token" not in body["data"][0]
         assert body["data"][0]["name"] == "laptop"
+
+    def test_list_response_uses_envelope_shape(self, api_key_client: TestClient) -> None:
+        token = _login(api_key_client)
+        api_key_client.post(
+            "/api/v1/users/me/api-keys",
+            headers={"Authorization": f"Bearer {token}"},
+            json={"name": "shape", "ttl": "30d"},
+        )
+        resp = api_key_client.get(
+            "/api/v1/users/me/api-keys",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        body = resp.json()
+        assert set(body.keys()) == {"data"}
+        assert isinstance(body["data"], list)
 
     def test_list_requires_jwt(self, api_key_client: TestClient) -> None:
         resp = api_key_client.get("/api/v1/users/me/api-keys")
@@ -241,7 +255,6 @@ class TestApiKeyList:
         )
         resp = api_key_client.get("/api/v1/users/me/api-keys", headers={"Authorization": f"Bearer {token_a}"})
         body = resp.json()
-        assert body["count"] == 1
         assert [k["name"] for k in body["data"]] == ["alice-key"]
 
 

--- a/server/backend/tests/test_review.py
+++ b/server/backend/tests/test_review.py
@@ -104,7 +104,7 @@ class TestApprove:
         unit = _propose(client, domains=["searchable"])
         client.post(f"/api/v1/review/{unit['id']}/approve", headers=_auth_header(token))
         resp = client.get("/api/v1/knowledge", params={"domains": ["searchable"]})
-        assert len(resp.json()) == 1
+        assert len(resp.json()["data"]) == 1
 
 
 class TestReject:
@@ -121,7 +121,7 @@ class TestReject:
         unit = _propose(client, domains=["hidden"])
         client.post(f"/api/v1/review/{unit['id']}/reject", headers=_auth_header(token))
         resp = client.get("/api/v1/knowledge", params={"domains": ["hidden"]})
-        assert len(resp.json()) == 0
+        assert len(resp.json()["data"]) == 0
 
 
 class TestListUnits:

--- a/server/backend/tests/test_sqlite_store_e2e.py
+++ b/server/backend/tests/test_sqlite_store_e2e.py
@@ -42,7 +42,7 @@ def test_e2e_propose_via_store_query_via_api(tmp_path: Path, monkeypatch: pytest
 
         resp = client.get("/api/v1/knowledge", params={"domains": "smoke"})
         assert resp.status_code == 200
-        ids = [r["id"] for r in resp.json()]
+        ids = [r["id"] for r in resp.json()["data"]]
         assert unit.id in ids
 
     assert db.exists()

--- a/server/frontend/src/api.ts
+++ b/server/frontend/src/api.ts
@@ -1,5 +1,5 @@
 import type {
-  ApiKeysList,
+  ApiKeyList,
   CreatedApiKey,
   MessageResponse,
   ReviewDecisionResponse,
@@ -113,7 +113,7 @@ export const api = {
     return request<ReviewItem[]>(`/review/units${query ? `?${query}` : ""}`)
   },
 
-  listApiKeys: () => request<ApiKeysList>("/users/me/api-keys"),
+  listApiKeys: () => request<ApiKeyList>("/users/me/api-keys"),
 
   createApiKey: (name: string, ttl: string, labels: string[] = []) =>
     request<CreatedApiKey>("/users/me/api-keys", {

--- a/server/frontend/src/types.ts
+++ b/server/frontend/src/types.ts
@@ -101,7 +101,7 @@ export interface CreatedApiKey extends ApiKeyPublic {
   token: string
 }
 
-export interface ApiKeysList {
+export interface ApiKeyList {
   data: ApiKeyPublic[]
   count: number
 }

--- a/server/frontend/src/types.ts
+++ b/server/frontend/src/types.ts
@@ -103,7 +103,6 @@ export interface CreatedApiKey extends ApiKeyPublic {
 
 export interface ApiKeyList {
   data: ApiKeyPublic[]
-  count: number
 }
 
 export interface MessageResponse {


### PR DESCRIPTION
## Summary

- The cq CLI returned "No matching knowledge units found." against a server emitting the new `{data: [...]}` envelope, because both SDKs silently swallowed the JSON decode failure as graceful degradation. The same shape of bug also masked transport errors and non-200 statuses.
- Unifies the HTTP list response shape across the server, both SDKs, and the frontend. Two list endpoints (`GET /api/v1/knowledge`, `GET /api/v1/users/me/api-keys`) now share a single `FooList = {data: [...]}` envelope; the redundant `count` field is gone. The Go and Python SDKs decode the envelope and surface remote failures as `QueryResult.Warnings`; the CLI's `query` subcommand prints those warnings to stderr.
- Documents the wire-shape convention in `docs/architecture.md` (new section 6: HTTP API Conventions) so future list endpoints either pick `FooList` (unpaginated) or `FooPage` (cursor-paginated) without inventing a third shape.

## Commits

1. **`refactor(server): rename ApiKeysPublic to ApiKeyList`** — pure rename, no wire change. Frontend `ApiKeysList` renamed in lockstep.
2. **`refactor(server): switch list endpoints to {data} envelope, drop count`** — both `/api/v1/knowledge` and `/api/v1/users/me/api-keys` emit `{data}` only. Two new contract tests pin the shape so a stray `count` or other top-level field can't regress.
3. **`fix(sdk-go): decode {data} envelope and surface remote failures as warnings`** — silent `return nil` replaced with explicit error return; `Client.Query` appends remote errors to `QueryResult.Warnings`; CLI `query` command prints them to stderr; new `withFakeRemote(t, handler)` test helper in `cli/cmd/cmd_test.go` (drain_test.go's three inline equivalents migrate to it). `cli/go.mod` uncomments the local-SDK replace directive for the duration of the branch.
4. **`fix(sdk-python): decode {data} envelope from /api/v1/knowledge`** — explicit envelope-shape validation; warning text now names the actual problem instead of bubbling a Pydantic ValidationError up generically.
5. **`docs: add HTTP API Conventions section to architecture.md`** — `FooList` / `FooPage` convention, the `data` root-key rule, the "no count/total/offset" rule, snake_case wire fields, per-language class naming.

## Test plan

- [x] `make test` (full suite green at HEAD: 279 server backend + 335 Python SDK + Go SDK + CLI + 11 frontend tests, with `-race -count=20` stress run on the Go SDK).
- [x] `make lint` (all lint targets clean at HEAD).
- [x] New regression tests pin the original bug at three layers: server contract (`test_query_response_uses_envelope_shape`), Go SDK envelope decode (`TestRemoteQueryRejectsBareArrayResponse`), Python SDK envelope decode (`test_remote_query_warns_on_bare_array_response`), and CLI stderr surfacing (`TestQueryPrintsRemoteWarningsToStderr` asserts stderr contains both `"warning:"` and `"decoding"`).
- [ ] Manual smoke: against a server emitting the new envelope, `cq query --addr=... --domain=ci --api-key=...` returns the expected KUs (the case from the original bug report).

## Follow-ups (not in this PR)

- Align `/oauth/providers` to the `{data}` envelope upstream; the CLI's adapter at `cli/internal/auth/http_client.go` can then drop its bespoke `providers` field name.
- When the first cursor-paginated endpoint lands, both SDKs need a `FooPage` decoder. Today neither has one — by design, no abstraction ahead of need.
- Re-pin `cli/go.mod` to a published SDK version once the SDK release goes out (replace directive is uncommented in this PR for the local build).