### PR TITLE
Align knowledge stats response shape on StoreStats vocabulary

### DIFF
--- a/schema/embed.go
+++ b/schema/embed.go
@@ -2,6 +2,7 @@ package cqschema
 
 import (
 	"bytes"
+
 	_ "embed"
 )
 

--- a/schema/embed_test.go
+++ b/schema/embed_test.go
@@ -26,7 +26,13 @@ func TestSchemaAccessorsReturnNonEmptyJSON(t *testing.T) {
 		require.NotEmpty(t, raw, "schema %s should be embedded", name)
 		var doc map[string]any
 		require.NoError(t, json.Unmarshal(raw, &doc), "schema %s should be valid JSON", name)
-		require.Equal(t, "https://json-schema.org/draft/2020-12/schema", doc["$schema"], "schema %s should declare draft 2020-12", name)
+		require.Equal(
+			t,
+			"https://json-schema.org/draft/2020-12/schema",
+			doc["$schema"],
+			"schema %s should declare draft 2020-12",
+			name,
+		)
 	}
 }
 

--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -443,7 +443,7 @@ func (c *Client) Status(ctx context.Context) (StoreStats, error) {
 	if c.remote != nil {
 		remote, err := c.remote.stats(ctx)
 		if err == nil {
-			for tier, count := range remote.Tiers {
+			for tier, count := range remote.TierCounts {
 				// The remote store should never report a "local" tier, but guard
 				// against it to prevent overwriting the local count we already set.
 				if tier == Local {
@@ -452,7 +452,7 @@ func (c *Client) Status(ctx context.Context) (StoreStats, error) {
 				stats.TierCounts[tier] = count
 				stats.TotalCount += count
 			}
-			for domain, count := range remote.Domains {
+			for domain, count := range remote.DomainCounts {
 				stats.DomainCounts[domain] += count
 			}
 		}

--- a/sdk/go/client_test.go
+++ b/sdk/go/client_test.go
@@ -704,9 +704,9 @@ func TestStatusWithRemoteMergesTierCounts(t *testing.T) {
 		if r.URL.Path == "/api/v1/knowledge/stats" && r.Method == "GET" {
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{
-				"total_units": 3,
-				"tiers":       map[string]int{"private": 3, "public": 0},
-				"domains":     map[string]int{"api": 2},
+				"total_count":   3,
+				"tier_counts":   map[string]int{"private": 3, "public": 0},
+				"domain_counts": map[string]int{"api": 2},
 			})
 			return
 		}
@@ -735,9 +735,9 @@ func TestStatusWithRemoteMergesDomainCounts(t *testing.T) {
 		if r.URL.Path == "/api/v1/knowledge/stats" && r.Method == "GET" {
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{
-				"total_units": 5,
-				"tiers":       map[string]int{"private": 5, "public": 0},
-				"domains":     map[string]int{"api": 3, "db": 2},
+				"total_count":   5,
+				"tier_counts":   map[string]int{"private": 5, "public": 0},
+				"domain_counts": map[string]int{"api": 3, "db": 2},
 			})
 			return
 		}
@@ -786,9 +786,9 @@ func TestStatusIgnoresLocalTierFromRemote(t *testing.T) {
 		if r.URL.Path == "/api/v1/knowledge/stats" && r.Method == "GET" {
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{
-				"total_units": 6,
-				"tiers":       map[string]int{"local": 1, "private": 4, "public": 1},
-				"domains":     map[string]int{},
+				"total_count":   6,
+				"tier_counts":   map[string]int{"local": 1, "private": 4, "public": 1},
+				"domain_counts": map[string]int{},
 			})
 			return
 		}

--- a/sdk/go/remote.go
+++ b/sdk/go/remote.go
@@ -275,10 +275,12 @@ func (r *remoteClient) query(ctx context.Context, params QueryParams) ([]Knowled
 }
 
 // remoteStatsResponse holds the server's knowledge stats response.
+// Its fields mirror the StoreStats wire vocabulary, the canonical
+// stats contract for cq-compatible servers.
 type remoteStatsResponse struct {
-	TotalUnits int            `json:"total_units"`
-	Tiers      map[Tier]int   `json:"tiers"`
-	Domains    map[string]int `json:"domains"`
+	TotalCount   int            `json:"total_count"`
+	DomainCounts map[string]int `json:"domain_counts"`
+	TierCounts   map[Tier]int   `json:"tier_counts"`
 }
 
 // stats fetches store statistics from the remote API.

--- a/sdk/go/remote_test.go
+++ b/sdk/go/remote_test.go
@@ -337,9 +337,9 @@ func TestRemoteStats(t *testing.T) {
 		require.Equal(t, "GET", r.Method)
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
-			"total_units": 5,
-			"tiers":       map[string]int{"private": 4, "public": 1},
-			"domains":     map[string]int{"api": 3, "db": 2},
+			"total_count":   5,
+			"tier_counts":   map[string]int{"private": 4, "public": 1},
+			"domain_counts": map[string]int{"api": 3, "db": 2},
 		})
 	}))
 	defer srv.Close()
@@ -347,9 +347,35 @@ func TestRemoteStats(t *testing.T) {
 	rc := newRemoteClient(srv.URL, "", 5*time.Second, staticResolver{})
 	rs, err := rc.stats(context.Background())
 	require.NoError(t, err)
-	require.Equal(t, 5, rs.TotalUnits)
-	require.Equal(t, map[Tier]int{Private: 4, Public: 1}, rs.Tiers)
-	require.Equal(t, map[string]int{"api": 3, "db": 2}, rs.Domains)
+	require.Equal(t, 5, rs.TotalCount)
+	require.Equal(t, map[Tier]int{Private: 4, Public: 1}, rs.TierCounts)
+	require.Equal(t, map[string]int{"api": 3, "db": 2}, rs.DomainCounts)
+}
+
+// TestRemoteStatsDecodesStoreStatsWireShape serves a body marshalled from
+// the public StoreStats type and decodes it through the remote client,
+// pinning the wire DTO to the StoreStats vocabulary so the two cannot drift.
+func TestRemoteStatsDecodesStoreStatsWireShape(t *testing.T) {
+	t.Parallel()
+	body := StoreStats{
+		TotalCount:   7,
+		DomainCounts: map[string]int{"api": 4, "ci": 3},
+		TierCounts:   map[Tier]int{Private: 6, Public: 1},
+	}
+	data, err := json.Marshal(body)
+	require.NoError(t, err)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(data)
+	}))
+	defer srv.Close()
+
+	rc := newRemoteClient(srv.URL, "", 5*time.Second, staticResolver{})
+	rs, statsErr := rc.stats(context.Background())
+	require.NoError(t, statsErr)
+	require.Equal(t, body.TotalCount, rs.TotalCount)
+	require.Equal(t, body.TierCounts, rs.TierCounts)
+	require.Equal(t, body.DomainCounts, rs.DomainCounts)
 }
 
 func TestRemoteStatsServerError(t *testing.T) {

--- a/sdk/python/src/cq/client.py
+++ b/sdk/python/src/cq/client.py
@@ -369,14 +369,14 @@ class Client:
         if self._http is not None:
             remote = self._remote_stats()
             if remote is not None:
-                for tier, count in remote.get("tiers", {}).items():
+                for tier, count in remote.get("tier_counts", {}).items():
                     # The remote store should never report a "local" tier, but guard
                     # against it to prevent overwriting the local count we already set.
                     if tier == Tier.LOCAL:
                         continue
                     stats.tier_counts[tier] = count
                     stats.total_count += count
-                for domain, count in remote.get("domains", {}).items():
+                for domain, count in remote.get("domain_counts", {}).items():
                     stats.domain_counts[domain] = stats.domain_counts.get(domain, 0) + count
 
         return stats

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -10,6 +10,7 @@ import pytest
 
 from cq.client import Client, FallbackError, RemoteError
 from cq.models import FlagReason, Tier
+from cq.store import StoreStats
 
 
 @pytest.fixture()
@@ -704,7 +705,7 @@ class TestRemoteIntegration:
         """status() merges local and remote tier counts."""
         httpx_mock.add_response(
             url=httpx.URL("http://test-remote/api/v1/knowledge/stats"),
-            json={"total_units": 3, "tiers": {"private": 3, "public": 0}, "domains": {}},
+            json={"total_count": 3, "tier_counts": {"private": 3, "public": 0}, "domain_counts": {}},
         )
 
         local_client = Client(local_db_path=tmp_path / "test.db")
@@ -724,9 +725,9 @@ class TestRemoteIntegration:
         httpx_mock.add_response(
             url=httpx.URL("http://test-remote/api/v1/knowledge/stats"),
             json={
-                "total_units": 5,
-                "tiers": {"private": 5, "public": 0},
-                "domains": {"api": 3, "db": 2},
+                "total_count": 5,
+                "tier_counts": {"private": 5, "public": 0},
+                "domain_counts": {"api": 3, "db": 2},
             },
         )
 
@@ -761,7 +762,7 @@ class TestRemoteIntegration:
         """status() ignores 'local' tier in remote response to prevent double-counting."""
         httpx_mock.add_response(
             url=httpx.URL("http://test-remote/api/v1/knowledge/stats"),
-            json={"total_units": 6, "tiers": {"local": 1, "private": 4, "public": 1}, "domains": {}},
+            json={"total_count": 6, "tier_counts": {"local": 1, "private": 4, "public": 1}, "domain_counts": {}},
         )
 
         local_client = Client(local_db_path=tmp_path / "test.db")
@@ -774,6 +775,35 @@ class TestRemoteIntegration:
         assert stats.tier_counts["private"] == 4
         assert stats.tier_counts["public"] == 1
         assert stats.total_count == 6
+        c.close()
+
+    def test_status_decodes_store_stats_wire_shape(self, tmp_path: Path, httpx_mock) -> None:
+        """status() decodes a remote body marshalled from the public StoreStats model.
+
+        Pins the wire contract to the StoreStats vocabulary so the remote
+        decoder and the public stats type cannot drift apart.
+        """
+        remote = StoreStats(
+            total_count=7,
+            domain_counts={"api": 4, "ci": 3},
+            tier_counts={"private": 6, "public": 1},
+        )
+        httpx_mock.add_response(
+            url=httpx.URL("http://test-remote/api/v1/knowledge/stats"),
+            json=remote.model_dump(mode="json"),
+        )
+
+        local_client = Client(local_db_path=tmp_path / "test.db")
+        local_client.propose(summary="S", detail="D", action="A", domains=["api"])
+        local_client.close()
+
+        c = Client(addr="http://test-remote", local_db_path=tmp_path / "test.db")
+        stats = c.status()
+        assert stats.tier_counts == {"local": 1, "private": 6, "public": 1}
+        assert stats.total_count == 8
+        # "api" appears locally (1) and remotely (4); counts must accumulate.
+        assert stats.domain_counts["api"] == 5
+        assert stats.domain_counts["ci"] == 3
         c.close()
 
     def test_flag_local_ignores_remote_rejection(self, tmp_path: Path, httpx_mock):
@@ -813,7 +843,7 @@ class TestClientApiBaseUrl:
             captured.append(request.url)
             return httpx.Response(
                 status_code=200,
-                json={"total_units": 0, "tiers": {}, "domains": {}},
+                json={"total_count": 0, "tier_counts": {}, "domain_counts": {}},
                 request=request,
             )
 
@@ -850,7 +880,7 @@ class TestClientApiBaseUrl:
             captured.append(request.url)
             return httpx.Response(
                 status_code=200,
-                json={"total_units": 0, "tiers": {}, "domains": {}},
+                json={"total_count": 0, "tier_counts": {}, "domain_counts": {}},
                 request=request,
             )
 

--- a/server/backend/src/cq_server/models/knowledge.py
+++ b/server/backend/src/cq_server/models/knowledge.py
@@ -30,8 +30,12 @@ class ProposeRequest(BaseModel):
 
 
 class StatsResponse(BaseModel):
-    """Response body for store statistics."""
+    """Response body for store statistics.
 
-    total_units: int
-    tiers: dict[str, int]
-    domains: dict[str, int]
+    Field names follow the canonical ``StoreStats`` wire vocabulary shared
+    with the SDK clients; renaming them is a breaking wire change.
+    """
+
+    total_count: int
+    tier_counts: dict[str, int]
+    domain_counts: dict[str, int]

--- a/server/backend/src/cq_server/services/knowledge.py
+++ b/server/backend/src/cq_server/services/knowledge.py
@@ -93,7 +93,7 @@ class KnowledgeService:
     async def stats(self) -> StatsResponse:
         """Return overall knowledge-store stats (totals, tiers, domains)."""
         return StatsResponse(
-            total_units=await self._knowledge.count(),
-            tiers=await self._knowledge.counts_by_tier(),
-            domains=await self._knowledge.domain_counts(),
+            total_count=await self._knowledge.count(),
+            tier_counts=await self._knowledge.counts_by_tier(),
+            domain_counts=await self._knowledge.domain_counts(),
         )

--- a/server/backend/tests/test_app.py
+++ b/server/backend/tests/test_app.py
@@ -6,10 +6,12 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from cq.store import StoreStats
 from fastapi.testclient import TestClient
 
 from cq_server.api.deps import require_api_key
 from cq_server.app import app
+from cq_server.repositories import ReviewRepository
 
 TEST_USERNAME = "test-user"
 
@@ -75,8 +77,6 @@ def _propose_payload(**overrides: Any) -> dict[str, Any]:
 
 def _approve_unit(client: TestClient, unit_id: str) -> None:
     """Approve a unit by writing the review row directly, bypassing the auth flow."""
-    from cq_server.repositories import ReviewRepository
-
     reviews = ReviewRepository(client.app.state.database)
     asyncio.run(reviews.set_status(unit_id, "approved", "test-reviewer"))
 
@@ -287,13 +287,11 @@ class TestStats:
         resp = client.get("/api/v1/knowledge/stats")
         assert resp.status_code == 200
         body = resp.json()
-        assert body["total_units"] == 0
-        assert body["tiers"] == {}
-        assert body["domains"] == {}
+        assert body["total_count"] == 0
+        assert body["tier_counts"] == {}
+        assert body["domain_counts"] == {}
 
     def test_stats_after_inserts(self, client: TestClient) -> None:
-        from cq_server.repositories import ReviewRepository
-
         r1 = client.post("/api/v1/knowledge", json=_propose_payload(domains=["api", "auth"]))
         r2 = client.post("/api/v1/knowledge", json=_propose_payload(domains=["api", "payments"]))
         reviews = ReviewRepository(client.app.state.database)
@@ -302,11 +300,25 @@ class TestStats:
         resp = client.get("/api/v1/knowledge/stats")
         assert resp.status_code == 200
         body = resp.json()
-        assert body["total_units"] == 2
-        assert body["tiers"] == {"private": 2}
-        assert body["domains"]["api"] == 2
-        assert body["domains"]["auth"] == 1
-        assert body["domains"]["payments"] == 1
+        assert body["total_count"] == 2
+        assert body["tier_counts"] == {"private": 2}
+        assert body["domain_counts"]["api"] == 2
+        assert body["domain_counts"]["auth"] == 1
+        assert body["domain_counts"]["payments"] == 1
+
+    def test_stats_body_decodes_as_store_stats(self, client: TestClient) -> None:
+        """The stats body validates against the SDK's public StoreStats model.
+
+        Pins the wire contract to the canonical StoreStats vocabulary so the
+        server response and the SDK decoders cannot drift apart.
+        """
+        created = client.post("/api/v1/knowledge", json=_propose_payload(domains=["api"]))
+        _approve_unit(client, created.json()["id"])
+        resp = client.get("/api/v1/knowledge/stats")
+        stats = StoreStats.model_validate(resp.json())
+        assert stats.total_count == 1
+        assert stats.tier_counts == {"private": 1}
+        assert stats.domain_counts == {"api": 1}
 
 
 class TestReviewLifecycleEndToEnd:
@@ -410,7 +422,7 @@ class TestEndToEnd:
 
         # Stats reflect the unit.
         resp = client.get("/api/v1/knowledge/stats")
-        assert resp.json()["total_units"] == 1
+        assert resp.json()["total_count"] == 1
 
 
 class TestDatabaseUrlBoot:


### PR DESCRIPTION
## Summary

Fixes the inconsistent knowledge-stats wire contract described in #394. The public `StoreStats` types use `total_count`/`domain_counts`/`tier_counts`, but the SDK remote decoders and the OSS server used `total_units`/`tiers`/`domains`. A cq-compatible remote whose `/knowledge/stats` body used the public field names decoded to all-zero in both SDKs, so remote counts silently vanished.

This makes `StoreStats` the canonical wire vocabulary on every side and makes `tier_counts` first-class, so a server returns its full per-tier breakdown in a single call.

## Changes

- **Go SDK** (`sdk/go/remote.go`, `client.go`): retag `remoteStatsResponse` to `total_count`/`domain_counts`/`tier_counts`; `Client.Status` reads the renamed fields.
- **Python SDK** (`sdk/python/src/cq/client.py`): `status()` reads `tier_counts`/`domain_counts`.
- **OSS server** (`models/knowledge.py`, `services/knowledge.py`): rename `StatsResponse` fields to match.
- **Drift tests**: each side decodes a `StoreStats`-shaped body end-to-end so the wire DTO and the public type cannot drift apart again.
- **Lint**: a small golangci-lint `--fix` cleanup of `schema/embed*.go` is bundled in to avoid a standalone CI run.

## Validation

- `make lint` clean; `make test` green (Go SDK, Python SDK 401 passed, server 281 passed, frontend 11 passed).
- pragma validators (security, state-machine, error-handling, go-effective, go-proverbs, python-style) pass with no HARD or SHOULD findings.

## Note on remote-failure handling

Both SDKs still treat a remote that fails or returns an unmappable body as "no remote data" with no log or warning, so a version-skewed (old-vocabulary) server would silently show local-only counts. That swallow is tracked separately in #395; whoever picks it up should ensure the warning also fires on a decoded-but-empty remote result, not just on transport/HTTP errors, or the masking #394 calls out will not surface.

Closes #394

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardised statistics API response field names across SDKs and server for improved consistency.
  * Updated test fixtures to align with revised statistics data structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->