### PR TITLE
feat(sdk-python): node discovery package + Client wiring

### DIFF
--- a/schema/python/Makefile
+++ b/schema/python/Makefile
@@ -7,6 +7,7 @@ SCHEMA_FILES := \
 	flag.json \
 	health.json \
 	knowledge_unit.json \
+	node_discovery.json \
 	propose.json \
 	query.json \
 	review.json \

--- a/sdk/python/src/cq/client.py
+++ b/sdk/python/src/cq/client.py
@@ -151,8 +151,10 @@ class Client:
             )
 
     def close(self) -> None:
-        """Close the local store and HTTP client."""
+        """Close the local store, the Resolver, and the HTTP client."""
         self._store.close()
+        if self._resolver is not None:
+            self._resolver.close()
         if self._http is not None:
             self._http.close()
 
@@ -411,11 +413,14 @@ class Client:
     def _api_base_url(self) -> str:
         """Return the resolved API base URL for the configured node.
 
+        Any trailing slash in the resolved value is stripped so each call
+        site can append a leading-slash resource path (e.g. `/knowledge`)
+        without producing `//` in the request URL.
         Memoization lives in the Resolver; this helper keeps each call site
         a single statement so request URLs read uniformly across `_remote_*`.
         """
         assert self._addr is not None and self._resolver is not None
-        return self._resolver.resolve(self._addr).api_base_url
+        return self._resolver.resolve(self._addr).api_base_url.rstrip("/")
 
     def _remote_stats(self) -> dict | None:
         """Fetch store statistics from the remote API.

--- a/sdk/python/src/cq/client.py
+++ b/sdk/python/src/cq/client.py
@@ -5,6 +5,7 @@ Handles remote mode (HTTP calls to a cq API) and local mode
 """
 
 import contextlib
+import logging
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -13,6 +14,7 @@ import httpx
 from pydantic import ValidationError
 
 from ._util import _as_list
+from .discovery import Resolver, default_cache_dir
 from .models import (
     Context,
     FlagReason,
@@ -25,6 +27,14 @@ from .scoring import apply_confirmation, apply_flag
 from .store import LocalStore, StoreStats
 
 _DEFAULT_TIMEOUT = 5.0
+
+# Attach a NullHandler to the package-level "cq" logger so the SDK is silent
+# unless the caller wires a handler.
+# This is load-bearing for MCP-over-stdio transports where any stray write to
+# stderr or stdout corrupts the JSONRPC stream.
+# The NullHandler is installed on the parent "cq" logger so it covers every
+# sub-logger in the SDK (cq.client, cq.discovery, cq.store, etc.).
+logging.getLogger("cq").addHandler(logging.NullHandler())
 
 
 @dataclass(frozen=True, slots=True)
@@ -98,6 +108,8 @@ class Client:
         addr: str | None = None,
         local_db_path: Path | None = None,
         timeout: float = _DEFAULT_TIMEOUT,
+        logger: logging.Logger | None = None,
+        _resolver: Resolver | None = None,
     ) -> None:
         """Initialize the client.
 
@@ -107,18 +119,35 @@ class Client:
             local_db_path: Local SQLite path. Reads from CQ_LOCAL_DB_PATH
                 env var if not provided. Defaults to $XDG_DATA_HOME/cq/local.db.
             timeout: HTTP request timeout in seconds. Defaults to 5.0.
+            logger: Logger for SDK diagnostics.
+                Defaults to ``logging.getLogger("cq.client")``.
+                The library installs a NullHandler on the parent ``cq`` logger at import time,
+                so the SDK is silent unless the caller wires a handler.
+            _resolver: Private test seam for injecting a pre-built Resolver.
+                Not part of the public API; the leading underscore signals that
+                callers outside the SDK's own tests should leave this unset.
         """
         self._addr = addr or os.environ.get("CQ_ADDR")
         db_path = local_db_path or _db_path_from_env()
         self._store = LocalStore(db_path=db_path)
+        self._logger = logger if logger is not None else logging.getLogger("cq.client")
         self._http: httpx.Client | None = None
+        self._resolver: Resolver | None = None
         if self._addr:
             api_key = os.environ.get("CQ_API_KEY", "")
             headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
             self._http = httpx.Client(
-                base_url=self._addr,
                 timeout=timeout,
                 headers=headers,
+            )
+            self._resolver = (
+                _resolver
+                if _resolver is not None
+                else Resolver(
+                    cache_dir=default_cache_dir(),
+                    http_client=self._http,
+                    logger=self._logger,
+                )
             )
 
     def close(self) -> None:
@@ -379,6 +408,15 @@ class Client:
 
     # -- Remote HTTP helpers (graceful degradation) --
 
+    def _api_base_url(self) -> str:
+        """Return the resolved API base URL for the configured node.
+
+        Memoization lives in the Resolver; this helper keeps each call site
+        a single statement so request URLs read uniformly across `_remote_*`.
+        """
+        assert self._addr is not None and self._resolver is not None
+        return self._resolver.resolve(self._addr).api_base_url
+
     def _remote_stats(self) -> dict | None:
         """Fetch store statistics from the remote API.
 
@@ -387,7 +425,7 @@ class Client:
         """
         assert self._http is not None
         try:
-            resp = self._http.get("/api/v1/knowledge/stats")
+            resp = self._http.get(f"{self._api_base_url()}/knowledge/stats")
             resp.raise_for_status()
             return resp.json()
         except httpx.HTTPError:
@@ -417,11 +455,11 @@ class Client:
             params["frameworks"] = frameworks
         if pattern:
             params["pattern"] = pattern
-        resp = self._http.get("/api/v1/knowledge", params=params)
+        resp = self._http.get(f"{self._api_base_url()}/knowledge", params=params)
         resp.raise_for_status()
         body = resp.json()
         if not isinstance(body, dict) or "data" not in body:
-            raise ValueError("expected {data: [...]} envelope from /api/v1/knowledge")
+            raise ValueError("expected {data: [...]} envelope from knowledge list endpoint")
         return [KnowledgeUnit.model_validate(item) for item in body["data"]]
 
     def _remote_propose(self, unit: KnowledgeUnit) -> KnowledgeUnit:
@@ -443,7 +481,7 @@ class Client:
             "created_by": unit.created_by,
         }
         try:
-            resp = self._http.post("/api/v1/knowledge", json=body)
+            resp = self._http.post(f"{self._api_base_url()}/knowledge", json=body)
             resp.raise_for_status()
         except httpx.HTTPStatusError as exc:
             raise RemoteError(
@@ -474,7 +512,7 @@ class Client:
         """
         assert self._http is not None
         try:
-            resp = self._http.post(f"/api/v1/knowledge/{unit_id}/confirmations")
+            resp = self._http.post(f"{self._api_base_url()}/knowledge/{unit_id}/confirmations")
             resp.raise_for_status()
         except httpx.HTTPStatusError as exc:
             raise RemoteError(
@@ -506,7 +544,7 @@ class Client:
         assert self._http is not None
         try:
             resp = self._http.post(
-                f"/api/v1/knowledge/{unit_id}/flags",
+                f"{self._api_base_url()}/knowledge/{unit_id}/flags",
                 json={"reason": reason.value},
             )
             resp.raise_for_status()

--- a/sdk/python/src/cq/discovery/__init__.py
+++ b/sdk/python/src/cq/discovery/__init__.py
@@ -1,0 +1,26 @@
+"""Node discovery for cq clients: resolve a node address into an API base URL and protocol version."""
+
+from ._paths import default_cache_dir
+from ._resolver import DiscoveryError, Resolver
+from ._types import (
+    DEFAULT_API_PATH,
+    DEFAULT_API_VERSION,
+    DEFAULT_CACHE_TTL_SECONDS,
+    SUPPORTED_API_VERSION,
+    SUPPORTED_DISCOVERY_VERSION,
+    WELL_KNOWN_PATH,
+    NodeInfo,
+)
+
+__all__ = [
+    "DEFAULT_API_PATH",
+    "DEFAULT_API_VERSION",
+    "DEFAULT_CACHE_TTL_SECONDS",
+    "DiscoveryError",
+    "NodeInfo",
+    "Resolver",
+    "SUPPORTED_API_VERSION",
+    "SUPPORTED_DISCOVERY_VERSION",
+    "WELL_KNOWN_PATH",
+    "default_cache_dir",
+]

--- a/sdk/python/src/cq/discovery/_cache.py
+++ b/sdk/python/src/cq/discovery/_cache.py
@@ -1,0 +1,129 @@
+"""On-disk cache of resolved node discovery results.
+
+Stores one JSON document per address, keyed by SHA-256 of the address
+so that arbitrary URL characters never appear on disk.
+Entries expire by file modification time plus a configured time-to-live (TTL).
+Writes are atomic via temp-file plus rename so a crashed process never
+leaves a half-written entry visible to the next invocation.
+
+NOTE: instances are not safe for concurrent use across processes;
+concurrent writers to the same address race on the final rename and
+the last writer wins.
+NOTE: constructing a Cache with `cache_dir=None` disables every cache operation
+(get returns a miss, put and invalidate are no-ops) so callers can wire
+a cache unconditionally and let configuration decide whether on-disk
+persistence is active.
+"""
+
+import hashlib
+import os
+import tempfile
+import time
+from pathlib import Path
+
+from pydantic import ValidationError
+
+from ._types import NodeInfo
+from ._validate import validate as _validate
+
+
+class Cache:
+    """Disk-backed cache mapping a node address to its resolved NodeInfo.
+
+    Entries live as one JSON file per address under the configured directory.
+    Freshness is determined by the file's modification time;
+    entries older than the configured TTL are treated as misses.
+    Schema-invalid or unreadable entries are also treated as misses and
+    removed so the next read starts clean.
+    """
+
+    def __init__(self, cache_dir: Path | None, ttl_seconds: int) -> None:
+        """Build a cache rooted at cache_dir with the given freshness time-to-live (TTL).
+
+        A cache_dir of None disables the cache entirely;
+        every cache operation becomes a no-op.
+        The directory itself is created lazily on the first successful put
+        so constructing a cache for a never-used address is free.
+        """
+        self._dir: Path | None = cache_dir
+        self._ttl_seconds = ttl_seconds
+
+    def get(self, addr: str) -> NodeInfo | None:
+        """Return the cached NodeInfo for addr when a fresh, valid entry exists, otherwise None.
+
+        An entry is fresh when its file modification time is within the configured TTL.
+        Unreadable, expired, or schema-invalid entries are reported as a miss;
+        invalid entries are also removed from disk so the next read is a
+        clean miss rather than a repeated rejection.
+        """
+        if self._dir is None:
+            return None
+        path = self._dir / self._filename(addr)
+        try:
+            mtime = path.stat().st_mtime
+        except OSError:
+            return None
+        if (time.time() - mtime) > self._ttl_seconds:
+            return None
+        try:
+            raw = path.read_bytes()
+        except OSError:
+            return None
+        try:
+            info = NodeInfo.model_validate_json(raw)
+        except ValidationError:
+            _remove_quiet(path)
+            return None
+        try:
+            _validate(info)
+        except ValueError:
+            _remove_quiet(path)
+            return None
+        return info
+
+    def invalidate(self, addr: str) -> None:
+        """Remove the cache entry for addr if one exists.
+
+        A missing entry is not an error.
+        """
+        if self._dir is None:
+            return
+        _remove_quiet(self._dir / self._filename(addr))
+
+    def put(self, addr: str, info: NodeInfo) -> None:
+        """Write info to disk as the cache entry for addr.
+
+        The write is atomic:
+        data is first written to a temp file in the cache directory and then
+        renamed into place, so a partial write from a crashed process is never
+        observable on the next read.
+        NOTE: the temp file is created inside `cache_dir`, not the OS temp directory,
+        so the write succeeds wherever the final write does (Windows, macOS, Linux)
+        with no additional permission requirements.
+        The cache directory is created if it does not already exist.
+        """
+        if self._dir is None:
+            return
+        self._dir.mkdir(parents=True, exist_ok=True)
+        final_path = self._dir / self._filename(addr)
+        # Open a temp file in the same directory so the rename stays on one filesystem.
+        fd, tmp_name = tempfile.mkstemp(prefix="tmp-", suffix=".json", dir=self._dir)
+        tmp_path = Path(tmp_name)
+        try:
+            with os.fdopen(fd, "wb") as f:
+                f.write(info.model_dump_json().encode("utf-8"))
+            tmp_path.replace(final_path)
+        finally:
+            _remove_quiet(tmp_path)
+
+    def _filename(self, addr: str) -> str:
+        """Return the on-disk filename for addr: lowercase SHA-256 hex plus .json."""
+        return hashlib.sha256(addr.encode()).hexdigest() + ".json"
+
+
+def _remove_quiet(path: Path) -> None:
+    """Delete path if present; suppress FileNotFoundError so callers can treat removal as best-effort."""
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        return

--- a/sdk/python/src/cq/discovery/_paths.py
+++ b/sdk/python/src/cq/discovery/_paths.py
@@ -1,0 +1,43 @@
+"""XDG-compliant cache directory resolution for the node discovery cache.
+
+Computes the default on-disk location where resolved discovery documents are stored,
+honoring the XDG Base Directory Specification so users can redirect the cache via XDG_CACHE_HOME.
+"""
+
+import logging
+import os
+from pathlib import Path
+
+_LOGGER = logging.getLogger("cq.discovery")
+
+
+def default_cache_dir() -> Path | None:
+    """Return the XDG-compliant cq discovery cache directory, or None when no location is resolvable.
+
+    Honors XDG_CACHE_HOME when set, falling back to ~/.cache/cq/discovery otherwise.
+    Returns None when neither XDG_CACHE_HOME nor HOME is set;
+    callers should treat None as "disable on-disk cache, use in-memory only."
+
+    A misconfigured XDG_CACHE_HOME (set but not an absolute path) is logged at warning level
+    on the `cq.discovery` logger and reported as None so the disable signal is uniform.
+
+    NOTE: matches the Go SDK's XDG validation (whitespace trim plus absolute-path requirement);
+    diverges only in surfacing the misconfiguration via a warning log instead of a returned error,
+    so callers wire one consistent disable signal.
+    """
+    xdg = os.environ.get("XDG_CACHE_HOME")
+    if xdg is not None:
+        trimmed = xdg.strip()
+        if trimmed:
+            candidate = Path(trimmed)
+            if not candidate.is_absolute():
+                _LOGGER.warning(
+                    "discovery: XDG_CACHE_HOME must be an absolute path, got %r; disabling on-disk cache",
+                    trimmed,
+                )
+                return None
+            return candidate / "cq" / "discovery"
+    home = os.environ.get("HOME")
+    if not home:
+        return None
+    return Path(home) / ".cache" / "cq" / "discovery"

--- a/sdk/python/src/cq/discovery/_resolver.py
+++ b/sdk/python/src/cq/discovery/_resolver.py
@@ -1,0 +1,278 @@
+"""Resolver: turn a cq node address into a NodeInfo.
+
+The resolver probes the node's discovery document at WELL_KNOWN_PATH,
+falls back to documented defaults when the node does not publish a discovery document,
+memoizes successful results in process,
+and persists them through a Cache so short-lived processes share state across invocations.
+
+NOTE: Resolver is safe for concurrent use; the in-process memo is guarded
+by a threading.Lock and the on-disk cache is fronted by atomic temp-file
+plus rename.
+
+NOTE: callers must treat DiscoveryError as the resolver's single failure
+channel.
+Transport exhaustion, malformed bodies, schema mismatches, and unexpected
+status codes all surface as DiscoveryError so the Client's FallbackError
+logic can distinguish operator/client misconfiguration from connectivity
+failures uniformly.
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import logging
+import threading
+import time
+from pathlib import Path
+from urllib.parse import urlparse, urlunparse
+
+import httpx
+from pydantic import ValidationError
+
+from ._cache import Cache
+from ._types import (
+    DEFAULT_API_PATH,
+    DEFAULT_API_VERSION,
+    DEFAULT_CACHE_TTL_SECONDS,
+    SUPPORTED_DISCOVERY_VERSION,
+    WELL_KNOWN_PATH,
+    NodeInfo,
+)
+from ._validate import validate as _validate_info
+
+_DEFAULT_LOGGER = logging.getLogger("cq.discovery")
+_DEFAULT_TIMEOUT = 5.0
+_RETRY_ATTEMPTS = 2
+_RETRY_BACKOFF_SECONDS = 0.2
+_MAX_BODY_BYTES = 64 * 1024
+
+
+class DiscoveryError(Exception):
+    """Raised when the discovery probe fails for any non-recoverable reason.
+
+    Misconfigured responses (HTML pages, malformed JSON, unknown fields,
+    schema/api version mismatches, hostless or non-http api_base_urls) and
+    transport failures that survive the retry budget all surface as
+    DiscoveryError so a single exception type covers resolver-layer
+    failure.
+
+    NOTE: distinct from httpx.HTTPError so the Client's FallbackError
+    logic can treat resolver failures separately from per-call HTTP
+    failures.
+    """
+
+
+class Resolver:
+    """Map a cq node address to a NodeInfo by probing the node's discovery document at WELL_KNOWN_PATH.
+
+    When the node does not publish a discovery document, the documented
+    defaults (`addr + DEFAULT_API_PATH`, `DEFAULT_API_VERSION`) are
+    returned.
+    A valid discovery response yields a parsed NodeInfo whose
+    `api_base_url` is taken verbatim from the document.
+    Every other shape (text/html, malformed JSON, schema or api version
+    mismatch, hostless or non-http api_base_url, retry-exhausted transport
+    failure) raises DiscoveryError.
+
+    Successful resolutions are memoized in-process for the lifetime of
+    the Resolver and, when a cache_dir is configured, persisted to disk
+    so short-lived processes share results across invocations.
+
+    NOTE: instances are safe for concurrent use;
+    concurrent resolve() calls for the same address are coalesced into a single probe (single-flight).
+    """
+
+    def __init__(
+        self,
+        cache_dir: Path | None,
+        http_client: httpx.Client | None = None,
+        logger: logging.Logger | None = None,
+    ) -> None:
+        """Build a Resolver with the given on-disk cache location and HTTP transport.
+
+        `cache_dir=None` disables on-disk caching;
+        the in-process memo still applies.
+        `http_client` defaults to a fresh `httpx.Client` so callers do not
+        need to wire one for the default code path.
+        `logger` defaults to `logging.getLogger("cq.discovery")`.
+        NOTE: this module does not install a NullHandler;
+        the Client layer is responsible for taming the cq logger tree.
+        """
+        self._cache = Cache(cache_dir=cache_dir, ttl_seconds=DEFAULT_CACHE_TTL_SECONDS)
+        self._http: httpx.Client = http_client if http_client is not None else httpx.Client(timeout=_DEFAULT_TIMEOUT)
+        self._owns_http: bool = http_client is None
+        self._logger = logger if logger is not None else _DEFAULT_LOGGER
+        self._lock = threading.Lock()
+        self._mem: dict[str, NodeInfo] = {}
+        self._inflight: dict[str, concurrent.futures.Future[NodeInfo]] = {}
+
+    def close(self) -> None:
+        """Release resources owned by this Resolver.
+
+        Closes the underlying httpx.Client only when this Resolver created it.
+        A client passed in by the caller is the caller's to close.
+        """
+        if self._owns_http:
+            self._http.close()
+
+    def __enter__(self) -> Resolver:
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        self.close()
+
+    def resolve(self, addr: str) -> NodeInfo:
+        """Return the NodeInfo for addr, probing the network only when no cached entry is available.
+
+        Trailing slashes in addr are normalized away before lookup so
+        `https://node.example.com` and `https://node.example.com/` share
+        a cache entry.
+        Concurrent callers for the same address are coalesced (single-flight):
+        the first caller probes, every other caller waits for that probe's result
+        and sees the same NodeInfo (or the same DiscoveryError).
+        Disk-cache write failures are logged at warning level and
+        otherwise swallowed:
+        the resolution itself remains valid for the lifetime of this
+        process.
+        """
+        addr = addr.rstrip("/")
+
+        with self._lock:
+            cached = self._mem.get(addr)
+            if cached is not None:
+                return cached
+            future = self._inflight.get(addr)
+            if future is not None:
+                elected = False
+            else:
+                future = concurrent.futures.Future()
+                self._inflight[addr] = future
+                elected = True
+
+        if not elected:
+            # Waiters block outside the lock so the elected prober can make progress.
+            return future.result()
+
+        try:
+            result = self._resolve_uncached(addr)
+        except BaseException as exc:
+            with self._lock:
+                self._inflight.pop(addr, None)
+            future.set_exception(exc)
+            raise
+        else:
+            with self._lock:
+                self._mem[addr] = result
+                self._inflight.pop(addr, None)
+            future.set_result(result)
+            return result
+
+    def _resolve_uncached(self, addr: str) -> NodeInfo:
+        """Run the disk-cache check and network probe for addr.
+
+        NOTE: callers must own the single-flight election;
+        this helper does no in-process memoization and is not safe to call directly
+        outside the resolve() flow.
+        """
+        from_disk = self._cache.get(addr)
+        if from_disk is not None:
+            return from_disk
+
+        info = self._probe(addr)
+        try:
+            self._cache.put(addr, info)
+        except OSError as err:
+            self._logger.warning("discovery: cache write failed for %s: %s", addr, err)
+        return info
+
+    def _probe(self, addr: str) -> NodeInfo:
+        """Fetch the discovery document for addr and turn it into a NodeInfo.
+
+        When the node does not publish a discovery document, the documented defaults are returned
+        so an unconfigured node remains reachable.
+        Any unexpected response, an HTML body, malformed JSON, an unknown field,
+        or a schema/api version mismatch becomes a DiscoveryError rather than a silent fallback.
+        """
+        url = _join_well_known(addr)
+        try:
+            response = self._fetch_with_retry(url)
+        except httpx.HTTPError as err:
+            raise DiscoveryError(f"discovery: probe failed after {_RETRY_ATTEMPTS} attempts: {err}") from err
+
+        if response.status_code == 404:
+            return _defaults_for(addr)
+        if response.status_code != 200:
+            raise DiscoveryError(f"discovery: unexpected status {response.status_code} from {url}")
+
+        content_type = response.headers.get("Content-Type", "")
+        if content_type.lower().startswith("text/html"):
+            raise DiscoveryError(
+                f"discovery: {addr} returned text/html — the address likely points at a SPA, not a cq node API"
+            )
+
+        body = response.content[:_MAX_BODY_BYTES]
+        try:
+            info = NodeInfo.model_validate_json(body)
+        except ValidationError as err:
+            details = "; ".join(f"{'.'.join(str(p) for p in e['loc'])}: {e['msg']}" for e in err.errors())
+            raise DiscoveryError(f"discovery: parse body: {details}") from err
+
+        try:
+            _validate_info(info)
+        except ValueError as err:
+            raise DiscoveryError(f"discovery: {err}") from err
+        return info
+
+    def _fetch_with_retry(self, url: str) -> httpx.Response:
+        """Issue a GET to url, retrying transport errors and server-side failures up to the configured attempt budget.
+
+        Client-side responses are returned without retry so a node that does not publish a discovery document
+        remains observable in one attempt.
+        The backoff is linear and short:
+        attempt `i` (1-indexed) sleeps `i * _RETRY_BACKOFF_SECONDS`
+        before issuing the request.
+        """
+        last_error: Exception | None = None
+        for attempt in range(_RETRY_ATTEMPTS):
+            if attempt > 0:
+                time.sleep(attempt * _RETRY_BACKOFF_SECONDS)
+            try:
+                response = self._http.get(url, headers={"Accept": "application/json"})
+            except httpx.HTTPError as err:
+                last_error = err
+                continue
+            if response.status_code >= 500:
+                last_error = httpx.HTTPStatusError(
+                    f"status {response.status_code}", request=response.request, response=response
+                )
+                continue
+            return response
+        if last_error is None:
+            raise RuntimeError("retry budget exhausted without recording a failure")
+        raise last_error
+
+
+def _defaults_for(addr: str) -> NodeInfo:
+    """Return the NodeInfo applied when a node does not publish a discovery document.
+
+    The api_base_url is `addr + DEFAULT_API_PATH`, the api_version is
+    `DEFAULT_API_VERSION`, and the document schema version is
+    `SUPPORTED_DISCOVERY_VERSION`.
+    """
+    return NodeInfo(
+        version=SUPPORTED_DISCOVERY_VERSION,
+        api_base_url=addr + DEFAULT_API_PATH,
+        api_version=DEFAULT_API_VERSION,
+    )
+
+
+def _join_well_known(addr: str) -> str:
+    """Append WELL_KNOWN_PATH to addr's existing path rather than replacing it.
+
+    Addresses like `https://node.example.com/cq` keep their `/cq` prefix
+    so the probe lands at `/cq/.well-known/cq-node`.
+    """
+    parsed = urlparse(addr)
+    base_path = parsed.path.rstrip("/")
+    new_path = base_path + WELL_KNOWN_PATH
+    return urlunparse(parsed._replace(path=new_path))

--- a/sdk/python/src/cq/discovery/_resolver.py
+++ b/sdk/python/src/cq/discovery/_resolver.py
@@ -270,7 +270,7 @@ def _join_well_known(addr: str) -> str:
     """Append WELL_KNOWN_PATH to addr's existing path rather than replacing it.
 
     Addresses like `https://node.example.com/cq` keep their `/cq` prefix
-    so the probe lands at `/cq/.well-known/cq-node`.
+    so the probe lands at `/cq/.well-known/cq-node.json`.
     """
     parsed = urlparse(addr)
     base_path = parsed.path.rstrip("/")

--- a/sdk/python/src/cq/discovery/_types.py
+++ b/sdk/python/src/cq/discovery/_types.py
@@ -1,0 +1,50 @@
+"""Type definitions and protocol constants for node discovery.
+
+Holds the wire-level invariants shared across the discovery package:
+the well-known document location, the schema and protocol versions this client understands,
+the defaults applied when a node publishes no document, and the resolved view returned to callers.
+"""
+
+from typing import Final
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# API base path applied when a node does not publish a discovery document.
+# Appended to the user-supplied address to form the effective API base URL.
+DEFAULT_API_PATH: Final[str] = "/api/v1"
+
+# Protocol version assumed when a node does not publish a discovery document.
+DEFAULT_API_VERSION: Final[str] = "v1"
+
+# URL path at which a node publishes its discovery document, relative to the user-supplied address.
+WELL_KNOWN_PATH: Final[str] = "/.well-known/cq-node.json"
+
+# Protocol version this client speaks.
+# A node advertising any other version is rejected with a clear error.
+SUPPORTED_API_VERSION: Final[str] = "v1"
+
+# Discovery-document schema version this client understands.
+# A document declaring any other value is rejected with a clear error
+# so a future incompatible schema cannot be silently parsed with this client's assumptions.
+SUPPORTED_DISCOVERY_VERSION: Final[int] = 1
+
+# How long, in seconds, a successful discovery result is considered fresh on disk before re-probing.
+DEFAULT_CACHE_TTL_SECONDS: Final[int] = 24 * 60 * 60
+
+
+class NodeInfo(BaseModel):
+    """Resolved view of a cq node after running discovery.
+
+    Every field is populated either from the node's discovery document or from protocol defaults,
+    so callers never see an empty api_base_url or api_version on a successful resolve.
+
+    NOTE: callers should treat api_base_url as the complete URL to append resource paths to;
+    there is no implicit version prefix to add on top.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    version: int = Field(description="Discovery-document schema version.")
+    api_base_url: str = Field(description="Complete URL the client uses verbatim. No implicit version prefix.")
+    api_version: str = Field(description="Protocol version the node speaks.")
+    node_name: str | None = Field(default=None, description="Optional human-readable display name.")

--- a/sdk/python/src/cq/discovery/_validate.py
+++ b/sdk/python/src/cq/discovery/_validate.py
@@ -32,6 +32,12 @@ def validate(info: NodeInfo) -> None:
         raise ValueError(f"api_base_url {info.api_base_url!r} must use http or https scheme")
     if not parsed.hostname:
         raise ValueError(f"api_base_url {info.api_base_url!r} is missing a host")
+    try:
+        # Accessing .port forces validation of the port segment; urlparse itself is lenient
+        # and would accept a non-numeric value that later fails inside the HTTP client.
+        _ = parsed.port
+    except ValueError as err:
+        raise ValueError(f"api_base_url {info.api_base_url!r} has an invalid port") from err
     if not info.api_version:
         raise ValueError("api_version is required")
     if info.api_version != SUPPORTED_API_VERSION:

--- a/sdk/python/src/cq/discovery/_validate.py
+++ b/sdk/python/src/cq/discovery/_validate.py
@@ -1,0 +1,41 @@
+"""Protocol-compatibility checks for a parsed discovery document.
+
+Both the on-disk cache and the live resolver apply the same rules so a
+stale or malformed entry on disk is rejected exactly like a malformed
+fresh response.
+Keeping the check in one module pins that equivalence.
+"""
+
+from urllib.parse import urlparse
+
+from ._types import SUPPORTED_API_VERSION, SUPPORTED_DISCOVERY_VERSION, NodeInfo
+
+
+def validate(info: NodeInfo) -> None:
+    """Reject a NodeInfo that does not describe a node this client can speak to.
+
+    Mismatches are raised in domain terms so users see actionable messages
+    rather than raw comparison failures.
+    The rules:
+    a supported schema version, a non-empty http(s) api_base_url with a host,
+    and a supported api_version.
+    """
+    if info.version != SUPPORTED_DISCOVERY_VERSION:
+        raise ValueError(
+            f"discovery document declares version {info.version} "
+            f"but this client supports {SUPPORTED_DISCOVERY_VERSION} — upgrade the client"
+        )
+    if not info.api_base_url:
+        raise ValueError("api_base_url is required")
+    parsed = urlparse(info.api_base_url)
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError(f"api_base_url {info.api_base_url!r} must use http or https scheme")
+    if not parsed.hostname:
+        raise ValueError(f"api_base_url {info.api_base_url!r} is missing a host")
+    if not info.api_version:
+        raise ValueError("api_version is required")
+    if info.api_version != SUPPORTED_API_VERSION:
+        raise ValueError(
+            f"node speaks api_version {info.api_version!r} "
+            f"but this client supports {SUPPORTED_API_VERSION!r} — upgrade the client"
+        )

--- a/sdk/python/tests/conftest.py
+++ b/sdk/python/tests/conftest.py
@@ -2,10 +2,35 @@
 
 import pytest
 
+from cq.discovery import SUPPORTED_DISCOVERY_VERSION, NodeInfo
+
 
 @pytest.fixture(autouse=True)
-def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Clear CQ environment variables so tests are isolated from the host."""
+def _isolate_env(monkeypatch: pytest.MonkeyPatch, tmp_path_factory: pytest.TempPathFactory) -> None:
+    """Clear cq env vars and redirect the discovery cache so tests are isolated from the host."""
     monkeypatch.delenv("CQ_ADDR", raising=False)
     monkeypatch.delenv("CQ_API_KEY", raising=False)
     monkeypatch.delenv("CQ_LOCAL_DB_PATH", raising=False)
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path_factory.mktemp("xdg_cache")))
+
+
+class StaticResolver:
+    """Test double that returns a default-shaped NodeInfo without HTTP or disk I/O.
+
+    Synthesizes ``api_base_url = addr.rstrip("/") + "/api/v1"`` so test
+    assertions written against the default discovery fallback continue
+    to hold even when the Client is wired through a resolver.
+    """
+
+    def resolve(self, addr: str) -> NodeInfo:
+        return NodeInfo(
+            version=SUPPORTED_DISCOVERY_VERSION,
+            api_base_url=addr.rstrip("/") + "/api/v1",
+            api_version="v1",
+        )
+
+
+@pytest.fixture()
+def static_resolver() -> StaticResolver:
+    """Resolver test-double returning the default-shaped NodeInfo for every addr."""
+    return StaticResolver()

