### PR TITLE
status: type tier_counts keys as Tier and skip unknown tiers

### DIFF
--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -423,6 +423,9 @@ func (c *Client) Query(ctx context.Context, params QueryParams) (QueryResult, er
 // only local counts are returned, the failure is logged at warn level,
 // and a non-fatal entry is added to StoreStats.Warnings so callers can
 // distinguish an unreachable remote from a genuinely empty store.
+// A remote tier this SDK does not recognize is skipped and logged at
+// warn level, so its count is dropped from the totals rather than
+// carried as an unknown key.
 func (c *Client) Status(ctx context.Context) (StoreStats, error) {
 	ctx, cancel := c.operationContext(ctx)
 	defer cancel()
@@ -453,6 +456,14 @@ func (c *Client) Status(ctx context.Context) (StoreStats, error) {
 			stats.Warnings = append(stats.Warnings, fmt.Errorf("remote stats unavailable: %w", err))
 		} else {
 			for tier, count := range remote.TierCounts {
+				if !tier.Valid() {
+					// A tier this SDK does not recognize (e.g. a newer server).
+					// Skip it rather than carry an unknown key, and log so the
+					// dropped count is visible, not silent.
+					c.logger.Warn("status: ignoring unknown tier in remote stats", "tier", tier)
+
+					continue
+				}
 				// The remote store should never report a "local" tier, but guard
 				// against it to prevent overwriting the local count we already set.
 				if tier == Local {

--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -423,9 +423,9 @@ func (c *Client) Query(ctx context.Context, params QueryParams) (QueryResult, er
 // only local counts are returned, the failure is logged at warn level,
 // and a non-fatal entry is added to StoreStats.Warnings so callers can
 // distinguish an unreachable remote from a genuinely empty store.
-// A remote tier this SDK does not recognize is skipped and logged at
-// warn level, so its count is dropped from the totals rather than
-// carried as an unknown key.
+// A remote tier this SDK does not recognize is skipped, logged at warn
+// level, and recorded in StoreStats.Warnings, so its count is dropped
+// from the totals rather than carried as an unknown key.
 func (c *Client) Status(ctx context.Context) (StoreStats, error) {
 	ctx, cancel := c.operationContext(ctx)
 	defer cancel()
@@ -458,9 +458,11 @@ func (c *Client) Status(ctx context.Context) (StoreStats, error) {
 			for tier, count := range remote.TierCounts {
 				if !tier.Valid() {
 					// A tier this SDK does not recognize (e.g. a newer server).
-					// Skip it rather than carry an unknown key, and log so the
-					// dropped count is visible, not silent.
+					// Skip it rather than carry an unknown key. Log and surface
+					// a warning so the dropped count stays visible to callers
+					// even when the client logger is silenced.
 					c.logger.Warn("status: ignoring unknown tier in remote stats", "tier", tier)
+					stats.Warnings = append(stats.Warnings, fmt.Errorf("ignoring unknown remote stats tier %s", tier))
 
 					continue
 				}

--- a/sdk/go/client_test.go
+++ b/sdk/go/client_test.go
@@ -317,6 +317,37 @@ func TestStatusWarnsOnRemoteFailure(t *testing.T) {
 	require.Contains(t, logBuf.String(), "remote stats unavailable")
 }
 
+func TestStatusSkipsUnknownRemoteTier(t *testing.T) {
+	testClearEnv(t)
+	srv := httptest.NewServer(withDiscoveryNotFound(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"total_count":   13,
+			"tier_counts":   map[string]int{"private": 4, "team": 9},
+			"domain_counts": map[string]int{},
+		})
+	})))
+	t.Cleanup(srv.Close)
+
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	c, err := NewClient(WithAddr(srv.URL), WithLocalDBPath(dbPath), WithLogger(logger))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c.Close() })
+
+	// A tier the SDK does not recognize is dropped from the totals and logged,
+	// never carried as an unknown key.
+	stats, err := c.Status(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 4, stats.TotalCount, "only the known private tier counts toward the total")
+	require.Equal(t, 4, stats.TierCounts[Private])
+	require.NotContains(t, stats.TierCounts, Tier("team"))
+	require.Contains(t, logBuf.String(), "unknown tier")
+}
+
 func TestLifecycle(t *testing.T) {
 	c := newTestClient(t)
 	ctx := context.Background()

--- a/sdk/go/client_test.go
+++ b/sdk/go/client_test.go
@@ -338,14 +338,16 @@ func TestStatusSkipsUnknownRemoteTier(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = c.Close() })
 
-	// A tier the SDK does not recognize is dropped from the totals and logged,
-	// never carried as an unknown key.
+	// A tier the SDK does not recognize is dropped from the totals, logged, and
+	// surfaced as a warning; never carried as an unknown key.
 	stats, err := c.Status(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, 4, stats.TotalCount, "only the known private tier counts toward the total")
 	require.Equal(t, 4, stats.TierCounts[Private])
 	require.NotContains(t, stats.TierCounts, Tier("team"))
 	require.Contains(t, logBuf.String(), "unknown tier")
+	require.NotEmpty(t, stats.Warnings, "dropped tier should surface as a warning")
+	require.Contains(t, stats.Warnings[0].Error(), "team")
 }
 
 func TestLifecycle(t *testing.T) {

--- a/sdk/go/enums.go
+++ b/sdk/go/enums.go
@@ -72,6 +72,16 @@ func (t Tier) IsRemote() bool {
 	return t == Private || t == Public
 }
 
+// Valid reports whether t is a known tier.
+func (t Tier) Valid() bool {
+	switch t {
+	case Local, Private, Public:
+		return true
+	default:
+		return false
+	}
+}
+
 // String returns a comma-separated list of flag reasons.
 func (r FlagReasons) String() string {
 	names := make([]string, len(r))

--- a/sdk/go/enums_test.go
+++ b/sdk/go/enums_test.go
@@ -30,6 +30,30 @@ func TestTierIsRemote(t *testing.T) {
 	}
 }
 
+func TestTierValid(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		tier     Tier
+		expected bool
+	}{
+		{name: "local", tier: Local, expected: true},
+		{name: "private", tier: Private, expected: true},
+		{name: "public", tier: Public, expected: true},
+		{name: "empty string", tier: "", expected: false},
+		{name: "unknown value", tier: "team", expected: false},
+		{name: "legacy proto local", tier: "TIER_LOCAL", expected: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.expected, tc.tier.Valid())
+		})
+	}
+}
+
 func TestTierValues(t *testing.T) {
 	t.Parallel()
 

--- a/sdk/python/src/cq/client.py
+++ b/sdk/python/src/cq/client.py
@@ -366,8 +366,9 @@ class Client:
         can distinguish an unreachable remote from a genuinely empty store.
 
         Remote tier keys are coerced to ``Tier``; a tier this SDK does not
-        recognize is skipped and logged at warn level, so its count is dropped
-        from the totals rather than carried as a bare string.
+        recognize is skipped, logged at warn level, and recorded in
+        ``StoreStats.warnings``, so its count is dropped from the totals rather
+        than carried as a bare string.
         """
         stats = self._store.stats()
         stats.tier_counts = {Tier.LOCAL: stats.total_count}
@@ -388,9 +389,13 @@ class Client:
                         tier = Tier(tier_key)
                     except ValueError:
                         # A tier this SDK's enum does not know (e.g. a newer
-                        # server). Skip it rather than carry a bare string, and
-                        # log so the dropped count is visible, not silent.
-                        self._logger.warning("Ignoring unknown tier %r in remote stats", tier_key)
+                        # server). Skip it rather than carry a bare string. Log
+                        # and surface a warning so the dropped count stays
+                        # visible to callers even when the SDK logger is
+                        # silenced by the default NullHandler.
+                        message = f"Ignoring unknown tier {tier_key!r} in remote stats"
+                        self._logger.warning(message)
+                        stats.warnings.append(message)
                         continue
                     # The remote store should never report a "local" tier, but guard
                     # against it to prevent overwriting the local count we already set.

--- a/sdk/python/src/cq/client.py
+++ b/sdk/python/src/cq/client.py
@@ -364,6 +364,10 @@ class Client:
         only local counts are returned, the failure is logged at warn level,
         and a non-fatal entry is added to ``StoreStats.warnings`` so callers
         can distinguish an unreachable remote from a genuinely empty store.
+
+        Remote tier keys are coerced to ``Tier``; a tier this SDK does not
+        recognize is skipped and logged at warn level, so its count is dropped
+        from the totals rather than carried as a bare string.
         """
         stats = self._store.stats()
         stats.tier_counts = {Tier.LOCAL: stats.total_count}
@@ -379,7 +383,15 @@ class Client:
                 self._logger.warning("Remote stats unavailable: %s", exc)
                 stats.warnings.append(f"Remote stats unavailable: {exc}")
             else:
-                for tier, count in remote.get("tier_counts", {}).items():
+                for tier_key, count in remote.get("tier_counts", {}).items():
+                    try:
+                        tier = Tier(tier_key)
+                    except ValueError:
+                        # A tier this SDK's enum does not know (e.g. a newer
+                        # server). Skip it rather than carry a bare string, and
+                        # log so the dropped count is visible, not silent.
+                        self._logger.warning("Ignoring unknown tier %r in remote stats", tier_key)
+                        continue
                     # The remote store should never report a "local" tier, but guard
                     # against it to prevent overwriting the local count we already set.
                     if tier == Tier.LOCAL:

--- a/sdk/python/src/cq/store.py
+++ b/sdk/python/src/cq/store.py
@@ -18,7 +18,7 @@ from typing import Any
 from pydantic import BaseModel, Field
 
 from ._util import _as_list
-from .models import KnowledgeUnit
+from .models import KnowledgeUnit, Tier
 from .scoring import calculate_relevance
 
 logger = logging.getLogger(__name__)
@@ -55,7 +55,9 @@ class StoreStats(BaseModel):
     domain_counts: dict[str, int] = Field(default_factory=dict)
     recent: list[KnowledgeUnit] = Field(default_factory=list)
     confidence_distribution: dict[str, int] = Field(default_factory=dict)
-    tier_counts: dict[str, int] = Field(default_factory=dict)
+    # Keyed by Tier rather than str: the tiers are a closed set, and typing
+    # the keys keeps producers and consumers from drifting into bare strings.
+    tier_counts: dict[Tier, int] = Field(default_factory=dict)
 
     # Non-fatal issues encountered while aggregating stats, such as a
     # remote API being unreachable. When present, the reported counts

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -110,7 +110,7 @@ class TestLocalOnlyMode:
             domains=["api"],
         )
         stats = client.status()
