### PR TITLE
status: surface remote stats failures and show per-tier counts

### DIFF
--- a/cli/cmd/status.go
+++ b/cli/cmd/status.go
@@ -6,6 +6,8 @@ import (
 	"sort"
 
 	"github.com/spf13/cobra"
+
+	cq "github.com/mozilla-ai/cq/sdk/go"
 )
 
 // NewStatusCmd returns the status command.
@@ -34,6 +36,10 @@ func NewStatusCmd() *cobra.Command {
 				return err
 			}
 
+			for _, w := range stats.Warnings {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: %s\n", w)
+			}
+
 			if format == "json" {
 				enc := json.NewEncoder(cmd.OutOrStdout())
 				enc.SetIndent("", jsonIndent)
@@ -43,6 +49,26 @@ func NewStatusCmd() *cobra.Command {
 
 			w := cmd.OutOrStdout()
 			_, _ = fmt.Fprintf(w, "Knowledge units: %d\n\n", stats.TotalCount)
+
+			// Render the per-tier split whenever any tier holds units, in
+			// canonical order, omitting empty tiers. Collecting the lines
+			// first avoids emitting a bare "By tier:" header for an empty
+			// store.
+			var tierLines []string
+			for _, tier := range []cq.Tier{cq.Local, cq.Private, cq.Public} {
+				if count := stats.TierCounts[tier]; count > 0 {
+					tierLines = append(tierLines, fmt.Sprintf("  %-20s %d", tier, count))
+				}
+			}
+
+			if len(tierLines) > 0 {
+				_, _ = fmt.Fprintln(w, "By tier:")
+				for _, line := range tierLines {
+					_, _ = fmt.Fprintln(w, line)
+				}
+
+				_, _ = fmt.Fprintln(w)
+			}
 
 			if len(stats.DomainCounts) > 0 {
 				_, _ = fmt.Fprintln(w, "Domains:")

--- a/cli/cmd/status_test.go
+++ b/cli/cmd/status_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -27,4 +28,51 @@ func TestStatusJSONFormat(t *testing.T) {
 	status.SetArgs([]string{"--format", "json"})
 	require.NoError(t, status.Execute())
 	require.Contains(t, buf.String(), `"total_count"`)
+}
+
+func TestStatusTextShowsTierBreakdown(t *testing.T) {
+	testSetup(t)
+	withFakeRemote(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"total_count":7,"tier_counts":{"private":4,"public":3},"domain_counts":{}}`))
+	}))
+
+	status := NewStatusCmd()
+	var out bytes.Buffer
+	status.SetOut(&out)
+	status.SetArgs([]string{})
+	require.NoError(t, status.Execute())
+
+	got := out.String()
+	require.Contains(t, got, "By tier:")
+	require.Contains(t, got, "private")
+	require.Contains(t, got, "public")
+	require.Contains(t, got, "Knowledge units: 7")
+}
+
+func TestStatusTextOmitsTierBreakdownWhenEmpty(t *testing.T) {
+	testSetup(t)
+
+	status := NewStatusCmd()
+	var out bytes.Buffer
+	status.SetOut(&out)
+	status.SetArgs([]string{})
+	require.NoError(t, status.Execute())
+	require.NotContains(t, out.String(), "By tier:")
+}
+
+func TestStatusWarnsOnRemoteFailure(t *testing.T) {
+	testSetup(t)
+	withFakeRemote(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+
+	status := NewStatusCmd()
+	var out, errBuf bytes.Buffer
+	status.SetOut(&out)
+	status.SetErr(&errBuf)
+	status.SetArgs([]string{})
+	require.NoError(t, status.Execute())
+	require.Contains(t, errBuf.String(), "warning:")
+	require.Contains(t, errBuf.String(), "remote stats unavailable")
 }

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -36,4 +36,4 @@ require (
 
 // Monorepo: the SDK is consumed locally. Re-pin to a published version
 // when the SDK is released alongside the CLI.
-//replace github.com/mozilla-ai/cq/sdk/go => ../sdk/go
+replace github.com/mozilla-ai/cq/sdk/go => ../sdk/go

--- a/plugins/cq/commands/status.md
+++ b/plugins/cq/commands/status.md
@@ -22,7 +22,7 @@ Present the results using this structure:
 ### Tier Counts
 local: {count} | private: {count} | public: {count}
 
-*local* = on this machine only; *private* = shared with everyone who can reach the same `CQ_ADDR`; *public* = open commons (not yet available).
+*local* = on this machine only; *private* = shared with everyone who can reach the same `CQ_ADDR`; *public* = the open commons, shared across every node that participates in it (available when your configured remote serves it).
 
 ### Domains
 {domain}: {count} | {domain}: {count} | ...
@@ -42,15 +42,14 @@ The `tier_counts` field contains the tier breakdown. Display all tiers present i
 
 The `recent` field reflects the local store only. When a remote is configured and reachable, units proposed via `Client.Propose` go directly to the remote and do not appear here. If `recent` is empty, render the section as `(no recent local additions)` so users understand the scope.
 
-If the response includes `promoted_to_remote`, add this line after the total count:
+If the `warnings` field is non-empty, surface each entry prominently above the summary so the counts are not mistaken for the full picture. A warning means stats aggregation degraded; for example, an unreachable or misconfigured remote, in which case the counts reflect the local store only:
 
 ```
-Promoted {promoted_to_remote} knowledge units to the remote store at startup.
+> ⚠️ {warning}
 ```
 
 ## Empty Store
 
-When all tier counts are 0 (or `tier_counts` is absent):
+When all tier counts are 0 (or `tier_counts` is absent), display only:
 
-- **With `promoted_to_remote`:** Show the header, tier counts line, and promotion line. Omit Domains, Recent Local Additions, and Confidence sections (there is no data to display).
-- **Without `promoted_to_remote`:** Display only: "The cq store is empty. Knowledge units are added via `propose` or the `/cq:reflect` command."
+"The cq store is empty. Knowledge units are added via `propose` or the `/cq:reflect` command."

--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -419,8 +419,10 @@ func (c *Client) Query(ctx context.Context, params QueryParams) (QueryResult, er
 
 // Status returns aggregated statistics about the knowledge store.
 // When a remote API is configured and reachable, tier counts include
-// both local and remote breakdowns. If the remote is unreachable,
-// only local counts are returned.
+// both local and remote breakdowns. If the remote stats request fails,
+// only local counts are returned, the failure is logged at warn level,
+// and a non-fatal entry is added to StoreStats.Warnings so callers can
+// distinguish an unreachable remote from a genuinely empty store.
 func (c *Client) Status(ctx context.Context) (StoreStats, error) {
 	ctx, cancel := c.operationContext(ctx)
 	defer cancel()
@@ -442,7 +444,14 @@ func (c *Client) Status(ctx context.Context) (StoreStats, error) {
 
 	if c.remote != nil {
 		remote, err := c.remote.stats(ctx)
-		if err == nil {
+		if err != nil {
+			// Surface the failure rather than silently reporting local-only
+			// counts that look identical to a genuinely empty store. Log to
+			// the client's logger (stderr, safe for the MCP stdout channel)
+			// and carry a warning to the caller.
+			c.logger.Warn("status: remote stats unavailable", "err", err)
+			stats.Warnings = append(stats.Warnings, fmt.Errorf("remote stats unavailable: %w", err))
+		} else {
 			for tier, count := range remote.TierCounts {
 				// The remote store should never report a "local" tier, but guard
 				// against it to prevent overwriting the local count we already set.

--- a/sdk/go/client_test.go
+++ b/sdk/go/client_test.go
@@ -1,9 +1,11 @@
 package cq
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -268,6 +270,51 @@ func TestStatus(t *testing.T) {
 	stats, err = c.Status(ctx)
 	require.NoError(t, err)
 	require.Equal(t, 1, stats.TotalCount)
+}
+
+func TestStatusAggregatesRemote(t *testing.T) {
+	c := newTestClientWithRemote(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"total_count":   3,
+			"tier_counts":   map[string]int{"private": 2, "public": 1},
+			"domain_counts": map[string]int{"api": 3},
+		})
+	}))
+
+	stats, err := c.Status(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, stats.Warnings)
+	require.Equal(t, 3, stats.TotalCount)
+	require.Equal(t, 2, stats.TierCounts[Private])
+	require.Equal(t, 1, stats.TierCounts[Public])
+	require.Equal(t, 3, stats.DomainCounts["api"])
+}
+
+func TestStatusWarnsOnRemoteFailure(t *testing.T) {
+	testClearEnv(t)
+	srv := httptest.NewServer(withDiscoveryNotFound(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	})))
+	t.Cleanup(srv.Close)
+
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	c, err := NewClient(WithAddr(srv.URL), WithLocalDBPath(dbPath), WithLogger(logger))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c.Close() })
+
+	// A failing remote must surface as a warning + log, not a silent
+	// local-only result indistinguishable from a genuinely empty store.
+	stats, err := c.Status(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 0, stats.TotalCount)
+	require.NotEmpty(t, stats.Warnings, "remote failure should surface as a warning")
+	require.Contains(t, stats.Warnings[0].Error(), "remote stats unavailable")
+	require.Contains(t, logBuf.String(), "remote stats unavailable")
 }
 
 func TestLifecycle(t *testing.T) {

--- a/sdk/go/types.go
+++ b/sdk/go/types.go
@@ -103,6 +103,11 @@ type StoreStats struct {
 	Recent                 []KnowledgeUnit `json:"recent"`
 	ConfidenceDistribution map[string]int  `json:"confidence_distribution"`
 	TierCounts             map[Tier]int    `json:"tier_counts"`
+
+	// Warnings collects non-fatal issues encountered while aggregating
+	// stats, such as a remote API being unreachable. When present, the
+	// reported counts reflect the local store only.
+	Warnings Warnings `json:"warnings,omitempty"`
 }
 
 type Warnings []error

--- a/sdk/python/src/cq/client.py
+++ b/sdk/python/src/cq/client.py
@@ -440,12 +440,16 @@ class Client:
 
         Raises:
             httpx.HTTPError: For transport-layer or HTTP status failures.
-            ValueError: If the response body is not valid JSON.
+            ValueError: If the response body is not a JSON object (invalid
+                JSON, or a valid non-object such as an array or string).
         """
         assert self._http is not None
         resp = self._http.get(f"{self._api_base_url()}/knowledge/stats")
         resp.raise_for_status()
-        return resp.json()
+        body = resp.json()
+        if not isinstance(body, dict):
+            raise ValueError("expected a JSON object from the knowledge stats endpoint")
+        return body
 
     def _remote_query(
         self,

--- a/sdk/python/src/cq/client.py
+++ b/sdk/python/src/cq/client.py
@@ -360,15 +360,25 @@ class Client:
         """Return knowledge store statistics with tier counts.
 
         When a remote API is configured and reachable, tier counts include
-        both local and remote breakdowns. If the remote is unreachable,
-        only local counts are returned.
+        both local and remote breakdowns. If the remote stats request fails,
+        only local counts are returned, the failure is logged at warn level,
+        and a non-fatal entry is added to ``StoreStats.warnings`` so callers
+        can distinguish an unreachable remote from a genuinely empty store.
         """
         stats = self._store.stats()
         stats.tier_counts = {Tier.LOCAL: stats.total_count}
 
         if self._http is not None:
-            remote = self._remote_stats()
-            if remote is not None:
+            try:
+                remote = self._remote_stats()
+            except (httpx.HTTPError, ValueError) as exc:
+                # Surface the failure rather than silently reporting local-only
+                # counts that look identical to a genuinely empty store. Log via
+                # the SDK logger (NullHandler by default, so MCP-over-stdio stays
+                # clean) and carry a warning to the caller.
+                self._logger.warning("Remote stats unavailable: %s", exc)
+                stats.warnings.append(f"Remote stats unavailable: {exc}")
+            else:
                 for tier, count in remote.get("tier_counts", {}).items():
                     # The remote store should never report a "local" tier, but guard
                     # against it to prevent overwriting the local count we already set.
@@ -422,19 +432,20 @@ class Client:
         assert self._addr is not None and self._resolver is not None
         return self._resolver.resolve(self._addr).api_base_url.rstrip("/")
 
-    def _remote_stats(self) -> dict | None:
+    def _remote_stats(self) -> dict:
         """Fetch store statistics from the remote API.
 
         Returns:
-            The stats dict on success, None on transport error.
+            The decoded stats dict on success.
+
+        Raises:
+            httpx.HTTPError: For transport-layer or HTTP status failures.
+            ValueError: If the response body is not valid JSON.
         """
         assert self._http is not None
-        try:
-            resp = self._http.get(f"{self._api_base_url()}/knowledge/stats")
-            resp.raise_for_status()
-            return resp.json()
-        except httpx.HTTPError:
-            return None
+        resp = self._http.get(f"{self._api_base_url()}/knowledge/stats")
+        resp.raise_for_status()
+        return resp.json()
 
     def _remote_query(
         self,

--- a/sdk/python/src/cq/store.py
+++ b/sdk/python/src/cq/store.py
@@ -57,6 +57,11 @@ class StoreStats(BaseModel):
     confidence_distribution: dict[str, int] = Field(default_factory=dict)
     tier_counts: dict[str, int] = Field(default_factory=dict)
 
+    # Non-fatal issues encountered while aggregating stats, such as a
+    # remote API being unreachable. When present, the reported counts
+    # reflect the local store only.
+    warnings: list[str] = Field(default_factory=list)
+
 
 _SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS knowledge_units (

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -779,6 +779,20 @@ class TestRemoteIntegration:
         assert any("unavailable" in w.lower() for w in stats.warnings)
         c.close()
 
+    def test_status_remote_non_object_body_surfaces_warning(self, tmp_path: Path, httpx_mock):
+        """A 2xx stats body that is valid JSON but not an object (e.g. a bare array)
+        must surface as a warning, not raise AttributeError from status()."""
+        httpx_mock.add_response(
+            url=httpx.URL("http://test-remote/api/v1/knowledge/stats"),
+            json=[1, 2, 3],
+        )
+
+        c = Client(addr="http://test-remote", local_db_path=tmp_path / "test.db")
+        stats = c.status()
+        assert stats.tier_counts == {"local": 0}
+        assert stats.warnings, "non-object stats body should surface as a warning"
+        c.close()
+
     def test_status_ignores_local_tier_from_remote(self, tmp_path: Path, httpx_mock):
         """status() ignores 'local' tier in remote response to prevent double-counting."""
         httpx_mock.add_response(

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -744,8 +744,9 @@ class TestRemoteIntegration:
         assert stats.domain_counts["db"] == 2
         c.close()
 
-    def test_status_remote_unreachable_returns_local_only(self, tmp_path: Path, httpx_mock):
-        """status() returns local-only tier counts when remote is unreachable."""
+    def test_status_remote_unreachable_surfaces_warning(self, tmp_path: Path, httpx_mock, caplog):
+        """A remote stats failure surfaces a warning + log, not a silent local-only result
+        indistinguishable from a genuinely empty store."""
         httpx_mock.add_exception(httpx.ConnectError("Connection refused"))
 
         local_client = Client(local_db_path=tmp_path / "test.db")
@@ -753,9 +754,29 @@ class TestRemoteIntegration:
         local_client.close()
 
         c = Client(addr="http://unreachable", local_db_path=tmp_path / "test.db")
-        stats = c.status()
+        with caplog.at_level(logging.WARNING, logger="cq.client"):
+            stats = c.status()
         assert stats.total_count == 1
         assert stats.tier_counts == {"local": 1}
+        assert stats.warnings, "remote failure should surface as a warning"
+        assert any("unavailable" in w.lower() for w in stats.warnings)
+        assert any("Remote stats unavailable" in r.message for r in caplog.records)
+        c.close()
+
+    def test_status_remote_http_error_surfaces_warning(self, tmp_path: Path, httpx_mock):
+        """A remote stats HTTP error (e.g. 401 from a misconfigured key) surfaces as a warning
+        rather than a silent local-only result."""
+        httpx_mock.add_response(
+            url=httpx.URL("http://test-remote/api/v1/knowledge/stats"),
+            json={"detail": "Invalid API key"},
+            status_code=401,
+        )
+
+        c = Client(addr="http://test-remote", local_db_path=tmp_path / "test.db")
+        stats = c.status()
+        assert stats.tier_counts == {"local": 0}
+        assert stats.warnings, "remote HTTP error should surface as a warning"
+        assert any("unavailable" in w.lower() for w in stats.warnings)
         c.close()
 
     def test_status_ignores_local_tier_from_remote(self, tmp_path: Path, httpx_mock):


### PR DESCRIPTION
## Summary

Both SDK clients aggregated remote knowledge-store stats only on the success path and silently discarded failures, so an unreachable, unauthorized, or unparseable remote produced a local-only/empty `cq status` that was indistinguishable from a genuinely empty store.

This makes the failure visible and, while in the status path, surfaces the per-tier breakdown the CLI already computed but never displayed.

## Changes

- **SDK (Go + Python):** `Status()`/`status()` now log a remote stats failure at warn level (stderr in Go, the SDK logger in Python; both safe for MCP-over-stdio) and attach a non-fatal entry to `StoreStats.Warnings`/`warnings`. `_remote_stats` (Python) now raises instead of swallowing.
- **CLI:** `cq status` prints stats warnings to stderr, and the text output now renders a `By tier:` block (local/private/public); previously only the combined total was shown. JSON mode already carried `tier_counts`/`warnings`.
- **/cq:status skill:** renders the `warnings` field, describes the public commons accurately (drops the stale "not yet available"), and removes the obsolete `promoted_to_remote` instruction.

## Notes

- Rebased onto #398, which aligned the stats wire vocabulary to `total_count`/`tier_counts`/`domain_counts`; the reconciled code uses those field names.
- `cli/go.mod` temporarily re-enables the local `replace` directive so the CLI builds against the unreleased SDK `Warnings` field. This must be reverted once the SDK is released and the CLI is re-pinned.

## Testing

- `make lint` and `make test` (Go SDK + CLI, Python backend, frontend) all pass.
- Added/updated tests: SDK warning + log on remote failure (transport and HTTP-status paths), CLI stderr warning, CLI tier breakdown rendering (and omission when empty).

Fixes #395


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Status command adds a “By tier:” breakdown showing Local, Private and Public counts (omits empty tiers).

* **Bug Fixes**
  * Remote statistics failures now surface non‑fatal warnings and clearly indicate counts reflect the local store only; warnings are emitted to standard error.

* **Documentation**
  * Status docs clarified tier definitions and when warnings are shown during stats aggregation issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->