### PR TITLE
Guard Scoop autoupdate contract in CLI release workflows

### DIFF
--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -104,6 +104,9 @@ jobs:
         run: |
           OS="$(echo "$GOOS" | sed 's/./\U&/')"
 
+          # NOTE: the Windows archive names are a public contract for Scoop
+          # autoupdate; see the "Scoop autoupdate contract" check in
+          # validate-cli-release.yaml before renaming them.
           if [[ "$GOOS" == "windows" ]]; then
             ARCHIVE="cq_${OS}_${ARCHIVE_ARCH}.zip"
             zip -j "$ARCHIVE" cq.exe NOTICE README.md ../LICENSE
@@ -149,6 +152,21 @@ jobs:
       - name: Combine checksums
         working-directory: dist
         run: cat *.sha256 > checksums.txt && rm -f *.sha256
+
+      # Scoop autoupdate reads these exact artifacts from each release; see the
+      # "Scoop autoupdate contract" check in validate-cli-release.yaml for why.
+      # Fail loudly here against the real artifacts before they reach the release.
+      - name: Verify Scoop autoupdate artifacts
+        working-directory: dist
+        run: |
+          set -euo pipefail
+          for asset in cq_Windows_x86_64.zip cq_Windows_arm64.zip checksums.txt; do
+            if [[ ! -f "$asset" ]]; then
+              echo "::error::Missing $asset; Scoop autoupdate would stall. See validate-cli-release.yaml."
+              exit 1
+            fi
+          done
+          echo "Scoop autoupdate artifacts present"
 
       - name: Upload to release
         env:

--- a/.github/workflows/validate-cli-release.yaml
+++ b/.github/workflows/validate-cli-release.yaml
@@ -108,9 +108,14 @@ jobs:
             fi
           }
 
-          require "x86_64 Windows asset" "cq_\${OS}_\${ARCHIVE_ARCH}.zip"
-          require "checksums.txt artifact" "checksums.txt"
-          require "cli/vX.Y.Z tag pattern" "cli/v"
+          # Match the specific enforcement points, not incidental mentions:
+          # the single Windows archive template (covers both arches via the
+          # matrix), the checksums.txt generation, and the tag-validation regex
+          # (anchored ^cli/v, distinct from the cli/v examples in input
+          # descriptions and error strings).
+          require "Windows archive name template" "cq_\${OS}_\${ARCHIVE_ARCH}.zip"
+          require "checksums.txt generation" "> checksums.txt"
+          require "cli/vX.Y.Z tag-validation regex" "^cli/v"
 
           if [[ "$missing" -ne 0 ]]; then
             exit 1

--- a/.github/workflows/validate-cli-release.yaml
+++ b/.github/workflows/validate-cli-release.yaml
@@ -71,3 +71,49 @@ jobs:
             -output /dev/null
 
           echo "Brew template validated successfully"
+
+      # Scoop autoupdate contract.
+      #
+      # The CLI is distributed on Windows via Scoop's community "Main" bucket:
+      #   manifest:  https://github.com/ScoopInstaller/Main/blob/master/bucket/cq.json
+      #
+      # Unlike Homebrew (we own mozilla-ai/homebrew-tap and push cq.rb on every
+      # release), the Scoop manifest lives in a repo we do not own and updates
+      # itself: ScoopInstaller's Excavator workflow runs every ~4h, reads the
+      # manifest's checkver/autoupdate fields, and commits new versions directly.
+      #   excavator: https://github.com/ScoopInstaller/Main/blob/master/.github/workflows/excavator.yml
+      #
+      # That automation depends on three things release-cli.yaml must keep stable.
+      # If any drift, Scoop silently stops updating (the manifest just stalls)
+      # while Homebrew keeps working; an easy divergence to miss. This check
+      # fails the PR early if the release workflow stops honoring the contract:
+      #
+      #   1. tag scheme cli/vX.Y.Z      -> checkver regex "cli/v([\d.]+)"
+      #   2. asset names cq_Windows_*   -> autoupdate.architecture.*.url
+      #   3. a checksums.txt artifact   -> autoupdate.hash.url
+      #
+      # To change a Windows asset name or the checksums file, update cq.json in
+      # ScoopInstaller/Main in the same change, or Scoop autoupdate will break.
+      - name: Validate Scoop autoupdate contract
+        run: |
+          set -euo pipefail
+
+          workflow=.github/workflows/release-cli.yaml
+          missing=0
+
+          require() {
+            if ! grep -qF "$2" "$workflow"; then
+              echo "::error file=${workflow}::Scoop autoupdate contract broken: expected $1 ($2) not found. Update ScoopInstaller/Main bucket/cq.json to match, or Scoop autoupdate will silently stall."
+              missing=1
+            fi
+          }
+
+          require "x86_64 Windows asset" "cq_\${OS}_\${ARCHIVE_ARCH}.zip"
+          require "checksums.txt artifact" "checksums.txt"
+          require "cli/vX.Y.Z tag pattern" "cli/v"
+
+          if [[ "$missing" -ne 0 ]]; then
+            exit 1
+          fi
+
+          echo "Scoop autoupdate contract validated successfully"


### PR DESCRIPTION
The CLI is now installable on Windows via Scoop (ScoopInstaller/Main#8083). Unlike Homebrew, where we own mozilla-ai/homebrew-tap and push cq.rb on every release, the Scoop manifest lives in a repo we do not own and updates itself: ScoopInstaller's Excavator runs roughly every 4 hours, reads the manifest's checkver/autoupdate fields, and commits new versions directly. No push from us is needed.

That convenience comes with an implicit contract. Excavator keeps working only while release-cli.yaml keeps emitting the same Windows asset names (cq_Windows_x86_64.zip, cq_Windows_arm64.zip), a checksums.txt artifact, and cli/vX.Y.Z tags. If any of those drift, Scoop silently stops updating while Homebrew keeps working, which is easy to miss.

This PR makes that contract explicit and enforced:

- validate-cli-release.yaml gains a "Validate Scoop autoupdate contract" step beside the existing Homebrew validation. It is the single place documenting why Scoop is pull-based (with links to the manifest and the Excavator workflow) and statically fails a PR if release-cli.yaml drops any of the three contract points.
- release-cli.yaml gains a "Verify Scoop autoupdate artifacts" step in the publish job that asserts the real cq_Windows_*.zip and checksums.txt exist before upload, plus a pointer comment at the packaging step directing engineers to the explanation.

No behavior change to released artifacts; these are guardrails only.

Verification: make lint passes; the static check passes against current release-cli.yaml and correctly fails on a simulated asset rename.

Follow-up (not in this PR): Scoop's checkver regex "cli/v([\d.]+)" would mis-capture a pre-release tag like cli/v0.11.0-rc1 as 0.11.0. It lives in ScoopInstaller/Main, not here; worth a small upstream PR if we ever ship CLI pre-releases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release pipeline validation to verify that all expected artefacts, including Windows binaries and checksums, are present before publishing.
  * Added validation framework to maintain compatibility requirements with third-party package manager integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->