### PR TITLE
Add Pi (pi.dev) as a supported install host

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -92,6 +92,30 @@ To uninstall:
 make uninstall-windsurf
 ```
 
+### Pi
+
+Pi has no native MCP. cq installs via its CLI instead: the cq skill, a cq block in Pi's `AGENTS.md` that maps each cq action to a `cq` CLI call, and `/cq-status` / `/cq-reflect` prompt templates.
+
+```bash
+make install-pi
+```
+
+Or for a specific project:
+
+```bash
+make install-pi PROJECT=/path/to/your/project
+```
+
+To uninstall:
+
+```bash
+make uninstall-pi
+# or for a specific project:
+make uninstall-pi PROJECT=/path/to/your/project
+```
+
+To verify, run `/cq-status` in a Pi session (note: `/cq-status`, not `/cq:status`, and there is no MCP approval prompt — cq runs as a CLI). The agent runs `cq status --format json` and renders the summary.
+
 ### Go SDK
 
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,12 @@ help:
 	@echo "  make install-windsurf                        Install globally (~/.codeium/windsurf/)"
 	@echo "  make uninstall-windsurf                      Remove global Windsurf install"
 	@echo ""
+	@echo "Pi:"
+	@echo "  make install-pi                              Install globally (~/.pi/agent/)"
+	@echo "  make install-pi PROJECT=/path/to/app         Install into a specific project"
+	@echo "  make uninstall-pi                            Remove global Pi install"
+	@echo "  make uninstall-pi PROJECT=/path/to/app       Remove from a specific project"
+	@echo ""
 	@echo "All hosts at once:"
 	@echo "  make install-all                             Install every host globally"
 	@echo "  make install-all PROJECT=/path/to/app        Install every project-capable host into a project"
@@ -167,14 +173,30 @@ ifdef PROJECT
 endif
 	cd scripts/install && uv run python -m cq_install uninstall --target windsurf --global
 
+.PHONY: install-pi
+install-pi:
+ifdef PROJECT
+	cd scripts/install && uv run python -m cq_install install --target pi --project "$(PROJECT)"
+else
+	cd scripts/install && uv run python -m cq_install install --target pi --global
+endif
+
+.PHONY: uninstall-pi
+uninstall-pi:
+ifdef PROJECT
+	cd scripts/install && uv run python -m cq_install uninstall --target pi --project "$(PROJECT)"
+else
+	cd scripts/install && uv run python -m cq_install uninstall --target pi --global
+endif
+
 .PHONY: install-all
 install-all:
 ifdef PROJECT
-	cd scripts/install && uv run python -m cq_install install --target opencode --target cursor --target claude --project "$(PROJECT)"
+	cd scripts/install && uv run python -m cq_install install --target opencode --target cursor --target claude --target pi --project "$(PROJECT)"
 	@echo "Note: Windsurf has no per-project MCP config; installing it globally."
 	cd scripts/install && uv run python -m cq_install install --target windsurf --global
 else
-	cd scripts/install && uv run python -m cq_install install --target opencode --target cursor --target windsurf --target claude --global
+	cd scripts/install && uv run python -m cq_install install --target opencode --target cursor --target windsurf --target claude --target pi --global
 endif
 
 .PHONY: compose-up

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Run `make setup-plugin` before running the relevant `Makefile` target:
 | OpenCode | `make install-opencode` |
 | Cursor   | `make install-cursor`   |
 | Windsurf | `make install-windsurf` |
+| Pi       | `make install-pi`       |
 
 For Windows, project-specific installs, and uninstall instructions, see [DEVELOPMENT.md](DEVELOPMENT.md).
 

--- a/plugins/cq/uv.lock
+++ b/plugins/cq/uv.lock
@@ -22,7 +22,7 @@ wheels = [
 
 [[package]]
 name = "cq-plugin"
-version = "0.9.0"
+version = "0.10.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/scripts/install/src/cq_install/hosts/__init__.py
+++ b/scripts/install/src/cq_install/hosts/__init__.py
@@ -6,6 +6,7 @@ from cq_install.hosts.base import HostDef
 from cq_install.hosts.claude import ClaudeHost
 from cq_install.hosts.cursor import CursorHost
 from cq_install.hosts.opencode import OpenCodeHost
+from cq_install.hosts.pi import PiHost
 from cq_install.hosts.windsurf import WindsurfHost
 
 REGISTRY: dict[str, HostDef] = {
@@ -13,6 +14,7 @@ REGISTRY: dict[str, HostDef] = {
     "cursor": CursorHost(),
     "windsurf": WindsurfHost(),
     "claude": ClaudeHost(),
+    "pi": PiHost(),
 }
 
 

--- a/scripts/install/src/cq_install/hosts/pi.py
+++ b/scripts/install/src/cq_install/hosts/pi.py
@@ -164,8 +164,9 @@ def _agents_block(binary_path: Path) -> str:
 Before starting any implementation task, load the `cq` skill and follow its Core Protocol.
 
 This runtime has no cq MCP server. The cq skill and `/cq-*` commands describe the protocol using
-MCP-tool wording; in this runtime, perform every cq action by running the cq CLI through your shell
-and parsing `--format json` output. The cq binary is: `{cq}`. Map each action:
+MCP-tool wording; in this runtime, perform every cq action by running the cq CLI through your shell.
+Parse `--format json` output for the commands that support it (query, propose, status); confirm and
+flag return plain text. The cq binary is: `{cq}`. Map each action:
 
 {mapping}
 

--- a/scripts/install/src/cq_install/hosts/pi.py
+++ b/scripts/install/src/cq_install/hosts/pi.py
@@ -1,0 +1,183 @@
+"""Pi (pi.dev) host adapter.
+
+Pi has no native MCP, so cq integrates via its standalone CLI: the cq block
+written into Pi's AGENTS.md maps each cq action to a `cq <verb> --format json`
+invocation the agent runs through its shell. The skill and commands are
+installed unchanged (commands only have their `name:` frontmatter stripped).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from cq_install.common import (
+    copy_tree,
+    remove_copied_tree,
+    remove_markdown_block,
+    upsert_markdown_block,
+)
+from cq_install.content import (
+    CQ_BLOCK_END,
+    CQ_BLOCK_START,
+    cq_binary_name,
+)
+from cq_install.context import Action, ChangeResult, InstallContext
+from cq_install.hosts.base import HostDef
+from cq_install.pi_commands import transform_command
+from cq_install.runtime import runtime_root
+
+PI_AGENTS_FILE = "AGENTS.md"
+PI_COMMANDS_DIR = "commands"
+PI_HOST_SKILLS_MANIFEST = ".cq-install-manifest.json"
+PI_PROMPTS_DIR = "prompts"
+PI_SKILLS_DIR = "skills"
+
+# Pi reads global config from ~/.pi/agent/ and per-project config from
+# <project>/.pi/ (note the asymmetry: global has an extra `agent` segment).
+PI_GLOBAL_TARGET = Path(".pi") / "agent"
+PI_PROJECT_TARGET = ".pi"
+
+
+class PiHost(HostDef):
+    """Adapter for the Pi coding agent."""
+
+    name = "pi"
+
+    def global_target(self) -> Path:
+        """Return the global Pi config dir (~/.pi/agent)."""
+        return Path.home() / PI_GLOBAL_TARGET
+
+    def install(self, ctx: InstallContext) -> list[ChangeResult]:
+        """Install cq into the Pi target."""
+        results: list[ChangeResult] = []
+        results.extend(self._install_skills(ctx))
+        results.extend(ctx.run_state.ensure_cq_binary(ctx))
+        results.extend(self._install_prompts(ctx))
+        results.append(self._install_agents_md(ctx))
+        return results
+
+    def project_target(self, project: Path) -> Path:
+        """Return the per-project Pi config dir (<project>/.pi)."""
+        return project / PI_PROJECT_TARGET
+
+    def uninstall(self, ctx: InstallContext) -> list[ChangeResult]:
+        """Remove cq from the Pi target."""
+        return [
+            remove_copied_tree(
+                ctx.target / PI_SKILLS_DIR,
+                manifest_name=PI_HOST_SKILLS_MANIFEST,
+                dry_run=ctx.dry_run,
+            ),
+            self._uninstall_prompts(ctx),
+            remove_markdown_block(
+                ctx.target / PI_AGENTS_FILE,
+                CQ_BLOCK_START,
+                CQ_BLOCK_END,
+                dry_run=ctx.dry_run,
+            ),
+        ]
+
+    def _install_agents_md(self, ctx: InstallContext) -> ChangeResult:
+        binary_path = runtime_root() / "bin" / cq_binary_name()
+        return upsert_markdown_block(
+            ctx.target / PI_AGENTS_FILE,
+            CQ_BLOCK_START,
+            CQ_BLOCK_END,
+            _agents_block(binary_path),
+            dry_run=ctx.dry_run,
+        )
+
+    def _install_prompts(self, ctx: InstallContext) -> list[ChangeResult]:
+        results: list[ChangeResult] = []
+        commands_src = ctx.plugin_root / PI_COMMANDS_DIR
+        prompts_dst = ctx.target / PI_PROMPTS_DIR
+        for cmd_file in sorted(commands_src.glob("*.md")):
+            transformed = transform_command(cmd_file.read_text())
+            target_file = prompts_dst / f"cq-{cmd_file.name}"
+            results.append(_write_text_idempotent(target_file, transformed, dry_run=ctx.dry_run))
+        return results
+
+    def _install_skills(self, ctx: InstallContext) -> list[ChangeResult]:
+        if ctx.host_isolated_skills:
+            return [
+                copy_tree(
+                    ctx.plugin_root / PI_SKILLS_DIR,
+                    ctx.target / PI_SKILLS_DIR,
+                    manifest_name=PI_HOST_SKILLS_MANIFEST,
+                    dry_run=ctx.dry_run,
+                )
+            ]
+        return ctx.run_state.ensure_shared_skills(ctx)
+
+    def _uninstall_prompts(self, ctx: InstallContext) -> ChangeResult:
+        commands_src = ctx.plugin_root / PI_COMMANDS_DIR
+        prompts_dst = ctx.target / PI_PROMPTS_DIR
+        removed = False
+        skipped = False
+        for cmd_file in sorted(commands_src.glob("*.md")):
+            target_file = prompts_dst / f"cq-{cmd_file.name}"
+            if not target_file.exists():
+                continue
+            expected = transform_command(cmd_file.read_text())
+            if target_file.read_text() != expected:
+                skipped = True
+                continue
+            if not ctx.dry_run:
+                target_file.unlink()
+            removed = True
+        if removed and prompts_dst.exists() and not any(prompts_dst.iterdir()) and not ctx.dry_run:
+            prompts_dst.rmdir()
+        if skipped:
+            return ChangeResult(
+                action=Action.SKIPPED,
+                path=prompts_dst,
+                detail="user-modified prompt files left in place",
+            )
+        return ChangeResult(
+            action=Action.REMOVED if removed else Action.UNCHANGED,
+            path=prompts_dst,
+        )
+
+
+def _agents_block(binary_path: Path) -> str:
+    cq = str(binary_path)
+    # Each mapping line is assembled from fragments so the source stays within
+    # the line-length limit; the rendered markdown line is intentionally long.
+    query = (
+        f"- query   -> `{cq} query --domain <d> [--domain <d> ...] "
+        "[--language <l>] [--framework <f>] [--pattern <p>] [--limit <n>] --format json`"
+    )
+    propose = (
+        f"- propose -> `{cq} propose --summary <s> --detail <d> --action <a> --domain <d> "
+        "[--domain <d> ...] [--language <l>] [--framework <f>] [--pattern <p>] --format json`"
+    )
+    confirm = f"- confirm -> `{cq} confirm <unit_id>`"
+    flag = (
+        f"- flag    -> `{cq} flag <unit_id> --reason <stale|incorrect|duplicate> "
+        "[--detail <text>] [--duplicate-of <id>]`"
+    )
+    status = f"- status  -> `{cq} status --format json`"
+    mapping = "\n".join([query, propose, confirm, flag, status])
+    return f"""{CQ_BLOCK_START}
+## CQ
+
+Before starting any implementation task, load the `cq` skill and follow its Core Protocol.
+
+This runtime has no cq MCP server. The cq skill and `/cq-*` commands describe the protocol using
+MCP-tool wording; in this runtime, perform every cq action by running the cq CLI through your shell
+and parsing `--format json` output. The cq binary is: `{cq}`. Map each action:
+
+{mapping}
+
+Repeat `--domain` once per tag.
+{CQ_BLOCK_END}"""
+
+
+def _write_text_idempotent(path: Path, content: str, *, dry_run: bool) -> ChangeResult:
+    if path.exists() and path.read_text() == content:
+        return ChangeResult(action=Action.UNCHANGED, path=path)
+    action = Action.UPDATED if path.exists() else Action.CREATED
+    if not dry_run:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+    return ChangeResult(action=action, path=path)