--- a/sdk/python/tests/conftest.py
+++ b/sdk/python/tests/conftest.py
@@ -29,6 +29,9 @@ class StaticResolver:
             api_version="v1",
         )
 
+    def close(self) -> None:
+        """No-op; the test double owns no resources."""
+
 
 @pytest.fixture()
 def static_resolver() -> StaticResolver:

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -1,5 +1,6 @@
 """Tests for Client."""
 
+import logging
 from collections.abc import Iterator
 from pathlib import Path
 from unittest.mock import patch
@@ -16,6 +17,27 @@ def client(tmp_path: Path) -> Iterator[Client]:
     c = Client(local_db_path=tmp_path / "test.db")
     yield c
     c.close()
+
+
+class TestClientLogger:
+    def test_silent_by_default(self, tmp_path: Path, caplog: pytest.LogCaptureFixture):
+        with caplog.at_level(logging.DEBUG):
+            c = Client(local_db_path=tmp_path / "test.db")
+            c.close()
+        assert caplog.records == []
+        cq_logger = logging.getLogger("cq")
+        assert any(isinstance(h, logging.NullHandler) for h in cq_logger.handlers)
+
+    def test_accepts_caller_supplied_logger(self, tmp_path: Path):
+        supplied = logging.getLogger("test.cq.caller")
+        c = Client(local_db_path=tmp_path / "test.db", logger=supplied)
+        assert c._logger is supplied
+        c.close()
+
+    def test_default_logger_is_cq_client(self, tmp_path: Path):
+        c = Client(local_db_path=tmp_path / "test.db")
+        assert c._logger.name == "cq.client"
+        c.close()
 
 
 class TestLocalOnlyMode:
