### PR TITLE
Add Homebrew install instruction to CLI README

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -8,6 +8,9 @@ frameworks.
 ## Installation
 
 ```bash
+# Homebrew.
+brew install --cask mozilla-ai/tap/cq
+
 # Go install.
 go install github.com/mozilla-ai/cq/cli@latest
 


### PR DESCRIPTION
## Summary
- Adds `brew install --cask mozilla-ai/tap/cq` as the first install option in the CLI README

## Test plan
- [ ] Verify the Homebrew tap and cask exist at `mozilla-ai/tap/cq`