--- a/scripts/install/src/cq_install/pi_commands.py
+++ b/scripts/install/src/cq_install/pi_commands.py
@@ -1,0 +1,37 @@
+"""Pi command-file transform: strip `name:` frontmatter for Pi prompt files.
+
+Pi derives a prompt's command name from its filename, not from a `name:`
+frontmatter field, so the field is dropped. `description` is retained
+(Pi shows it in autocomplete). The body is left intact; the cq block in
+Pi's AGENTS.md redirects the body's MCP-tool wording to the cq CLI.
+"""
+
+from __future__ import annotations
+
+
+def transform_command(source: str) -> str:
+    """Return the Pi-flavored version of a Claude Code command file.
+
+    Drops the `name:` line from the YAML frontmatter. Returns the source
+    unchanged when there is no frontmatter or the frontmatter is unclosed.
+    """
+    lines = source.splitlines(keepends=True)
+    if not lines or lines[0].rstrip("\n") != "---":
+        return source
+
+    out: list[str] = [lines[0]]
+    in_frontmatter = True
+    closed = False
+    for line in lines[1:]:
+        if in_frontmatter and line.rstrip("\n") == "---":
+            out.append(line)
+            in_frontmatter = False
+            closed = True
+            continue
+        if in_frontmatter and line.startswith("name:"):
+            continue
+        out.append(line)
+
+    if not closed:
+        return source
+    return "".join(out)