@@ -769,6 +791,262 @@ class TestRemoteIntegration:
         c.close()
 
 
+class TestClientApiBaseUrl:
+    def test_remote_calls_use_resolved_api_base_url(self, tmp_path: Path):
+        """`_remote_*` calls should be routed through the Resolver's api_base_url, not addr + /api/v1."""
+        from cq.discovery import SUPPORTED_DISCOVERY_VERSION, NodeInfo
+
+        class _StaticResolver:
+            def resolve(self, addr: str) -> NodeInfo:
+                return NodeInfo(
+                    version=SUPPORTED_DISCOVERY_VERSION,
+                    api_base_url="https://api.example.com/v2",
+                    api_version="v1",
+                )
+
+        captured: list[httpx.URL] = []
+
+        def capturing_send(self, request, **kwargs):
+            captured.append(request.url)
+            return httpx.Response(
+                status_code=200,
+                json={"total_units": 0, "tiers": {}, "domains": {}},
+                request=request,
+            )
+
+        with patch.object(httpx.Client, "send", capturing_send):
+            c = Client(
+                addr="https://node.example.com",
+                local_db_path=tmp_path / "test.db",
+                _resolver=_StaticResolver(),  # type: ignore[arg-type]
+            )
+            c.status()
+            c.close()
+
+        assert len(captured) == 1
+        assert str(captured[0]) == "https://api.example.com/v2/knowledge/stats"
+
+
+class TestClientDiscoveryErrorPropagation:
+    """DiscoveryError from the Resolver surfaces terminally to the caller.
+
+    The Client's fallback paths catch httpx.HTTPError and RemoteError (for
+    transport and server-side faults), but DiscoveryError signals operator
+    or client misconfiguration that local-storage fallback cannot repair.
+    These tests pin that contract for every public method that touches the
+    remote.
+    """
+
+    class _RaisingResolver:
+        def resolve(self, addr: str):
+            from cq.discovery import DiscoveryError
+
+            raise DiscoveryError("test discovery failure")
+
+    def test_query_propagates_discovery_error(self, tmp_path: Path):
+        from cq.discovery import DiscoveryError
+
+        c = Client(
+            addr="https://node.example.com",
+            local_db_path=tmp_path / "test.db",
+            _resolver=self._RaisingResolver(),  # type: ignore[arg-type]
+        )
+        with pytest.raises(DiscoveryError):
+            c.query(["python"])
+        c.close()
+
+    def test_propose_propagates_discovery_error(self, tmp_path: Path):
+        from cq.discovery import DiscoveryError
+
+        c = Client(
+            addr="https://node.example.com",
+            local_db_path=tmp_path / "test.db",
+            _resolver=self._RaisingResolver(),  # type: ignore[arg-type]
+        )
+        with pytest.raises(DiscoveryError):
+            c.propose(
+                summary="Use connection pooling",
+                detail="Connections are expensive.",
+                action="Pool them.",
+                domains=["python"],
+            )
+        c.close()
+
+    def test_confirm_propagates_discovery_error(self, tmp_path: Path):
+        from cq.discovery import DiscoveryError
+
+        c = Client(
+            addr="https://node.example.com",
+            local_db_path=tmp_path / "test.db",
+            _resolver=self._RaisingResolver(),  # type: ignore[arg-type]
+        )
+        with pytest.raises(DiscoveryError):
+            c.confirm("nonexistent-id", tier=Tier.PRIVATE)
+        c.close()
+
+    def test_flag_propagates_discovery_error(self, tmp_path: Path):
+        from cq.discovery import DiscoveryError
+
+        c = Client(
+            addr="https://node.example.com",
+            local_db_path=tmp_path / "test.db",
+            _resolver=self._RaisingResolver(),  # type: ignore[arg-type]
+        )
+        with pytest.raises(DiscoveryError):
+            c.flag("nonexistent-id", FlagReason.INCORRECT, tier=Tier.PRIVATE)
+        c.close()
+
+    def test_drain_propagates_discovery_error(self, tmp_path: Path):
+        from cq.discovery import DiscoveryError
+
+        c = Client(
+            addr="https://node.example.com",
+            local_db_path=tmp_path / "test.db",
+            _resolver=self._RaisingResolver(),  # type: ignore[arg-type]
+        )
+        # Seed one local unit so drain has work to do; without it the
+        # for-loop body never runs and the resolver is never invoked.
+        from cq.models import Context, Insight, create_knowledge_unit
+
+        unit = create_knowledge_unit(
+            domains=["python"],
+            insight=Insight(summary="s", detail="d", action="a"),
+            context=Context(languages=[], frameworks=[], pattern=""),
+            created_by="",
+        )
+        c._store.insert(unit)
+        with pytest.raises(DiscoveryError):
+            c.drain()
+        c.close()
+
+    def test_transport_failure_still_falls_back_on_propose(self, tmp_path: Path):
+        """A resolver that succeeds combined with an HTTP transport failure should
+        still produce the historical FallbackError so the local-store fallback
+        path is unaffected by Resolver wiring.
+        """
+        from cq.discovery import SUPPORTED_DISCOVERY_VERSION, NodeInfo
+
+        class _StaticResolver:
+            def resolve(self, addr: str) -> NodeInfo:
+                return NodeInfo(
+                    version=SUPPORTED_DISCOVERY_VERSION,
+                    api_base_url="https://api.example.com/v1",
+                    api_version="v1",
+                )
+
+        def transport_failing_send(self, request, **kwargs):
+            raise httpx.ConnectError("simulated network failure")
+
+        with patch.object(httpx.Client, "send", transport_failing_send):
+            c = Client(
+                addr="https://node.example.com",
+                local_db_path=tmp_path / "test.db",
+                _resolver=_StaticResolver(),  # type: ignore[arg-type]
+            )
+            with pytest.raises(FallbackError):
+                c.propose(
+                    summary="Use connection pooling",
+                    detail="Connections are expensive.",
+                    action="Pool them.",
+                    domains=["python"],
+                )
+            c.close()
+
+
+class TestRealResolver404Fallback:
+    """Pin the 404-fallback URL contract end-to-end through a real Resolver.
+
+    When the node does not publish a discovery document, the Resolver synthesizes
+    `addr + DEFAULT_API_PATH` and the Client routes subsequent API calls there.
+    This test exercises the real Resolver (no `_resolver=` injection) so the
+    `/api/v1/<resource>` contract stays pinned against future drift in either
+    the Resolver or the Client.
+    """
+
+    def test_well_known_404_routes_api_calls_to_default_api_path(self, tmp_path: Path):
+        captured: list[httpx.URL] = []
+
+        def capturing_send(self, request, **kwargs):
+            captured.append(request.url)
+            if request.url.path == "/.well-known/cq-node.json":
+                return httpx.Response(status_code=404, request=request)
+            if request.url.path == "/api/v1/knowledge":
+                return httpx.Response(
+                    status_code=200,
+                    json={"data": []},
+                    request=request,
+                )
+            raise AssertionError(f"unexpected request {request.url}")
+
+        with patch.object(httpx.Client, "send", capturing_send):
+            c = Client(
+                addr="https://node.example.com",
+                local_db_path=tmp_path / "test.db",
+            )
+            c.query(["api"], limit=1)
+            c.close()
+
+        assert len(captured) == 2
+        assert captured[0].path == "/.well-known/cq-node.json"
+        assert captured[0].host == "node.example.com"
+        assert captured[1].path == "/api/v1/knowledge"
+        assert captured[1].host == "node.example.com"
+
+
+class TestStaticResolverFixture:
+    """Smoke tests that exercise the shared ``static_resolver`` conftest fixture.
+
+    The fixture synthesizes the same ``addr + /api/v1`` suffix the default
+    discovery fallback produces, so assertions against ``/api/v1/...`` paths
+    hold for clients wired through the fixture without an HTTP probe.
+    """
+
+    def test_query_routes_through_static_resolver(self, tmp_path: Path, httpx_mock, static_resolver):
+        remote_unit = {
+            "id": "ku_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa01",
+            "domains": ["api"],
+            "insight": {"summary": "S", "detail": "D", "action": "A"},
+            "tier": "private",
+        }
+        httpx_mock.add_response(
+            url=httpx.URL("http://test-remote/api/v1/knowledge", params={"domains": ["api"], "limit": "5"}),
+            json={"data": [remote_unit]},
+        )
+
+        c = Client(
+            addr="http://test-remote",
+            local_db_path=tmp_path / "test.db",
+            _resolver=static_resolver,
+        )
+        result = c.query(["api"])
+        assert result.source == "remote"
+        assert len(result.units) == 1
+        assert result.units[0].id == "ku_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa01"
+        c.close()
+
+    def test_propose_routes_through_static_resolver(self, tmp_path: Path, httpx_mock, static_resolver):
+        server_unit = {
+            "id": "ku_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb01",
+            "domains": ["api"],
+            "insight": {"summary": "Remote only", "detail": "D", "action": "A"},
+            "tier": "private",
+        }
+        httpx_mock.add_response(
+            url=httpx.URL("http://test-remote/api/v1/knowledge"),
+            json={"knowledge_unit": server_unit},
+            status_code=200,
+        )
+
+        c = Client(
+            addr="http://test-remote",
+            local_db_path=tmp_path / "test.db",
+            _resolver=static_resolver,
+        )
+        result = c.propose(summary="Remote only", detail="D", action="A", domains=["api"])
+        assert result.id == "ku_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb01"
+        c.close()
+
+
 @pytest.fixture()
 def httpx_mock():
     """Minimal httpx mock for testing remote API calls."""
