### PR TITLE
docs: add Pi agent configuration

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -184,6 +184,16 @@ Add to `~/.config/opencode/opencode.json` or your project-level config, in the M
 }
 ```
 
+### Pi
+
+Add to `~/.pi/agent/settings.json` under `shellCommandPrefix`:
+
+```json
+{
+  "shellCommandPrefix": "export CQ_ADDR='http://localhost:3000'"
+}
+```
+
 ## Configuration
 
 cq works out of the box in local-only mode with no configuration. Set environment variables to customize the local store path or connect to a remote API.


### PR DESCRIPTION
## Summary
- document how to set CQ_ADDR for Pi via shellCommandPrefix

## Testing
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for configuring Pi agent settings, including instructions for setting the `CQ_ADDR` environment variable to point to a local API instance. Configuration details now include a JSON snippet example for agent settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->