--- a/scripts/install/src/cq_install/pi_commands.py
+++ b/scripts/install/src/cq_install/pi_commands.py
@@ -12,7 +12,9 @@ from __future__ import annotations
 def transform_command(source: str) -> str:
     """Return the Pi-flavored version of a Claude Code command file.
 
-    Drops the `name:` line from the YAML frontmatter. Returns the source
+    Drops the `name:` line from the YAML frontmatter and rewrites `/cq:`
+    slash-command references to `/cq-` so the body matches Pi's
+    filename-derived command names (e.g. `/cq-status`). Returns the source
     unchanged when there is no frontmatter or the frontmatter is unclosed.
     """
     lines = source.splitlines(keepends=True)
@@ -34,4 +36,4 @@ def transform_command(source: str) -> str:
 
     if not closed:
         return source
-    return "".join(out)
+    return "".join(out).replace("/cq:", "/cq-")

--- a/scripts/install/tests/test_hosts_pi.py
+++ b/scripts/install/tests/test_hosts_pi.py
@@ -1,0 +1,105 @@
+"""Tests for the Pi host install/uninstall flow."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from cq_install.content import cq_binary_name
+from cq_install.context import Action, InstallContext, RunState
+from cq_install.hosts.pi import PiHost
+from cq_install.runtime import runtime_root
+
+RUNTIME_BINARY = Path("bin") / cq_binary_name()
+
+
+def _ctx(tmp_path: Path, plugin_root: Path, *, host_isolated: bool = False) -> InstallContext:
+    target = tmp_path / "target"
+    target.mkdir(exist_ok=True)
+    return InstallContext(
+        target=target,
+        plugin_root=plugin_root,
+        shared_skills_path=tmp_path / "shared",
+        host_isolated_skills=host_isolated,
+        dry_run=False,
+        run_state=RunState(),
+    )
+
+
+def test_pi_global_target_default():
+    assert PiHost().global_target() == Path.home() / ".pi" / "agent"
+
+
+def test_pi_project_target():
+    assert PiHost().project_target(Path("/proj")) == Path("/proj") / ".pi"
+
+
+def test_pi_install_shared_skills_default(tmp_path, plugin_root):
+    ctx = _ctx(tmp_path, plugin_root, host_isolated=False)
+    PiHost().install(ctx)
+    assert (ctx.shared_skills_path / "cq" / "SKILL.md").exists()
+    assert not (ctx.target / "skills").exists()
+
+
+def test_pi_install_host_isolated_copies_skills_into_target(tmp_path, plugin_root):
+    ctx = _ctx(tmp_path, plugin_root, host_isolated=True)
+    PiHost().install(ctx)
+    assert (ctx.target / "skills" / "cq" / "SKILL.md").exists()
+
+
+def test_pi_install_writes_agents_block_with_cli_mapping(tmp_path, plugin_root):
+    ctx = _ctx(tmp_path, plugin_root)
+    PiHost().install(ctx)
+
+    text = (ctx.target / "AGENTS.md").read_text()
+    assert "<!-- cq:start -->" in text
+    assert "<!-- cq:end -->" in text
+    # Absolute binary path is embedded (do not assume cq is on PATH).
+    assert str(runtime_root() / RUNTIME_BINARY) in text
+    # All five verbs are mapped to the CLI.
+    for verb in ("query", "propose", "confirm", "flag", "status"):
+        assert f"{verb} " in text
+    assert "--format json" in text
+
+
+def test_pi_install_agents_block_idempotent(tmp_path, plugin_root):
+    PiHost().install(_ctx(tmp_path, plugin_root))
+    first = (tmp_path / "target" / "AGENTS.md").read_text()
+    PiHost().install(_ctx(tmp_path, plugin_root))
+    assert (tmp_path / "target" / "AGENTS.md").read_text() == first
+
+
+def test_pi_install_writes_prefixed_prompt_files(tmp_path, plugin_root):
+    ctx = _ctx(tmp_path, plugin_root)
+    PiHost().install(ctx)
+    prompts = ctx.target / "prompts"
+    assert (prompts / "cq-status.md").exists()
+    assert (prompts / "cq-reflect.md").exists()
+    # name: frontmatter stripped (Pi names commands from the filename).
+    assert "name: cq:status" not in (prompts / "cq-status.md").read_text()
+
+
+def test_pi_install_idempotent(tmp_path, plugin_root):
+    PiHost().install(_ctx(tmp_path, plugin_root))
+    second = PiHost().install(_ctx(tmp_path, plugin_root))
+    actions = [r.action for r in second]
+    assert all(a in (Action.UNCHANGED, Action.CREATED) for a in actions)
+    assert any(a == Action.UNCHANGED for a in actions)
+
+
+def test_pi_uninstall_removes_assets(tmp_path, plugin_root):
+    ctx = _ctx(tmp_path, plugin_root)
+    PiHost().install(ctx)
+    PiHost().uninstall(ctx)
+    assert not (ctx.target / "prompts" / "cq-status.md").exists()
+    text = (ctx.target / "AGENTS.md").read_text() if (ctx.target / "AGENTS.md").exists() else ""
+    assert "<!-- cq:start -->" not in text
+
+
+def test_pi_uninstall_preserves_user_edited_prompts(tmp_path, plugin_root):
+    ctx = _ctx(tmp_path, plugin_root)
+    PiHost().install(ctx)
+    prompt_file = ctx.target / "prompts" / "cq-status.md"
+    prompt_file.write_text("user-edited content\n")
+    PiHost().uninstall(ctx)
+    assert prompt_file.exists()
+    assert prompt_file.read_text() == "user-edited content\n"

--- a/scripts/install/tests/test_hosts_registry.py
+++ b/scripts/install/tests/test_hosts_registry.py
@@ -7,8 +7,14 @@ import pytest
 from cq_install.hosts import REGISTRY, HostDef, get_host
 
 
-def test_registry_lists_all_four_hosts():
-    assert set(REGISTRY) == {"cursor", "windsurf", "opencode", "claude"}
+def test_registry_lists_all_hosts():
+    assert set(REGISTRY) == {"cursor", "windsurf", "opencode", "claude", "pi"}
+
+
+def test_registry_includes_pi():
+    from cq_install.hosts.pi import PiHost
+
+    assert isinstance(get_host("pi"), PiHost)
 
 
 def test_get_host_returns_host_def():

--- a/scripts/install/tests/test_pi_commands.py
+++ b/scripts/install/tests/test_pi_commands.py
@@ -14,6 +14,15 @@ def test_transform_drops_name_frontmatter_keeps_description():
     assert out.startswith("---\n")
 
 
+def test_transform_rewrites_colon_command_refs_to_dash():
+    src = "---\nname: cq:status\ndescription: x\n---\n# /cq:status\nsee the /cq:reflect command\n"
+    out = transform_command(src)
+    assert "/cq-status" in out
+    assert "/cq-reflect" in out
+    assert "/cq:status" not in out
+    assert "/cq:reflect" not in out
+
+
 def test_transform_returns_source_when_no_frontmatter():
     src = "no frontmatter here\n"
     assert transform_command(src) == src

--- a/scripts/install/tests/test_pi_commands.py
+++ b/scripts/install/tests/test_pi_commands.py
@@ -1,0 +1,24 @@
+"""Tests for the Pi command-file transform."""
+
+from __future__ import annotations
+
+from cq_install.pi_commands import transform_command
+
+
+def test_transform_drops_name_frontmatter_keeps_description():
+    src = "---\nname: cq:status\ndescription: Show status.\n---\nbody line\n"
+    out = transform_command(src)
+    assert "name: cq:status" not in out
+    assert "description: Show status." in out
+    assert "body line" in out
+    assert out.startswith("---\n")
+
+
+def test_transform_returns_source_when_no_frontmatter():
+    src = "no frontmatter here\n"
+    assert transform_command(src) == src
+
+
+def test_transform_returns_source_when_frontmatter_unclosed():
+    src = "---\nname: cq:status\nbody without closing fence\n"
+    assert transform_command(src) == src


### PR DESCRIPTION
## What

Adds Pi (pi.dev) as a supported host in the `cq_install` framework, so `make install-pi` (and `cq_install --target pi`) wires cq into Pi.

Pi has no native MCP, so cq integrates via its CLI instead of an MCP server: a cq block in Pi's `AGENTS.md` maps each action to a `cq <verb> --format json` call, the skill installs unchanged, and the commands install as `/cq-status` and `/cq-reflect` prompt templates. No MCP, no third-party adapter, no extension.

## Why not a Pi extension?

Pi pushes extensions as its primary extension mechanism, but we deliberately chose the CLI + skill + AGENTS.md route:

- Pi extensions are proprietary to Pi, so that route locks us into Pi's `ExtensionAPI` and pulls away from the portable markdown + MCP that every other agent/IDE we support uses.
- It would be the only host integration where we maintain host-specific code; a Pi API change could break it, so it's ongoing brittleness we'd own.
- The CLI route reuses cq's existing, tested CLI — Pi just runs `cq ...` via its normal shell. An extension would be new TypeScript that ends up calling the same CLI anyway: more to maintain, no functional gain.
- It drops straight into the existing installer and matches how the other hosts work (skill + a cq block in `AGENTS.md`), so it's consistent and low-effort. (OpenCode already writes the `AGENTS.md` block too; Pi's just carries the extra CLI mapping since Pi has no MCP.)
- No publishing required — the installer writes files locally, same as the other hosts.
- Verified end-to-end in real Pi: skill loads, `/cq-status` runs, install/uninstall round-trips.

## Changes

- `PiHost` adapter plus a `name:`-stripping command transform; registered in the host registry.
- `make install-pi` / `uninstall-pi` targets, help block, and `install-all`; README and DEVELOPMENT docs.
- Re-sync `plugins/cq/uv.lock` (0.9.0 to 0.10.0) so `make lint` passes (separate first commit).

## Testing

- `make test-install`: 138 passed (13 new); `make lint-install` clean; plugin `uv lock --check` passes.
- Verified end-to-end in real Pi v0.78: install loads the skill, prompts, and AGENTS.md; `/cq-status` runs the CLI path; uninstall round-trips.

## Note

On uninstall the shared skill persists (it lives in the cross-agent `~/.agents/skills/`), matching the other hosts; use `--host-isolated-skills` for a Pi-private copy that uninstall removes.