@@ -785,6 +1063,11 @@ def httpx_mock():
     mock = _Mock()
 
     def patched_send(self, request, **kwargs):
+        # Treat the discovery probe as unconfigured so the resolver falls back
+        # to its `addr + /api/v1` defaults; the queued responses in these tests
+        # describe the API call under test, not the probe.
+        if request.url.path.endswith("/.well-known/cq-node.json"):
+            return httpx.Response(status_code=404, request=request)
         if exceptions:
             raise exceptions.pop(0)
         for idx, resp_config in enumerate(responses):

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -804,6 +804,9 @@ class TestClientApiBaseUrl:
                     api_version="v1",
                 )
 
+            def close(self) -> None:
+                """No-op; the test double owns no resources."""
+
         captured: list[httpx.URL] = []
 
         def capturing_send(self, request, **kwargs):
@@ -819,6 +822,43 @@ class TestClientApiBaseUrl:
                 addr="https://node.example.com",
                 local_db_path=tmp_path / "test.db",
                 _resolver=_StaticResolver(),  # type: ignore[arg-type]
+            )
+            c.status()
+            c.close()
+
+        assert len(captured) == 1
+        assert str(captured[0]) == "https://api.example.com/v2/knowledge/stats"
+
+    def test_trailing_slash_in_api_base_url_is_normalized(self, tmp_path: Path):
+        """A trailing slash in the resolved api_base_url must not produce // in the request URL."""
+        from cq.discovery import SUPPORTED_DISCOVERY_VERSION, NodeInfo
+
+        class _TrailingSlashResolver:
+            def resolve(self, addr: str) -> NodeInfo:
+                return NodeInfo(
+                    version=SUPPORTED_DISCOVERY_VERSION,
+                    api_base_url="https://api.example.com/v2/",
+                    api_version="v1",
+                )
+
+            def close(self) -> None:
+                """No-op; the test double owns no resources."""
+
+        captured: list[httpx.URL] = []
+
+        def capturing_send(self, request, **kwargs):
+            captured.append(request.url)
+            return httpx.Response(
+                status_code=200,
+                json={"total_units": 0, "tiers": {}, "domains": {}},
+                request=request,
+            )
+
+        with patch.object(httpx.Client, "send", capturing_send):
+            c = Client(
+                addr="https://node.example.com",
+                local_db_path=tmp_path / "test.db",
+                _resolver=_TrailingSlashResolver(),  # type: ignore[arg-type]
             )
             c.status()
             c.close()
@@ -842,6 +882,9 @@ class TestClientDiscoveryErrorPropagation:
             from cq.discovery import DiscoveryError
 
             raise DiscoveryError("test discovery failure")
+
+        def close(self) -> None:
+            """No-op; the test double owns no resources."""
 
     def test_query_propagates_discovery_error(self, tmp_path: Path):
         from cq.discovery import DiscoveryError
@@ -933,6 +976,9 @@ class TestClientDiscoveryErrorPropagation:
                     api_base_url="https://api.example.com/v1",
                     api_version="v1",
                 )
+
+            def close(self) -> None:
+                """No-op; the test double owns no resources."""
 
         def transport_failing_send(self, request, **kwargs):
             raise httpx.ConnectError("simulated network failure")