-        assert stats.tier_counts == {"local": 1}
+        assert stats.tier_counts == {Tier.LOCAL: 1}
 
     def test_drain_raises_without_remote(self, client: Client):
         with pytest.raises(RuntimeError, match="No remote API configured"):
@@ -714,9 +714,9 @@ class TestRemoteIntegration:
 
         c = Client(addr="http://test-remote", local_db_path=tmp_path / "test.db")
         stats = c.status()
-        assert stats.tier_counts["local"] == 1
-        assert stats.tier_counts["private"] == 3
-        assert stats.tier_counts["public"] == 0
+        assert stats.tier_counts[Tier.LOCAL] == 1
+        assert stats.tier_counts[Tier.PRIVATE] == 3
+        assert stats.tier_counts[Tier.PUBLIC] == 0
         assert stats.total_count == 4
         c.close()
 
@@ -757,7 +757,7 @@ class TestRemoteIntegration:
         with caplog.at_level(logging.WARNING, logger="cq.client"):
             stats = c.status()
         assert stats.total_count == 1
-        assert stats.tier_counts == {"local": 1}
+        assert stats.tier_counts == {Tier.LOCAL: 1}
         assert stats.warnings, "remote failure should surface as a warning"
         assert any("unavailable" in w.lower() for w in stats.warnings)
         assert any("Remote stats unavailable" in r.message for r in caplog.records)
