### PR TITLE
fix(cli): prevent stack overflow in `prompt <sub> --help`

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -78,8 +78,16 @@ func newRootCmd() *cobra.Command {
 	return rootCmd
 }
 
-// hideFlagsFor hides the persistent client flags on the named subcommands.
+// hideFlagsFor hides the persistent client flags on the named subcommands and
+// their descendants.
+//
+// NOTE: the help func must delegate to the captured default renderer, not to
+// c.Parent().HelpFunc(). Cobra resolves HelpFunc by walking up the parent
+// chain, so a descendant of a named command resolves back to this very
+// closure; delegating through the parent would recurse without bound.
 func hideFlagsFor(root *cobra.Command, names ...string) {
+	defaultHelp := root.HelpFunc()
+
 	hidden := make(map[string]bool, len(names))
 	for _, n := range names {
 		hidden[n] = true
@@ -94,7 +102,7 @@ func hideFlagsFor(root *cobra.Command, names ...string) {
 					}
 				}
 
-				c.Parent().HelpFunc()(c, args)
+				defaultHelp(c, args)
 			})
 		}
 	}

--- a/cli/main_test.go
+++ b/cli/main_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// helpSubprocessEnv triggers the in-process help rendering used by
+// TestPromptHelpDoesNotRecurse when set on the re-executed test binary.
+const helpSubprocessEnv = "CQ_HELP_SUBPROCESS_ARGS"
+
+// TestPromptHelpDoesNotRecurse guards against the help-func recursion that
+// caused `cq prompt <sub> --help` to stack overflow.
+//
+// The crash is a fatal runtime error that recover cannot catch, so each case
+// renders help in a re-executed subprocess: a regression aborts that child
+// with a non-zero exit instead of taking down the whole test process.
+func TestPromptHelpDoesNotRecurse(t *testing.T) {
+	if args := os.Getenv(helpSubprocessEnv); args != "" {
+		rootCmd := newRootCmd()
+		rootCmd.SetArgs([]string{"prompt", args, "--help"})
+		_ = rootCmd.Execute()
+
+		return
+	}
+
+	for _, sub := range []string{"skill", "reflect"} {
+		t.Run(sub, func(t *testing.T) {
+			cmd := exec.Command(os.Args[0], "-test.run=^TestPromptHelpDoesNotRecurse$")
+			cmd.Env = append(os.Environ(), helpSubprocessEnv+"="+sub)
+
+			out, err := cmd.CombinedOutput()
+			require.NoErrorf(t, err, "rendering `prompt %s --help` crashed:\n%s", sub, out)
+			require.Contains(t, string(out), "cq prompt "+sub)
+		})
+	}
+}

--- a/cli/main_test.go
+++ b/cli/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"testing"
@@ -22,7 +23,13 @@ func TestPromptHelpDoesNotRecurse(t *testing.T) {
 	if args := os.Getenv(helpSubprocessEnv); args != "" {
 		rootCmd := newRootCmd()
 		rootCmd.SetArgs([]string{"prompt", args, "--help"})
-		_ = rootCmd.Execute()
+
+		// Exit non-zero on any render error so the parent's exit-status check
+		// catches it, not only the fatal stack overflow this test guards.
+		if err := rootCmd.Execute(); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
 
 		return
 	}


### PR DESCRIPTION
## Problem
`cq prompt skill --help` and `cq prompt reflect --help` crash with `fatal error: stack overflow`.

## Root cause
`hideFlagsFor` set a custom cobra `HelpFunc` on `prompt` that delegated via `c.Parent().HelpFunc()(c, args)`. Cobra resolves `HelpFunc()` by walking up the parent chain, so the closure set on `prompt` is also the resolved help func for its subcommands. Rendering help for a subcommand ran the closure with `c=<sub>`, whose `c.Parent()` is `prompt`, whose `HelpFunc()` returns that same closure — unbounded recursion.

It was invisible on `prompt --help` because there `c.Parent()` is the root, whose default help func renders normally; the recursion only triggers for descendants.

## Fix
Capture the default renderer once (`defaultHelp := root.HelpFunc()`) and call it from the closure instead of re-resolving through the parent chain. Flag-hiding behavior is unchanged.

## Testing
- New regression test `TestPromptHelpDoesNotRecurse` renders both subcommands' help in a re-executed subprocess (the crash is a fatal error `recover()` can't catch). Verified it fails before the fix and passes after.
- `make lint-cli test-cli` — clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where requesting help for nested subcommands could recurse indefinitely, preventing help output from appearing.

* **Tests**
  * Added automated checks to ensure help output for nested subcommands is rendered correctly and does not trigger infinite recursion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->