--- a/sdk/python/tests/test_discovery.py
+++ b/sdk/python/tests/test_discovery.py
@@ -1,0 +1,548 @@
+"""Tests for the node-discovery Resolver.
+
+HTTP interactions are mocked with httpx.MockTransport rather than
+`pytest-httpx` so the SDK does not gain a new test dependency.
+The transport closure records call counts and sequences per-request
+responses, which is enough to mirror Go's `httptest.NewServer` pattern
+used in the upstream resolver test set.
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import json
+import threading
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import cq_schema
+import httpx
+import jsonschema
+import pytest
+
+from cq.discovery._resolver import DiscoveryError, Resolver
+from cq.discovery._types import (
+    DEFAULT_API_PATH,
+    DEFAULT_API_VERSION,
+    SUPPORTED_DISCOVERY_VERSION,
+    WELL_KNOWN_PATH,
+    NodeInfo,
+)
+
+_VALID_DOC = {
+    "version": 1,
+    "api_base_url": "https://api.example.com/api/v1",
+    "api_version": "v1",
+    "node_name": "example",
+}
+
+
+def _addr() -> str:
+    """Return the placeholder node address used by every test."""
+    return "https://node.example.com"
+
+
+def _json_response(payload: Any, status_code: int = 200) -> httpx.Response:
+    """Build an httpx.Response carrying a JSON body and Content-Type."""
+    return httpx.Response(
+        status_code=status_code,
+        headers={"Content-Type": "application/json"},
+        content=json.dumps(payload).encode("utf-8"),
+    )
+
+
+def _raw_response(body: bytes, *, content_type: str, status_code: int = 200) -> httpx.Response:
+    """Build an httpx.Response with a caller-supplied body and Content-Type."""
+    return httpx.Response(
+        status_code=status_code,
+        headers={"Content-Type": content_type},
+        content=body,
+    )
+
+
+class _Recorder:
+    """Capture every well-known probe and serve scripted responses.
+
+    The handler is invoked once per outbound request.
+    `calls` is the running request count so tests can pin retry counts.
+    """
+
+    def __init__(self, handler: Callable[[int, httpx.Request], httpx.Response]) -> None:
+        self.calls = 0
+        self._handler = handler
+
+    def __call__(self, request: httpx.Request) -> httpx.Response:
+        self.calls += 1
+        return self._handler(self.calls, request)
+
+
+def _client_with(recorder: _Recorder) -> httpx.Client:
+    """Build an httpx.Client whose transport routes every request through recorder."""
+    return httpx.Client(transport=httpx.MockTransport(recorder))
+
+
+def _resolver(
+    cache_dir: Path | None,
+    recorder: _Recorder | None = None,
+) -> Resolver:
+    """Build a Resolver wired to a MockTransport client."""
+    http_client = _client_with(recorder) if recorder is not None else httpx.Client()
+    return Resolver(cache_dir=cache_dir, http_client=http_client)
+
+
+@pytest.fixture(autouse=True)
+def _fast_sleep(monkeypatch: pytest.MonkeyPatch) -> list[float]:
+    """Replace time.sleep inside the resolver module with a recorder.
+
+    The list of recorded durations is reachable via request.getfixturevalue
+    for the few tests that pin retry backoff; everyone else gets a fast
+    suite for free.
+    """
+    calls: list[float] = []
+
+    def _record(seconds: float) -> None:
+        calls.append(seconds)
+
+    from cq.discovery import _resolver as resolver_module
+
+    monkeypatch.setattr(resolver_module.time, "sleep", _record)
+    return calls
+
+
+class TestResolveAcceptsValidDocument:
+    def test_returns_parsed_node_info(self, tmp_path: Path) -> None:
+        def handler(_call: int, request: httpx.Request) -> httpx.Response:
+            assert request.url.path == WELL_KNOWN_PATH
+            return _json_response(_VALID_DOC)
+
+        recorder = _Recorder(handler)
+        info = _resolver(tmp_path, recorder).resolve(_addr())
+        assert info.version == SUPPORTED_DISCOVERY_VERSION
+        assert info.api_base_url == "https://api.example.com/api/v1"
+        assert info.api_version == "v1"
+        assert info.node_name == "example"
+
+
+class TestResolveCachesOnDiskAcrossInstances:
+    def test_second_resolver_does_not_probe(self, tmp_path: Path) -> None:
+        recorder = _Recorder(lambda _c, _r: _json_response({}, status_code=404))
+        first = _resolver(tmp_path, recorder)
+        first.resolve(_addr())
+        assert recorder.calls == 1
+
+        # A fresh Resolver pointed at the same cache directory must serve
+        # the prior result from disk and issue zero new requests.
+        recorder.calls = 0
+        second = _resolver(tmp_path, recorder)
+        info = second.resolve(_addr())
+        assert recorder.calls == 0
+        assert info.api_base_url == _addr() + DEFAULT_API_PATH
+
+
+class TestResolveCachesSuccessInProcess:
+    def test_second_call_does_no_http(self, tmp_path: Path) -> None:
+        recorder = _Recorder(lambda _c, _r: _json_response(_VALID_DOC))
+        resolver = _resolver(tmp_path, recorder)
+        first = resolver.resolve(_addr())
+        second = resolver.resolve(_addr())
+        assert recorder.calls == 1
+        assert first == second
+
+
+class TestResolveFallsBackOn404:
+    def test_returns_defaults_and_caches(self, tmp_path: Path) -> None:
+        recorder = _Recorder(lambda _c, _r: _json_response({"detail": "not found"}, status_code=404))
+        resolver = _resolver(tmp_path, recorder)
+        info = resolver.resolve(_addr())
+        assert info.version == SUPPORTED_DISCOVERY_VERSION
+        assert info.api_base_url == _addr() + DEFAULT_API_PATH
+        assert info.api_version == DEFAULT_API_VERSION
+
+        # Second call is served by the in-process memo.
+        resolver.resolve(_addr())
+        assert recorder.calls == 1
+
+
+class TestResolveNormalizesTrailingSlash:
+    def test_trailing_slash_in_addr_is_stripped(self, tmp_path: Path) -> None:
+        recorder = _Recorder(lambda _c, _r: _json_response({}, status_code=404))
+        resolver = _resolver(tmp_path, recorder)
+        info = resolver.resolve(_addr() + "/")
+        assert info.api_base_url == _addr() + DEFAULT_API_PATH
+
+
+class TestResolveRejectsExtraField:
+    def test_unknown_field_raises(self, tmp_path: Path) -> None:
+        payload = dict(_VALID_DOC) | {"made_up_field": "x"}
+        recorder = _Recorder(lambda _c, _r: _json_response(payload))
+        resolver = _resolver(tmp_path, recorder)
+        with pytest.raises(DiscoveryError) as exc:
+            resolver.resolve(_addr())
+        assert "made_up_field" in str(exc.value).lower()
+
+        # Failed probes must not be cached.
+        with pytest.raises(DiscoveryError):
+            resolver.resolve(_addr())
+        assert recorder.calls == 2
+
+
+class TestResolveRejectsHostlessApiBaseUrl:
+    def test_missing_host_raises(self, tmp_path: Path) -> None:
+        payload = {
+            "version": 1,
+            "api_base_url": "https://",
+            "api_version": "v1",
+        }
+        recorder = _Recorder(lambda _c, _r: _json_response(payload))
+        resolver = _resolver(tmp_path, recorder)
+        with pytest.raises(DiscoveryError) as exc:
+            resolver.resolve(_addr())
+        assert "host" in str(exc.value).lower()
+
+        with pytest.raises(DiscoveryError):
+            resolver.resolve(_addr())
+        assert recorder.calls == 2
+
+
+class TestResolveRejectsHtml:
+    def test_text_html_mentions_spa(self, tmp_path: Path) -> None:
+        recorder = _Recorder(
+            lambda _c, _r: _raw_response(
+                b"<!doctype html><html>...</html>",
+                content_type="text/html; charset=utf-8",
+            )
+        )
+        resolver = _resolver(tmp_path, recorder)
+        with pytest.raises(DiscoveryError) as exc:
+            resolver.resolve(_addr())
+        assert "SPA" in str(exc.value)
+
+        with pytest.raises(DiscoveryError):
+            resolver.resolve(_addr())
+        assert recorder.calls == 2
+        # Regression sentinel: failed probes must not poison the on-disk cache.
+        assert list(tmp_path.iterdir()) == []
+
+
+class TestResolveRejectsMalformedJson:
+    def test_invalid_json_raises(self, tmp_path: Path) -> None:
+        recorder = _Recorder(lambda _c, _r: _raw_response(b"{not valid", content_type="application/json"))
+        resolver = _resolver(tmp_path, recorder)
+        with pytest.raises(DiscoveryError):
+            resolver.resolve(_addr())
+
+        with pytest.raises(DiscoveryError):
+            resolver.resolve(_addr())
+        assert recorder.calls == 2
+
+    def test_trailing_content_raises(self, tmp_path: Path) -> None:
+        body = json.dumps(_VALID_DOC).encode("utf-8") + b" garbage"
+        recorder = _Recorder(lambda _c, _r: _raw_response(body, content_type="application/json"))
+        resolver = _resolver(tmp_path, recorder)
+        with pytest.raises(DiscoveryError) as exc:
+            resolver.resolve(_addr())
+        assert "trailing" in str(exc.value).lower()
+
+
+class TestResolveRejectsMismatchedApiVersion:
+    def test_v2_names_both_versions(self, tmp_path: Path) -> None:
+        payload = dict(_VALID_DOC) | {"api_version": "v2"}
+        recorder = _Recorder(lambda _c, _r: _json_response(payload))
+        resolver = _resolver(tmp_path, recorder)
+        with pytest.raises(DiscoveryError) as exc:
+            resolver.resolve(_addr())
+        message = str(exc.value)
+        assert "v1" in message
+        assert "v2" in message
+
+        with pytest.raises(DiscoveryError):
+            resolver.resolve(_addr())
+        assert recorder.calls == 2
+
+
+class TestResolveRejectsMismatchedDiscoveryVersion:
+    def test_version_2_names_both_versions(self, tmp_path: Path) -> None:
+        payload = dict(_VALID_DOC) | {"version": 2}
+        recorder = _Recorder(lambda _c, _r: _json_response(payload))
+        resolver = _resolver(tmp_path, recorder)
+        with pytest.raises(DiscoveryError) as exc:
+            resolver.resolve(_addr())
+        message = str(exc.value)
+        assert "1" in message
+        assert "2" in message
+
+        with pytest.raises(DiscoveryError):
+            resolver.resolve(_addr())
+        assert recorder.calls == 2
+
+
+class TestResolveRejectsMissingDiscoveryVersion:
+    def test_absent_version_field_raises(self, tmp_path: Path) -> None:
+        payload = {k: v for k, v in _VALID_DOC.items() if k != "version"}
+        recorder = _Recorder(lambda _c, _r: _json_response(payload))
+        resolver = _resolver(tmp_path, recorder)
+        with pytest.raises(DiscoveryError):
+            resolver.resolve(_addr())
+
+        with pytest.raises(DiscoveryError):
+            resolver.resolve(_addr())
+        assert recorder.calls == 2
+
+
+class TestResolveRejectsNonHttpScheme:
+    def test_ftp_url_raises_mentions_scheme(self, tmp_path: Path) -> None:
+        payload = dict(_VALID_DOC) | {"api_base_url": "ftp://example.com/api/v1"}
+        recorder = _Recorder(lambda _c, _r: _json_response(payload))
+        resolver = _resolver(tmp_path, recorder)
+        with pytest.raises(DiscoveryError) as exc:
+            resolver.resolve(_addr())
+        assert "scheme" in str(exc.value).lower()
+
+        with pytest.raises(DiscoveryError):
+            resolver.resolve(_addr())
+        assert recorder.calls == 2
+
+
+class TestResolveRetriesOn5xx:
+    def test_two_5xx_responses_raises_after_two_calls(self, tmp_path: Path, _fast_sleep: list[float]) -> None:
+        recorder = _Recorder(lambda _c, _r: _raw_response(b"boom", content_type="text/plain", status_code=500))
+        resolver = _resolver(tmp_path, recorder)
+        with pytest.raises(DiscoveryError):
+            resolver.resolve(_addr())
+        assert recorder.calls == 2
+        # One backoff between two attempts.
+        assert _fast_sleep == [0.2]
+
+
+class TestResolveRetriesOnTransportError:
+    def test_two_transport_errors_raises_after_two_calls(self, tmp_path: Path, _fast_sleep: list[float]) -> None:
+        def handler(_call: int, request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError("boom", request=request)
+
+        recorder = _Recorder(handler)
+        resolver = _resolver(tmp_path, recorder)
+        with pytest.raises(DiscoveryError):
+            resolver.resolve(_addr())
+        assert recorder.calls == 2
+        assert _fast_sleep == [0.2]
+
+
+class TestResolveWithoutDiskCache:
+    def test_empty_cache_dir_still_resolves(self, tmp_path: Path) -> None:
+        recorder = _Recorder(lambda _c, _r: _json_response(_VALID_DOC))
+        # cache_dir=None disables the on-disk cache; tmp_path is here only
+        # to give the test a workspace, and it must stay empty.
+        resolver = _resolver(cache_dir=None, recorder=recorder)
+        info = resolver.resolve(_addr())
+        assert info.api_base_url == "https://api.example.com/api/v1"
+        assert list(tmp_path.iterdir()) == []
+
+
+class TestResolverClose:
+    def test_close_leaves_caller_supplied_client_open(self, tmp_path: Path) -> None:
+        recorder = _Recorder(lambda _c, _r: _json_response(_VALID_DOC))
+        http = _client_with(recorder)
+        resolver = Resolver(cache_dir=tmp_path, http_client=http)
+        resolver.close()
+        # The caller still owns the client and can keep using it.
+        info = NodeInfo.model_validate_json(http.get("https://node.example.com" + WELL_KNOWN_PATH).content)
+        assert info.api_version == "v1"
+        http.close()
+
+    def test_close_is_safe_when_resolver_owns_client(self, tmp_path: Path) -> None:
+        resolver = Resolver(cache_dir=tmp_path)
+        resolver.close()
+        assert resolver._http.is_closed
+
+
+class TestSchemaContractMatchesFixtures:
+    """Cross-ecosystem pin: the synced node_discovery schema must accept every fixture.
+
+    If Go adds a field to the schema without Python re-running sync-schema,
+    or if a fixture drifts from the schema, this test fails fast and forces
+    both ecosystems to land the change together.
+    """
+
+    def test_fixtures_match_schema(self) -> None:
+        schema = cq_schema.load_schema("node_discovery")
+        fixtures_dir = Path(__file__).resolve().parents[3] / "schema" / "fixtures"
+        minimal = json.loads((fixtures_dir / "node_discovery_minimal.json").read_bytes())
+        split = json.loads((fixtures_dir / "node_discovery_split.json").read_bytes())
+        invalid = json.loads((fixtures_dir / "node_discovery_invalid_version.json").read_bytes())
+
+        jsonschema.validate(minimal, schema)
+        jsonschema.validate(split, schema)
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(invalid, schema)
+
+    def test_minimal_fixture_resolves_as_node_info(self) -> None:
+        fixtures_dir = Path(__file__).resolve().parents[3] / "schema" / "fixtures"
+        raw = (fixtures_dir / "node_discovery_minimal.json").read_bytes()
+        info = NodeInfo.model_validate_json(raw)
+        assert info.version == SUPPORTED_DISCOVERY_VERSION
+        assert info.api_version == "v1"
+
+
+class _ConcurrentRecorder:
+    """Thread-safe recorder used by the single-flight tests.
+
+    Tracks call count under a lock so concurrent transport invocations stay observable,
+    signals first-call arrival before parking on an optional gate, and only then
+    invokes the supplied handler. The signal-before-park layout lets a test wait until
+    the elected prober is provably inside the transport before releasing the gate.
+    """
+
+    def __init__(
+        self,
+        handler: Callable[[int, httpx.Request], httpx.Response],
+        gate: threading.Event | None = None,
+        arrived: threading.Event | None = None,
+    ) -> None:
+        self.calls = 0
+        self._handler = handler
+        self._gate = gate
+        self._arrived = arrived
+        self._lock = threading.Lock()
+
+    def __call__(self, request: httpx.Request) -> httpx.Response:
+        with self._lock:
+            self.calls += 1
+            this_call = self.calls
+        # Signal arrival before parking so the test can wait for the elected prober
+        # to be observably inside the transport.
+        if self._arrived is not None and this_call == 1:
+            self._arrived.set()
+        # The gate is owned by the test; only the first call waits on it
+        # so the elected prober can be parked while waiters pile up.
+        if self._gate is not None and this_call == 1:
+            assert self._gate.wait(timeout=5.0)
+        return self._handler(this_call, request)
+
+
+def _concurrent_resolver(
+    tmp_path: Path,
+    recorder: _ConcurrentRecorder,
+) -> Resolver:
+    """Build a Resolver wired to a MockTransport that routes through the concurrent recorder."""
+    http_client = httpx.Client(transport=httpx.MockTransport(recorder))
+    return Resolver(cache_dir=tmp_path, http_client=http_client)
+
+
+def _wait_for_inflight_waiter(resolver: Resolver, addr: str, timeout: float = 5.0) -> None:
+    """Block until at least one thread is parked on the single-flight future for addr.
+
+    Spins on the futures Condition's internal waiter deque to avoid sleep-based pacing;
+    each waiter inside Condition.wait() leaves a lock object on `_condition._waiters`,
+    so a non-empty deque proves at least one thread is parked on future.result().
+    """
+    deadline = threading.Event()
+    timer = threading.Timer(timeout, deadline.set)
+    timer.start()
+    try:
+        while not deadline.is_set():
+            with resolver._lock:  # noqa: SLF001 — test introspection
+                future = resolver._inflight.get(addr)  # noqa: SLF001
+            if future is not None:
+                condition = future._condition  # noqa: SLF001
+                if condition._waiters:  # noqa: SLF001
+                    return
+        raise AssertionError(f"timed out waiting for an inflight waiter on {addr!r}")
+    finally:
+        timer.cancel()
+
+
+class TestResolverSingleFlight:
+    def test_concurrent_resolves_same_addr_share_one_probe(self, tmp_path: Path) -> None:
+        gate = threading.Event()
+        arrived = threading.Event()
+
+        def handler(_call: int, _request: httpx.Request) -> httpx.Response:
+            return _json_response(_VALID_DOC)
+
+        recorder = _ConcurrentRecorder(handler, gate=gate, arrived=arrived)
+        resolver = _concurrent_resolver(tmp_path, recorder)
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+            f1 = pool.submit(resolver.resolve, _addr())
+            # Wait until the elected prober is parked on the gate before submitting the second worker.
+            assert arrived.wait(timeout=5.0)
+            f2 = pool.submit(resolver.resolve, _addr())
+            # Make sure the second worker has registered as a waiter on the in-flight future
+            # before the elected prober's response lands.
+            _wait_for_inflight_waiter(resolver, _addr())
+            gate.set()
+            info_a = f1.result(timeout=5.0)
+            info_b = f2.result(timeout=5.0)
+
+        assert recorder.calls == 1
+        assert info_a == info_b
+        assert info_a.api_base_url == "https://api.example.com/api/v1"
+
+    def test_concurrent_resolves_different_addrs_probe_independently(self, tmp_path: Path) -> None:
+        addr_one = "https://one.example.com"
+        addr_two = "https://two.example.com"
+        payload_one = dict(_VALID_DOC) | {"api_base_url": "https://api-one.example.com/api/v1"}
+        payload_two = dict(_VALID_DOC) | {"api_base_url": "https://api-two.example.com/api/v1"}
+
+        def handler(_call: int, request: httpx.Request) -> httpx.Response:
+            host = request.url.host
+            if host == "one.example.com":
+                return _json_response(payload_one)
+            if host == "two.example.com":
+                return _json_response(payload_two)
+            raise AssertionError(f"unexpected host {host!r}")
+
+        recorder = _ConcurrentRecorder(handler)
+        resolver = _concurrent_resolver(tmp_path, recorder)
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+            f1 = pool.submit(resolver.resolve, addr_one)
+            f2 = pool.submit(resolver.resolve, addr_two)
+            info_one = f1.result(timeout=5.0)
+            info_two = f2.result(timeout=5.0)
+
+        assert recorder.calls == 2
+        assert info_one.api_base_url == "https://api-one.example.com/api/v1"
+        assert info_two.api_base_url == "https://api-two.example.com/api/v1"
+
+    def test_concurrent_resolves_propagate_probe_failure(self, tmp_path: Path) -> None:
+        gate = threading.Event()
+        arrived = threading.Event()
+
+        def handler(_call: int, _request: httpx.Request) -> httpx.Response:
+            return _raw_response(
+                b"<!doctype html><html>...</html>",
+                content_type="text/html; charset=utf-8",
+            )
+
+        recorder = _ConcurrentRecorder(handler, gate=gate, arrived=arrived)
+        resolver = _concurrent_resolver(tmp_path, recorder)
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+            f1 = pool.submit(resolver.resolve, _addr())
+            assert arrived.wait(timeout=5.0)
+            f2 = pool.submit(resolver.resolve, _addr())
+            _wait_for_inflight_waiter(resolver, _addr())
+            gate.set()
+            for fut in (f1, f2):
+                with pytest.raises(DiscoveryError):
+                    fut.result(timeout=5.0)
+
+        assert recorder.calls == 1
+
+    def test_failed_probe_does_not_memoize_for_next_caller(self, tmp_path: Path) -> None:
+        def handler(_call: int, _request: httpx.Request) -> httpx.Response:
+            return _raw_response(
+                b"<!doctype html><html>...</html>",
+                content_type="text/html; charset=utf-8",
+            )
+
+        recorder = _ConcurrentRecorder(handler)
+        resolver = _concurrent_resolver(tmp_path, recorder)
+
+        with pytest.raises(DiscoveryError):
+            resolver.resolve(_addr())
+        with pytest.raises(DiscoveryError):
+            resolver.resolve(_addr())
+        assert recorder.calls == 2

--- a/sdk/python/tests/test_discovery.py
+++ b/sdk/python/tests/test_discovery.py
@@ -205,6 +205,24 @@ class TestResolveRejectsHostlessApiBaseUrl:
         assert recorder.calls == 2
 
 
+class TestResolveRejectsInvalidPortApiBaseUrl:
+    def test_non_numeric_port_raises(self, tmp_path: Path) -> None:
+        payload = {
+            "version": 1,
+            "api_base_url": "https://example.com:bad/api/v1",
+            "api_version": "v1",
+        }
+        recorder = _Recorder(lambda _c, _r: _json_response(payload))
+        resolver = _resolver(tmp_path, recorder)
+        with pytest.raises(DiscoveryError) as exc:
+            resolver.resolve(_addr())
+        assert "port" in str(exc.value).lower()
+
+        with pytest.raises(DiscoveryError):
+            resolver.resolve(_addr())
+        assert recorder.calls == 2
+
+
 class TestResolveRejectsHtml:
     def test_text_html_mentions_spa(self, tmp_path: Path) -> None:
         recorder = _Recorder(

--- a/sdk/python/tests/test_discovery_cache.py
+++ b/sdk/python/tests/test_discovery_cache.py
@@ -1,0 +1,231 @@
+"""Tests for the on-disk discovery cache."""
+
+import hashlib
+import json
+import os
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+
+from cq.discovery._cache import Cache
+from cq.discovery._types import DEFAULT_CACHE_TTL_SECONDS, NodeInfo
+
+
+def _make_info(**overrides: object) -> NodeInfo:
+    defaults: dict[str, object] = {
+        "version": 1,
+        "api_base_url": "https://node.example.com/api/v1",
+        "api_version": "v1",
+    }
+    return NodeInfo(**(defaults | overrides))  # type: ignore[arg-type]  # pydantic kwarg widening
+
+
+@pytest.fixture()
+def cache_dir(tmp_path: Path) -> Path:
+    return tmp_path / "discovery-cache"
+
+
+class TestGet:
+    def test_returns_none_for_unknown_addr(self, cache_dir: Path) -> None:
+        cache = Cache(cache_dir=cache_dir, ttl_seconds=DEFAULT_CACHE_TTL_SECONDS)
+        assert cache.get("https://unknown.example.com") is None
+
+    def test_returns_hit_within_ttl(self, cache_dir: Path) -> None:
+        cache = Cache(cache_dir=cache_dir, ttl_seconds=60)
+        info = _make_info()
+        cache.put("https://node.example.com", info)
+        assert cache.get("https://node.example.com") == info
+
+    def test_returns_none_after_ttl(self, cache_dir: Path) -> None:
+        cache = Cache(cache_dir=cache_dir, ttl_seconds=60)
+        info = _make_info()
+        addr = "https://node.example.com"
+        cache.put(addr, info)
+        # Backdate mtime past the TTL.
+        path = cache_dir / (cache._filename(addr))
+        old = time.time() - 120
+        os.utime(path, (old, old))
+        assert cache.get(addr) is None
+
+
+class TestInvalidate:
+    def test_removes_existing_entry(self, cache_dir: Path) -> None:
+        cache = Cache(cache_dir=cache_dir, ttl_seconds=60)
+        addr = "https://node.example.com"
+        cache.put(addr, _make_info())
+        cache.invalidate(addr)
+        assert cache.get(addr) is None
+        assert not (cache_dir / cache._filename(addr)).exists()
+
+    def test_missing_entry_is_noop(self, cache_dir: Path) -> None:
+        cache = Cache(cache_dir=cache_dir, ttl_seconds=60)
+        # Must not raise.
+        cache.invalidate("https://never-written.example.com")
+
+
+class TestPut:
+    def test_leaves_no_temp_files(self, cache_dir: Path) -> None:
+        cache = Cache(cache_dir=cache_dir, ttl_seconds=60)
+        cache.put("https://node.example.com", _make_info())
+        # The only file in the cache dir is the final entry.
+        entries = list(cache_dir.iterdir())
+        assert len(entries) == 1
+        assert entries[0].name.endswith(".json")
+        assert not entries[0].name.startswith("tmp")
+
+    def test_creates_directory_lazily(self, tmp_path: Path) -> None:
+        cache_dir = tmp_path / "does-not-exist-yet"
+        cache = Cache(cache_dir=cache_dir, ttl_seconds=60)
+        assert not cache_dir.exists()
+        cache.put("https://node.example.com", _make_info())
+        assert cache_dir.is_dir()
+
+    def test_write_failure_leaves_no_temp_files(self, cache_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """If serialization fails mid-write, no temp file may remain."""
+        cache = Cache(cache_dir=cache_dir, ttl_seconds=60)
+
+        def boom(self: object) -> str:
+            raise RuntimeError("encode failure injected by test")
+
+        monkeypatch.setattr(NodeInfo, "model_dump_json", boom)
+        with pytest.raises(RuntimeError, match="encode failure injected by test"):
+            cache.put("https://node.example.com", _make_info())
+        # Directory may or may not exist; if it does, no temp residue.
+        if cache_dir.exists():
+            assert list(cache_dir.iterdir()) == []
+
+    def test_rename_failure_leaves_no_temp_files(self, cache_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """If the final rename fails, the exception propagates and no temp file remains."""
+        cache = Cache(cache_dir=cache_dir, ttl_seconds=60)
+
+        def boom(self: Path, target: object) -> Path:
+            raise OSError("rename failure injected by test")
+
+        monkeypatch.setattr(Path, "replace", boom)
+        with pytest.raises(OSError, match="rename failure injected by test"):
+            cache.put("https://node.example.com", _make_info())
+        assert list(cache_dir.iterdir()) == []
+
+
+class TestSchemaInvalidEntry:
+    def test_schema_invalid_stored_entry_is_miss_and_removed(self, cache_dir: Path) -> None:
+        """A cached file that does not parse as NodeInfo is treated as a miss and deleted."""
+        cache = Cache(cache_dir=cache_dir, ttl_seconds=60)
+        addr = "https://node.example.com"
+        path = cache_dir / cache._filename(addr)
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        # Write a syntactically valid but schema-invalid entry (empty api_base_url).
+        path.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "api_base_url": "",
+                    "api_version": "v1",
+                }
+            )
+        )
+        assert cache.get(addr) is None
+        assert not path.exists()
+
+    def test_unknown_field_stored_entry_is_miss_and_removed(self, cache_dir: Path) -> None:
+        """A cached file with unknown JSON fields is treated as a miss and deleted."""
+        cache = Cache(cache_dir=cache_dir, ttl_seconds=60)
+        addr = "https://node.example.com"
+        path = cache_dir / cache._filename(addr)
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "api_base_url": "https://node.example.com/api/v1",
+                    "api_version": "v1",
+                    "unexpected_field": "boom",
+                }
+            )
+        )
+        assert cache.get(addr) is None
+        assert not path.exists()
+
+    def test_wrong_discovery_version_is_miss_and_removed(self, cache_dir: Path) -> None:
+        cache = Cache(cache_dir=cache_dir, ttl_seconds=60)
+        addr = "https://node.example.com"
+        path = cache_dir / cache._filename(addr)
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(
+                {
+                    "version": 99,
+                    "api_base_url": "https://node.example.com/api/v1",
+                    "api_version": "v1",
+                }
+            )
+        )
+        assert cache.get(addr) is None
+        assert not path.exists()
+
+    def test_wrong_api_version_is_miss_and_removed(self, cache_dir: Path) -> None:
+        cache = Cache(cache_dir=cache_dir, ttl_seconds=60)
+        addr = "https://node.example.com"
+        path = cache_dir / cache._filename(addr)
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "api_base_url": "https://node.example.com/api/v1",
+                    "api_version": "v99",
+                }
+            )
+        )
+        assert cache.get(addr) is None
+        assert not path.exists()
+
+    def test_non_http_scheme_is_miss_and_removed(self, cache_dir: Path) -> None:
+        cache = Cache(cache_dir=cache_dir, ttl_seconds=60)
+        addr = "https://node.example.com"
+        path = cache_dir / cache._filename(addr)
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "api_base_url": "ftp://node.example.com/api/v1",
+                    "api_version": "v1",
+                }
+            )
+        )
+        assert cache.get(addr) is None
+        assert not path.exists()
+
+
+class TestDisabledCache:
+    """Cache(cache_dir=None) is a no-op on every operation."""
+
+    def test_get_returns_none(self) -> None:
+        cache = Cache(cache_dir=None, ttl_seconds=60)
+        assert cache.get("https://node.example.com") is None
+
+    def test_put_does_not_invoke_filesystem(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def boom(*args: object, **kwargs: object) -> tuple[int, str]:
+            raise AssertionError("mkstemp must not be called when disabled")
+
+        monkeypatch.setattr(tempfile, "mkstemp", boom)
+        Cache(cache_dir=None, ttl_seconds=60).put("https://node.example.com", _make_info())
+
+    def test_invalidate_does_not_invoke_filesystem(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def boom(self: Path) -> None:
+            raise AssertionError("unlink must not be called when disabled")
+
+        monkeypatch.setattr(Path, "unlink", boom)
+        Cache(cache_dir=None, ttl_seconds=60).invalidate("https://node.example.com")
+
+
+class TestFilename:
+    def test_filename_is_sha256_hex_json(self, cache_dir: Path) -> None:
+        """The filename must be deterministic SHA-256 hex of the address plus .json."""
+        cache = Cache(cache_dir=cache_dir, ttl_seconds=60)
+        addr = "https://node.example.com"
+        expected = hashlib.sha256(addr.encode()).hexdigest() + ".json"
+        assert cache._filename(addr) == expected

--- a/sdk/python/tests/test_discovery_paths.py
+++ b/sdk/python/tests/test_discovery_paths.py
@@ -1,0 +1,62 @@
+"""Tests for the XDG-compliant discovery cache directory resolver."""
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from cq.discovery._paths import default_cache_dir
+
+
+class TestDefaultCacheDir:
+    def test_xdg_cache_home_takes_precedence(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("XDG_CACHE_HOME", "/custom/xdg")
+        monkeypatch.setenv("HOME", "/home/user")
+        assert default_cache_dir() == Path("/custom/xdg/cq/discovery")
+
+    def test_falls_back_to_home_when_xdg_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+        monkeypatch.setenv("HOME", "/home/user")
+        assert default_cache_dir() == Path("/home/user/.cache/cq/discovery")
+
+    def test_returns_none_when_xdg_and_home_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+        monkeypatch.delenv("HOME", raising=False)
+        assert default_cache_dir() is None
+
+    def test_empty_xdg_falls_through_to_home(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("XDG_CACHE_HOME", "")
+        monkeypatch.setenv("HOME", "/home/user")
+        assert default_cache_dir() == Path("/home/user/.cache/cq/discovery")
+
+    def test_whitespace_xdg_falls_through_to_home_without_warning(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        monkeypatch.setenv("XDG_CACHE_HOME", "   ")
+        monkeypatch.setenv("HOME", "/home/user")
+        with caplog.at_level(logging.WARNING, logger="cq.discovery"):
+            result = default_cache_dir()
+        assert result == Path("/home/user/.cache/cq/discovery")
+        assert caplog.records == []
+
+    def test_relative_xdg_returns_none_and_warns(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        monkeypatch.setenv("XDG_CACHE_HOME", "relative/path")
+        monkeypatch.setenv("HOME", "/home/user")
+        with caplog.at_level(logging.WARNING, logger="cq.discovery"):
+            result = default_cache_dir()
+        assert result is None
+        assert len(caplog.records) == 1
+        assert caplog.records[0].levelno == logging.WARNING
+        assert "absolute path" in caplog.records[0].getMessage()
+        assert "relative/path" in caplog.records[0].getMessage()
+
+    def test_absolute_xdg_returns_subdirectory(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("XDG_CACHE_HOME", "/absolute/path")
+        monkeypatch.setenv("HOME", "/home/user")
+        assert default_cache_dir() == Path("/absolute/path") / "cq" / "discovery"


### PR DESCRIPTION
## Summary

- Brings the Python SDK to parity with the Go SDK's node discovery protocol that landed in #373.
- `cq.Client(addr=...)` now probes `/.well-known/cq-node.json` once per address per cache TTL and routes API calls through the resolved `api_base_url`. The 404 fallback preserves today's `addr + /api/v1` URL shape, so localhost and same-origin nodes are unaffected.
- `DiscoveryError` is distinct from `httpx.HTTPError` so callers and Propose's fallback logic can distinguish operator/client misconfiguration from connectivity failures.

## What's in here

Two atomic commits, each independently revertable:

- **`feat(sdk-python): add node discovery package`** — new `cq.discovery` package mirroring `sdk/go/discovery/`. Probes the well-known endpoint, validates the response against the synced JSON Schema, caches results to disk (XDG-compliant, SHA-256-keyed, atomic temp-file + rename, re-validated on read). `cache_dir=None` disables the disk layer. Concurrent `resolve()` calls for the same address are coalesced into a single probe; waiters share the elected prober's result or error (single-flight). Not yet wired into `Client`.
- **`feat(sdk-python): resolve API base URL via node discovery; logger injection`** — threads the Resolver through `Client`. Each `_remote_*` method now uses the resolved `api_base_url` verbatim; hardcoded `/api/v1` prefixes are removed. `Client` accepts an optional logger; the library installs a `NullHandler` on the `cq` logger so the SDK writes no logs by default, preserving the MCP-over-stdio invariant.

XDG_CACHE_HOME validation matches the Go SDK (whitespace trim + absolute-path requirement); misconfiguration surfaces via a warning log rather than a returned error, so callers wire one consistent disable signal.

## Test plan

- [x] \`make lint\` (repo root) clean.
- [x] \`make test\` (repo root) green: 398 Python SDK + 280 backend + 11 frontend + sub-makes (124/46).
- [x] 21 resolver tests + 18 cache tests + 7 paths tests + 16 new client tests covering logger injection, API base URL resolution, DiscoveryError propagation through \`query\`/\`propose\`/\`confirm\`/\`flag\`/\`drain\`, transport-failure fallback continuity, the static resolver fixture, and a real-resolver 404-fallback regression.
- [x] Manual end-to-end smoke against a local \`./server\` on port 3000:
  - Query succeeds; \`~/.cache/cq/discovery/<sha>.json\` is written with the synthesized defaults.
  - Second invocation does not re-probe (mtime stable; served from disk cache).
  - \`Client(addr="http://nonexistent.invalid").query(...)\` raises \`DiscoveryError\`, not silent fallback.

## Follow-up

The Python Resolver's single-flight behavior is stricter than the Go SDK today (Go allows concurrent same-address probes to race). A follow-up issue will track aligning the Go SDK to the same single-flight semantics; I'll file it once this lands and link the merged commit.

## Related

Refs: #373