@@ -774,7 +774,7 @@ class TestRemoteIntegration:
 
         c = Client(addr="http://test-remote", local_db_path=tmp_path / "test.db")
         stats = c.status()
-        assert stats.tier_counts == {"local": 0}
+        assert stats.tier_counts == {Tier.LOCAL: 0}
         assert stats.warnings, "remote HTTP error should surface as a warning"
         assert any("unavailable" in w.lower() for w in stats.warnings)
         c.close()
@@ -789,7 +789,7 @@ class TestRemoteIntegration:
 
         c = Client(addr="http://test-remote", local_db_path=tmp_path / "test.db")
         stats = c.status()
-        assert stats.tier_counts == {"local": 0}
+        assert stats.tier_counts == {Tier.LOCAL: 0}
         assert stats.warnings, "non-object stats body should surface as a warning"
         c.close()
 
@@ -806,17 +806,18 @@ class TestRemoteIntegration:
 
         c = Client(addr="http://test-remote", local_db_path=tmp_path / "test.db")
         stats = c.status()
-        assert stats.tier_counts["local"] == 1
-        assert stats.tier_counts["private"] == 4
-        assert stats.tier_counts["public"] == 1
+        assert stats.tier_counts[Tier.LOCAL] == 1
+        assert stats.tier_counts[Tier.PRIVATE] == 4
+        assert stats.tier_counts[Tier.PUBLIC] == 1
         assert stats.total_count == 6
         c.close()
 
     def test_status_skips_and_logs_unknown_remote_tier(
         self, tmp_path: Path, httpx_mock, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """A remote tier this SDK's enum does not know is skipped and logged,
-        not carried as a bare-string key nor summed into the total."""
+        """A remote tier this SDK's enum does not know is skipped, logged, and
+        surfaced as a warning; not carried as a bare-string key nor summed into
+        the total."""
         httpx_mock.add_response(
             url=httpx.URL("http://test-remote/api/v1/knowledge/stats"),
             json={"total_count": 13, "tier_counts": {"private": 4, "team": 9}, "domain_counts": {}},
@@ -829,6 +830,7 @@ class TestRemoteIntegration:
         assert all(isinstance(key, Tier) for key in stats.tier_counts)
         assert stats.total_count == 4  # local 0 + private 4; unknown 'team' dropped
         assert any("team" in record.message for record in caplog.records)
+        assert any("team" in warning for warning in stats.warnings)
         c.close()
 
     def test_status_decodes_store_stats_wire_shape(self, tmp_path: Path, httpx_mock) -> None:
@@ -853,7 +855,7 @@ class TestRemoteIntegration:
 
         c = Client(addr="http://test-remote", local_db_path=tmp_path / "test.db")
         stats = c.status()
-        assert stats.tier_counts == {"local": 1, "private": 6, "public": 1}
+        assert stats.tier_counts == {Tier.LOCAL: 1, Tier.PRIVATE: 6, Tier.PUBLIC: 1}
         assert stats.total_count == 8
         # "api" appears locally (1) and remotely (4); counts must accumulate.
         assert stats.domain_counts["api"] == 5

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -812,6 +812,25 @@ class TestRemoteIntegration:
         assert stats.total_count == 6
         c.close()
 
+    def test_status_skips_and_logs_unknown_remote_tier(
+        self, tmp_path: Path, httpx_mock, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A remote tier this SDK's enum does not know is skipped and logged,
+        not carried as a bare-string key nor summed into the total."""
+        httpx_mock.add_response(
+            url=httpx.URL("http://test-remote/api/v1/knowledge/stats"),
+            json={"total_count": 13, "tier_counts": {"private": 4, "team": 9}, "domain_counts": {}},
+        )
+
+        c = Client(addr="http://test-remote", local_db_path=tmp_path / "test.db")
+        with caplog.at_level(logging.WARNING, logger="cq.client"):
+            stats = c.status()
+        assert stats.tier_counts == {Tier.LOCAL: 0, Tier.PRIVATE: 4}
+        assert all(isinstance(key, Tier) for key in stats.tier_counts)
+        assert stats.total_count == 4  # local 0 + private 4; unknown 'team' dropped
+        assert any("team" in record.message for record in caplog.records)
+        c.close()
+
     def test_status_decodes_store_stats_wire_shape(self, tmp_path: Path, httpx_mock) -> None:
         """status() decodes a remote body marshalled from the public StoreStats model.
 


### PR DESCRIPTION
## Summary

`StoreStats.tier_counts` keys are a closed set (local/private/public), but the type didn't express that: Python typed it `dict[str, int]` and `status()` built a mixed-key dict (seeded with a `Tier` enum member, then merged with plain-string keys from the decoded remote body). This types the keys as `Tier` and decides how an unrecognized tier is handled.

## Changes

- **Python:** `StoreStats.tier_counts` is now `dict[Tier, int]`; `status()` coerces each remote tier key to `Tier` at the merge boundary.
- **Go:** `StoreStats.TierCounts` was already `map[Tier]int` but unmarshalled any string without validation; added `Tier.Valid()` and guard `Status()` with it.
- **Unknown tiers (the decision the issue asked to resolve):** a tier this SDK's enum does not recognize is skipped and logged at warn level, so its count is dropped from the totals rather than carried as a bare-string key. Visible, not silent.

## Out of scope (per the issue)

The headline total is `local + Σ(remote tier_counts)` and never reads the remote body's `total_count`; the issue defers that to the stats-contract docs, so it's untouched here.

## Testing

- `make lint` and `make test` (Go SDK + CLI, Python backend, frontend) all pass.
- Added: a `Tier.Valid()` table test (Go), and unknown-tier skip+log tests asserting the dropped count and `Tier`-typed keys (Go + Python).
- The Go change is non-breaking (`TierCounts` was already `map[Tier]int`), so the CLI builds against the released SDK v0.10.0 with no `replace` change.

Fixes #403


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Remote tier counts are now filtered to include only recognised tiers (unknown tiers are logged and excluded from totals), and status totals use enum-typed tier keys for consistency.

* **Documentation**
  * Client status behaviour now documents that unknown remote tier keys are skipped and recorded as warnings.

* **Tests**
  * Added tests in both SDKs verifying unknown remote tiers are logged and ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->