### PR TITLE
status: surface remote confidence_distribution in status() and label its scope

### DIFF
--- a/cli/cmd/status.go
+++ b/cli/cmd/status.go
@@ -4,11 +4,16 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/spf13/cobra"
 
 	cq "github.com/mozilla-ai/cq/sdk/go"
 )
+
+// maxDisplayDomains caps how many domains the text view lists inline before
+// truncating the remainder.
+const maxDisplayDomains = 8
 
 // NewStatusCmd returns the status command.
 func NewStatusCmd() *cobra.Command {
@@ -70,22 +75,6 @@ func NewStatusCmd() *cobra.Command {
 				_, _ = fmt.Fprintln(w)
 			}
 
-			if len(stats.DomainCounts) > 0 {
-				_, _ = fmt.Fprintln(w, "Domains:")
-
-				domains := make([]string, 0, len(stats.DomainCounts))
-				for d := range stats.DomainCounts {
-					domains = append(domains, d)
-				}
-
-				sort.Strings(domains)
-				for _, d := range domains {
-					_, _ = fmt.Fprintf(w, "  %-20s %d\n", d, stats.DomainCounts[d])
-				}
-
-				_, _ = fmt.Fprintln(w)
-			}
-
 			if len(stats.Recent) > 0 {
 				_, _ = fmt.Fprintln(w, "Recent:")
 				for _, ku := range stats.Recent {
@@ -96,10 +85,47 @@ func NewStatusCmd() *cobra.Command {
 			}
 
 			if len(stats.ConfidenceDistribution) > 0 {
-				_, _ = fmt.Fprintln(w, "Confidence distribution:")
-				for _, b := range []string{"[0.0-0.3)", "[0.3-0.5)", "[0.5-0.7)", "[0.7-1.0]"} {
+				_, _ = fmt.Fprintln(w, "Confidence distribution (excludes public commons):")
+				for _, b := range cq.ConfidenceBucketLabels() {
 					_, _ = fmt.Fprintf(w, "  %-10s %d\n", b, stats.ConfidenceDistribution[b])
 				}
+			}
+
+			// Domains are the least important section, so they sit last and
+			// stay compact: a count, then the most-tagged few inline with the
+			// remainder truncated.
+			if len(stats.DomainCounts) > 0 {
+				domains := make([]string, 0, len(stats.DomainCounts))
+				for d := range stats.DomainCounts {
+					domains = append(domains, d)
+				}
+				// Most-tagged first; ties broken alphabetically.
+				sort.Slice(domains, func(i, j int) bool {
+					if ci, cj := stats.DomainCounts[domains[i]], stats.DomainCounts[domains[j]]; ci != cj {
+						return ci > cj
+					}
+
+					return domains[i] < domains[j]
+				})
+
+				shown := domains
+				if len(shown) > maxDisplayDomains {
+					shown = shown[:maxDisplayDomains]
+				}
+
+				parts := make([]string, len(shown))
+				for i, d := range shown {
+					parts[i] = fmt.Sprintf("%s (%d)", d, stats.DomainCounts[d])
+				}
+
+				line := strings.Join(parts, ", ")
+				if remaining := len(domains) - len(shown); remaining > 0 {
+					line += fmt.Sprintf(" ... +%d more", remaining)
+				}
+
+				_, _ = fmt.Fprintln(w)
+				_, _ = fmt.Fprintf(w, "Domains: %d total\n", len(stats.DomainCounts))
+				_, _ = fmt.Fprintf(w, "  %s\n", line)
 			}
 
 			return nil

--- a/cli/cmd/status_test.go
+++ b/cli/cmd/status_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -59,6 +60,29 @@ func TestStatusTextOmitsTierBreakdownWhenEmpty(t *testing.T) {
 	status.SetArgs([]string{})
 	require.NoError(t, status.Execute())
 	require.NotContains(t, out.String(), "By tier:")
+}
+
+func TestStatusTextShowsCompactDomainsAfterConfidence(t *testing.T) {
+	testSetup(t)
+	withFakeRemote(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"total_count":23,"tier_counts":{"private":23},` +
+			`"domain_counts":{"a":5,"b":4,"c":3,"d":3,"e":2,"f":2,"g":1,"h":1,"i":1,"j":1}}`))
+	}))
+
+	status := NewStatusCmd()
+	var out bytes.Buffer
+	status.SetOut(&out)
+	status.SetArgs([]string{})
+	require.NoError(t, status.Execute())
+
+	got := out.String()
+	require.Contains(t, got, "Domains: 10 total")
+	require.Contains(t, got, "a (5)")       // most-tagged shown first
+	require.Contains(t, got, "... +2 more") // 10 distinct, 8 shown, 2 truncated
+	require.NotContains(t, got, ", ... +")  // no trailing comma before the ellipsis
+	// Domains are the least important section, so they sit last.
+	require.Less(t, strings.Index(got, "Confidence distribution"), strings.Index(got, "Domains:"))
 }
 
 func TestStatusWarnsOnRemoteFailure(t *testing.T) {

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -36,4 +36,4 @@ require (
 
 // Monorepo: the SDK is consumed locally. Re-pin to a published version
 // when the SDK is released alongside the CLI.
-//replace github.com/mozilla-ai/cq/sdk/go => ../sdk/go
+replace github.com/mozilla-ai/cq/sdk/go => ../sdk/go

--- a/cli/mcpserver/status.go
+++ b/cli/mcpserver/status.go
@@ -12,7 +12,7 @@ import (
 func StatusTool() mcp.Tool {
 	return mcp.NewTool("status",
 		mcp.WithDescription(
-			"Show knowledge store statistics: tier counts and domain counts aggregated across local and remote, plus recent additions and confidence distribution (local only).",
+			"Show knowledge store statistics: tier counts, domain counts, and confidence distribution aggregated across local and the remote's private/org units (excludes the public commons), plus recent additions.",
 		),
 	)
 }

--- a/plugins/cq/commands/status.md
+++ b/plugins/cq/commands/status.md
@@ -37,14 +37,15 @@ local: {count} | private: {count} | public: {count}
 ■ 0.0-0.3: {count} units
 
 ### Domains
-{distinct count} total — {domain} ({count}), {domain} ({count}), ... +{remaining} more
+{distinct count} total
+{domain} ({count}), {domain} ({count}) ... +{remaining} more
 ```
 
 The `tier_counts` field contains the tier breakdown. Display all tiers present in the response. Omit tiers with a count of 0.
 
 The `recent` field reflects the local store only. When a remote is configured and reachable, units proposed via `Client.Propose` go directly to the remote and do not appear here. If `recent` is empty, render the section as `(no recent local additions)` so users understand the scope.
 
-The `domain_counts` field maps each domain to its unit count. Domains are the least important section, so render them last and keep them compact: lead with the number of distinct domains, then the most-tagged few inline as `{domain} ({count})` (highest count first, ties alphabetical), capped at 8. If more than 8 exist, append ` ... +{remaining} more`; do not leave a trailing comma before the ellipsis.
+The `domain_counts` field maps each domain to its unit count. Domains are the least important section, so render them last and keep them compact: a `{distinct count} total` line, then the most-tagged few on the next line as `{domain} ({count})` (highest count first, ties alphabetical), capped at 8. If more than 8 exist, append the truncation marker after a single space, e.g. `{domain} ({count}) ... +{remaining} more`; do not leave a trailing comma before it.
 
 If the `warnings` field is non-empty, surface each entry prominently above the summary so the counts are not mistaken for the full picture. A warning means stats aggregation degraded; for example, an unreachable or misconfigured remote, in which case the counts reflect the local store only:
 

--- a/plugins/cq/commands/status.md
+++ b/plugins/cq/commands/status.md
@@ -24,23 +24,27 @@ local: {count} | private: {count} | public: {count}
 
 *local* = on this machine only; *private* = shared with everyone who can reach the same `CQ_ADDR`; *public* = the open commons, shared across every node that participates in it (available when your configured remote serves it).
 
-### Domains
-{domain}: {count} | {domain}: {count} | ...
-
 ### Recent Local Additions
 - {id}: "{summary}" ({relative time})
 - ...
 
 ### Confidence Distribution
+*(covers local plus your private/org units; excludes the public commons)*
+
 ■ 0.7-1.0: {count} units
 ■ 0.5-0.7: {count} units
 ■ 0.3-0.5: {count} units
 ■ 0.0-0.3: {count} units
+
+### Domains
+{distinct count} total — {domain} ({count}), {domain} ({count}), ... +{remaining} more
 ```
 
 The `tier_counts` field contains the tier breakdown. Display all tiers present in the response. Omit tiers with a count of 0.
 
 The `recent` field reflects the local store only. When a remote is configured and reachable, units proposed via `Client.Propose` go directly to the remote and do not appear here. If `recent` is empty, render the section as `(no recent local additions)` so users understand the scope.
+
+The `domain_counts` field maps each domain to its unit count. Domains are the least important section, so render them last and keep them compact: lead with the number of distinct domains, then the most-tagged few inline as `{domain} ({count})` (highest count first, ties alphabetical), capped at 8. If more than 8 exist, append ` ... +{remaining} more`; do not leave a trailing comma before the ellipsis.
 
 If the `warnings` field is non-empty, surface each entry prominently above the summary so the counts are not mistaken for the full picture. A warning means stats aggregation degraded; for example, an unreachable or misconfigured remote, in which case the counts reflect the local store only:
 

--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -426,6 +426,11 @@ func (c *Client) Query(ctx context.Context, params QueryParams) (QueryResult, er
 // A remote tier this SDK does not recognize is skipped, logged at warn
 // level, and recorded in StoreStats.Warnings, so its count is dropped
 // from the totals rather than carried as an unknown key.
+//
+// ConfidenceDistribution sums the local buckets with the remote's reported
+// buckets (the caller's private/org units), so it covers everything except
+// the public commons. A remote bucket label this SDK does not recognize is
+// skipped, logged, and recorded in StoreStats.Warnings.
 func (c *Client) Status(ctx context.Context) (StoreStats, error) {
 	ctx, cancel := c.operationContext(ctx)
 	defer cancel()
@@ -476,6 +481,22 @@ func (c *Client) Status(ctx context.Context) (StoreStats, error) {
 			}
 			for domain, count := range remote.DomainCounts {
 				stats.DomainCounts[domain] += count
+			}
+			for label, count := range remote.ConfidenceDistribution {
+				if _, ok := confidenceBuckets[label]; !ok {
+					// A bucket label this SDK does not recognize (e.g. a newer
+					// server). Skip it rather than carry an unknown key. Log and
+					// surface a warning so the dropped count stays visible to
+					// callers even when the client logger is silenced.
+					c.logger.Warn("status: ignoring unknown confidence bucket in remote stats", "bucket", label)
+					stats.Warnings = append(
+						stats.Warnings,
+						fmt.Errorf("ignoring unknown remote confidence bucket %s", label),
+					)
+
+					continue
+				}
+				stats.ConfidenceDistribution[label] += count
 			}
 		}
 	}

--- a/sdk/go/client_test.go
+++ b/sdk/go/client_test.go
@@ -842,6 +842,72 @@ func TestStatusWithRemoteMergesDomainCounts(t *testing.T) {
 	require.Equal(t, 2, stats.DomainCounts["db"])
 }
 
+func TestStatusWithRemoteMergesConfidenceDistribution(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/knowledge/stats" && r.Method == "GET" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"total_count":             5,
+				"tier_counts":             map[string]int{"private": 5, "public": 0},
+				"domain_counts":           map[string]int{},
+				"confidence_distribution": map[string]int{"0.5-0.7": 3, "0.7-1.0": 1},
+			})
+
+			return
+		}
+		// Propose unreachable — forces local fallback.
+		w.WriteHeader(http.StatusServiceUnavailable)
+	})
+	c := newTestClientWithRemote(t, handler)
+	ctx := context.Background()
+
+	// Local unit sits at the default 0.5 confidence, sharing the "0.5-0.7"
+	// bucket with the remote so we can verify accumulation.
+	_, err := c.Propose(ctx, ProposeParams{
+		Summary: "Local", Detail: "D.", Action: "A.", Domains: []string{"api"},
+	})
+	var fb *FallbackError
+	require.ErrorAs(t, err, &fb)
+
+	stats, err := c.Status(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 4, stats.ConfidenceDistribution["0.5-0.7"], "local 1 + remote 3")
+	require.Equal(t, 1, stats.ConfidenceDistribution["0.7-1.0"])
+}
+
+func TestStatusSkipsUnknownRemoteConfidenceBucket(t *testing.T) {
+	testClearEnv(t)
+	srv := httptest.NewServer(withDiscoveryNotFound(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"total_count":             5,
+			"tier_counts":             map[string]int{"private": 5},
+			"domain_counts":           map[string]int{},
+			"confidence_distribution": map[string]int{"0.5-0.7": 3, "0.5-0.9": 2},
+		})
+	})))
+	t.Cleanup(srv.Close)
+
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	c, err := NewClient(WithAddr(srv.URL), WithLocalDBPath(dbPath), WithLogger(logger))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c.Close() })
+
+	// A bucket label the SDK does not recognize is dropped, logged, and surfaced
+	// as a warning; never carried as an unknown key.
+	stats, err := c.Status(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 3, stats.ConfidenceDistribution["0.5-0.7"])
+	require.NotContains(t, stats.ConfidenceDistribution, "0.5-0.9")
+	require.Contains(t, logBuf.String(), "unknown confidence bucket")
+	require.NotEmpty(t, stats.Warnings, "dropped bucket should surface as a warning")
+	require.Contains(t, stats.Warnings[0].Error(), "0.5-0.9")
+}
+
 func TestStatusRemoteUnreachableStillReturnsLocal(t *testing.T) {
 	testClearEnv(t)
 	dbPath := filepath.Join(t.TempDir(), "test.db")

--- a/sdk/go/remote.go
+++ b/sdk/go/remote.go
@@ -278,9 +278,10 @@ func (r *remoteClient) query(ctx context.Context, params QueryParams) ([]Knowled
 // Its fields mirror the StoreStats wire vocabulary, the canonical
 // stats contract for cq-compatible servers.
 type remoteStatsResponse struct {
-	TotalCount   int            `json:"total_count"`
-	DomainCounts map[string]int `json:"domain_counts"`
-	TierCounts   map[Tier]int   `json:"tier_counts"`
+	TotalCount             int            `json:"total_count"`
+	DomainCounts           map[string]int `json:"domain_counts"`
+	TierCounts             map[Tier]int   `json:"tier_counts"`
+	ConfidenceDistribution map[string]int `json:"confidence_distribution"`
 }
 
 // stats fetches store statistics from the remote API.

--- a/sdk/go/store.go
+++ b/sdk/go/store.go
@@ -1,6 +1,7 @@
 package cq
 
 import (
+	"cmp"
 	"database/sql"
 	"encoding/json"
 	"errors"
@@ -56,6 +57,17 @@ const (
 	keyLastWriteAt = "last_write_at"
 )
 
+// confidenceBuckets are the canonical confidence-distribution buckets, ordered
+// low to high by upper bound. The labels are the wire contract shared with the
+// server and the other SDKs; keep them aligned so a remote distribution merges
+// without drift.
+var confidenceBuckets = map[string]float64{
+	"0.0-0.3": 0.3,
+	"0.3-0.5": 0.5,
+	"0.5-0.7": 0.7,
+	"0.7-1.0": math.Inf(1),
+}
+
 // errClosed is returned when an operation is attempted on a closed store.
 var errClosed = errors.New("store is closed")
 
@@ -70,6 +82,22 @@ type localStore struct {
 type storeQueryResult struct {
 	KUs      []KnowledgeUnit
 	Warnings []error
+}
+
+// ConfidenceBucketLabels returns the canonical confidence-distribution bucket
+// labels in ascending order by upper bound. Display and bucketing code should
+// use this rather than hardcoding labels, so order and spelling stay tied to
+// StoreStats output.
+func ConfidenceBucketLabels() []string {
+	labels := make([]string, 0, len(confidenceBuckets))
+	for label := range confidenceBuckets {
+		labels = append(labels, label)
+	}
+	slices.SortFunc(labels, func(a, b string) int {
+		return cmp.Compare(confidenceBuckets[a], confidenceBuckets[b])
+	})
+
+	return labels
 }
 
 // newLocalStore opens or creates a local store at the given path.
@@ -504,23 +532,12 @@ func (s *localStore) stats(recentLimit int) (StoreStats, error) {
 		return StoreStats{}, fmt.Errorf("iterating recent rows: %w", err)
 	}
 
-	// Confidence distribution.
-	buckets := map[string]int{
-		"[0.0-0.3)": 0,
-		"[0.3-0.5)": 0,
-		"[0.5-0.7)": 0,
-		"[0.7-1.0]": 0,
-	}
-
-	type bucket struct {
-		label string
-		upper float64
-	}
-	boundaries := []bucket{
-		{"[0.0-0.3)", 0.3},
-		{"[0.3-0.5)", 0.5},
-		{"[0.5-0.7)", 0.7},
-		{"[0.7-1.0]", math.Inf(1)},
+	// Confidence distribution. Iterate labels low to high so the first bound
+	// that exceeds a unit's confidence is its bucket.
+	orderedLabels := ConfidenceBucketLabels()
+	buckets := make(map[string]int, len(confidenceBuckets))
+	for label := range confidenceBuckets {
+		buckets[label] = 0
 	}
 
 	allRows, err := s.db.Query("SELECT data FROM knowledge_units")
@@ -539,9 +556,9 @@ func (s *localStore) stats(recentLimit int) (StoreStats, error) {
 			return StoreStats{}, fmt.Errorf("unmarshalling confidence unit: %w", err)
 		}
 		conf := ku.Evidence.Confidence
-		for _, b := range boundaries {
-			if conf < b.upper {
-				buckets[b.label]++
+		for _, label := range orderedLabels {
+			if conf < confidenceBuckets[label] {
+				buckets[label]++
 				break
 			}
 		}
@@ -583,6 +600,15 @@ func applyPragmas(db *sql.DB) error {
 	return nil
 }
 
+// ensureMetadata creates the metadata table and stamps the writer.
+func ensureMetadata(db *sql.DB) error {
+	if _, err := db.Exec(metadataDDL); err != nil {
+		return fmt.Errorf("creating metadata table: %w", err)
+	}
+
+	return stampWriter(db)
+}
+
 // insertDomains writes domain rows for a unit within an existing transaction.
 func insertDomains(tx *sql.Tx, unitID string, domains []string) error {
 	stmt, err := tx.Prepare("INSERT INTO knowledge_unit_domains (unit_id, domain) VALUES (?, ?)")
@@ -615,6 +641,11 @@ func insertFTS(tx *sql.Tx, ku KnowledgeUnit) error {
 	return nil
 }
 
+// marshalUnit serialises a KnowledgeUnit to JSON for SQLite storage.
+func marshalUnit(ku KnowledgeUnit) ([]byte, error) {
+	return json.Marshal(ku)
+}
+
 // normalizeDomains lowercases, trims whitespace, drops empties, and deduplicates preserving order.
 func normalizeDomains(domains []string) []string {
 	seen := make(map[string]struct{}, len(domains))
@@ -635,35 +666,6 @@ func normalizeDomains(domains []string) []string {
 	return result
 }
 
-// marshalUnit serialises a KnowledgeUnit to JSON for SQLite storage.
-func marshalUnit(ku KnowledgeUnit) ([]byte, error) {
-	return json.Marshal(ku)
-}
-
-// unmarshalUnit deserialises a KnowledgeUnit from JSON.
-func unmarshalUnit(data []byte) (KnowledgeUnit, error) {
-	var ku KnowledgeUnit
-	if err := json.Unmarshal(data, &ku); err != nil {
-		return KnowledgeUnit{}, err
-	}
-	return ku, nil
-}
-
-// writerTag returns a User-Agent style identifier for this SDK.
-func writerTag() string {
-	goVer := strings.TrimPrefix(runtime.Version(), "go")
-	return fmt.Sprintf("cq-go-sdk/%s go/%s", version.Version(), goVer)
-}
-
-// ensureMetadata creates the metadata table and stamps the writer.
-func ensureMetadata(db *sql.DB) error {
-	if _, err := db.Exec(metadataDDL); err != nil {
-		return fmt.Errorf("creating metadata table: %w", err)
-	}
-
-	return stampWriter(db)
-}
-
 // stampWriter updates the last_writer and last_write_at metadata.
 func stampWriter(db *sql.DB) error {
 	now := time.Now().UTC().Format(time.RFC3339)
@@ -680,4 +682,19 @@ func stampWriter(db *sql.DB) error {
 		}
 	}
 	return nil
+}
+
+// unmarshalUnit deserialises a KnowledgeUnit from JSON.
+func unmarshalUnit(data []byte) (KnowledgeUnit, error) {
+	var ku KnowledgeUnit
+	if err := json.Unmarshal(data, &ku); err != nil {
+		return KnowledgeUnit{}, err
+	}
+	return ku, nil
+}
+
+// writerTag returns a User-Agent style identifier for this SDK.
+func writerTag() string {
+	goVer := strings.TrimPrefix(runtime.Version(), "go")
+	return fmt.Sprintf("cq-go-sdk/%s go/%s", version.Version(), goVer)
 }

--- a/sdk/go/store.go
+++ b/sdk/go/store.go
@@ -57,10 +57,11 @@ const (
 	keyLastWriteAt = "last_write_at"
 )
 
-// confidenceBuckets are the canonical confidence-distribution buckets, ordered
-// low to high by upper bound. The labels are the wire contract shared with the
-// server and the other SDKs; keep them aligned so a remote distribution merges
-// without drift.
+// confidenceBuckets maps each canonical confidence-distribution label to its
+// exclusive upper bound. The unbracketed labels are the wire contract shared
+// with the server and the other SDKs; keep them aligned so a remote
+// distribution merges without drift. Use ConfidenceBucketLabels() for the
+// labels in ascending order.
 var confidenceBuckets = map[string]float64{
 	"0.0-0.3": 0.3,
 	"0.3-0.5": 0.5,

--- a/sdk/go/store_test.go
+++ b/sdk/go/store_test.go
@@ -12,6 +12,11 @@ import (
 	_ "modernc.org/sqlite"
 )
 
+func TestConfidenceBucketLabels(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, []string{"0.0-0.3", "0.3-0.5", "0.5-0.7", "0.7-1.0"}, ConfidenceBucketLabels())
+}
+
 func newTestStore(t *testing.T) *localStore {
 	t.Helper()
 
@@ -776,10 +781,10 @@ func TestStats(t *testing.T) {
 
 		stats, err := s.stats(10)
 		require.NoError(t, err)
-		require.Equal(t, 2, stats.ConfidenceDistribution["[0.0-0.3)"])
-		require.Equal(t, 1, stats.ConfidenceDistribution["[0.3-0.5)"])
-		require.Equal(t, 1, stats.ConfidenceDistribution["[0.5-0.7)"])
-		require.Equal(t, 2, stats.ConfidenceDistribution["[0.7-1.0]"])
+		require.Equal(t, 2, stats.ConfidenceDistribution["0.0-0.3"])
+		require.Equal(t, 1, stats.ConfidenceDistribution["0.3-0.5"])
+		require.Equal(t, 1, stats.ConfidenceDistribution["0.5-0.7"])
+		require.Equal(t, 2, stats.ConfidenceDistribution["0.7-1.0"])
 	})
 }
 

--- a/sdk/go/store_test.go
+++ b/sdk/go/store_test.go
@@ -773,7 +773,9 @@ func TestStats(t *testing.T) {
 		t.Parallel()
 		s := newTestStore(t)
 
-		for _, conf := range []float64{0.1, 0.2, 0.4, 0.6, 0.8, 0.95} {
+		// Includes the exact bucket boundaries (0.3, 0.5, 0.7) to pin the
+		// strict-< edge: a value equal to a boundary lands in the next bucket up.
+		for _, conf := range []float64{0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.95} {
 			ku := newFakeKU(t, []string{"api"})
 			ku.Evidence.Confidence = conf
 			require.NoError(t, s.insert(ku))
@@ -781,10 +783,10 @@ func TestStats(t *testing.T) {
 
 		stats, err := s.stats(10)
 		require.NoError(t, err)
-		require.Equal(t, 2, stats.ConfidenceDistribution["0.0-0.3"])
-		require.Equal(t, 1, stats.ConfidenceDistribution["0.3-0.5"])
-		require.Equal(t, 1, stats.ConfidenceDistribution["0.5-0.7"])
-		require.Equal(t, 2, stats.ConfidenceDistribution["0.7-1.0"])
+		require.Equal(t, 2, stats.ConfidenceDistribution["0.0-0.3"]) // 0.1, 0.2
+		require.Equal(t, 2, stats.ConfidenceDistribution["0.3-0.5"]) // 0.3, 0.4
+		require.Equal(t, 2, stats.ConfidenceDistribution["0.5-0.7"]) // 0.5, 0.6
+		require.Equal(t, 3, stats.ConfidenceDistribution["0.7-1.0"]) // 0.7, 0.8, 0.95
 	})
 }
 

--- a/sdk/go/types.go
+++ b/sdk/go/types.go
@@ -98,11 +98,25 @@ type QueryResult struct {
 
 // StoreStats holds aggregated statistics about the knowledge store.
 type StoreStats struct {
-	TotalCount             int             `json:"total_count"`
-	DomainCounts           map[string]int  `json:"domain_counts"`
-	Recent                 []KnowledgeUnit `json:"recent"`
-	ConfidenceDistribution map[string]int  `json:"confidence_distribution"`
-	TierCounts             map[Tier]int    `json:"tier_counts"`
+	// TotalCount is the number of knowledge units across the local store
+	// and any units a configured remote reports.
+	TotalCount int `json:"total_count"`
+
+	// DomainCounts is the per-domain unit count, summing the local store
+	// with any units a configured remote reports.
+	DomainCounts map[string]int `json:"domain_counts"`
+
+	// Recent holds the most recently confirmed units from the local store.
+	Recent []KnowledgeUnit `json:"recent"`
+
+	// ConfidenceDistribution covers the local store plus any private/org
+	// units a configured remote reports; it excludes the public commons.
+	// Keys are the canonical bucket labels (see confidenceBuckets).
+	ConfidenceDistribution map[string]int `json:"confidence_distribution"`
+
+	// TierCounts is the unit count per tier: the local total plus any
+	// private/public totals a configured remote reports.
+	TierCounts map[Tier]int `json:"tier_counts"`
 
 	// Warnings collects non-fatal issues encountered while aggregating
 	// stats, such as a remote API being unreachable. When present, the

--- a/sdk/python/src/cq/client.py
+++ b/sdk/python/src/cq/client.py
@@ -356,6 +356,22 @@ class Client:
             return result
         raise KeyError(f"Remote unreachable; cannot flag unit: {unit_id}")
 
+    def _stats_section(self, remote: dict, key: str, stats: StoreStats) -> dict:
+        """Return ``remote[key]`` when it is a mapping, else warn and return empty.
+
+        A remote that omits a section is fine (treated as empty). One that sends
+        a non-object section (e.g. ``null`` or a list) degrades to local-only
+        counts for that section with a warning, rather than raising and losing
+        the whole status.
+        """
+        value = remote.get(key, {})
+        if isinstance(value, dict):
+            return value
+        message = f"Ignoring non-object {key!r} in remote stats"
+        self._logger.warning(message)
+        stats.warnings.append(message)
+        return {}
+
     def status(self) -> StoreStats:
         """Return knowledge store statistics with tier counts.
 
@@ -393,7 +409,7 @@ class Client:
                 self._logger.warning("Remote stats unavailable: %s", exc)
                 stats.warnings.append(f"Remote stats unavailable: {exc}")
             else:
-                for tier_key, count in remote.get("tier_counts", {}).items():
+                for tier_key, count in self._stats_section(remote, "tier_counts", stats).items():
                     try:
                         tier = Tier(tier_key)
                     except ValueError:
@@ -412,9 +428,9 @@ class Client:
                         continue
                     stats.tier_counts[tier] = count
                     stats.total_count += count
-                for domain, count in remote.get("domain_counts", {}).items():
+                for domain, count in self._stats_section(remote, "domain_counts", stats).items():
                     stats.domain_counts[domain] = stats.domain_counts.get(domain, 0) + count
-                for label, count in remote.get("confidence_distribution", {}).items():
+                for label, count in self._stats_section(remote, "confidence_distribution", stats).items():
                     if label not in known_buckets:
                         # A bucket label this SDK does not recognize (e.g. a
                         # newer server). Skip it rather than carry an unknown

--- a/sdk/python/src/cq/client.py
+++ b/sdk/python/src/cq/client.py
@@ -369,9 +369,18 @@ class Client:
         recognize is skipped, logged at warn level, and recorded in
         ``StoreStats.warnings``, so its count is dropped from the totals rather
         than carried as a bare string.
+
+        ``confidence_distribution`` sums the local buckets with the remote's
+        reported buckets (the caller's private/org units), so it covers
+        everything except the public commons. Local and remote share the
+        canonical bucket labels; a label this SDK does not recognize is
+        skipped, logged, and recorded in ``StoreStats.warnings``.
         """
         stats = self._store.stats()
         stats.tier_counts = {Tier.LOCAL: stats.total_count}
+        # The local store seeds every canonical bucket, so its keys are the
+        # label set a remote distribution must match to merge.
+        known_buckets = set(stats.confidence_distribution)
 
         if self._http is not None:
             try:
@@ -405,6 +414,18 @@ class Client:
                     stats.total_count += count
                 for domain, count in remote.get("domain_counts", {}).items():
                     stats.domain_counts[domain] = stats.domain_counts.get(domain, 0) + count
+                for label, count in remote.get("confidence_distribution", {}).items():
+                    if label not in known_buckets:
+                        # A bucket label this SDK does not recognize (e.g. a
+                        # newer server). Skip it rather than carry an unknown
+                        # key. Log and surface a warning so the dropped count
+                        # stays visible even when the SDK logger is silenced by
+                        # the default NullHandler.
+                        message = f"Ignoring unknown confidence bucket {label!r} in remote stats"
+                        self._logger.warning(message)
+                        stats.warnings.append(message)
+                        continue
+                    stats.confidence_distribution[label] = stats.confidence_distribution.get(label, 0) + count
 
         return stats
 

--- a/sdk/python/src/cq/store.py
+++ b/sdk/python/src/cq/store.py
@@ -26,7 +26,10 @@ logger = logging.getLogger(__name__)
 # Sort fallback for knowledge units with no last_confirmed timestamp.
 _EPOCH_UTC = datetime.min.replace(tzinfo=UTC)
 
-# Confidence distribution bucket boundaries (upper bound, label).
+# Confidence-distribution buckets (exclusive upper bound, label), ordered low
+# to high. These labels are the canonical wire-contract convention; servers and
+# other SDKs follow the same labels so a remote distribution merges without the
+# labels drifting apart.
 _CONFIDENCE_BUCKETS: list[tuple[float, str]] = [
     (0.3, "0.0-0.3"),
     (0.5, "0.3-0.5"),
@@ -54,6 +57,9 @@ class StoreStats(BaseModel):
     total_count: int
     domain_counts: dict[str, int] = Field(default_factory=dict)
     recent: list[KnowledgeUnit] = Field(default_factory=list)
+    # Covers the local store plus any private/org units a configured remote
+    # reports; it excludes the public commons. Keyed by the canonical bucket
+    # labels (see CONFIDENCE_BUCKETS).
     confidence_distribution: dict[str, int] = Field(default_factory=dict)
     # Keyed by Tier rather than str: the tiers are a closed set, and typing
     # the keys keeps producers and consumers from drifting into bare strings.

--- a/sdk/python/src/cq/store.py
+++ b/sdk/python/src/cq/store.py
@@ -59,7 +59,7 @@ class StoreStats(BaseModel):
     recent: list[KnowledgeUnit] = Field(default_factory=list)
     # Covers the local store plus any private/org units a configured remote
     # reports; it excludes the public commons. Keyed by the canonical bucket
-    # labels (see CONFIDENCE_BUCKETS).
+    # labels (see _CONFIDENCE_BUCKETS).
     confidence_distribution: dict[str, int] = Field(default_factory=dict)
     # Keyed by Tier rather than str: the tiers are a closed set, and typing
     # the keys keeps producers and consumers from drifting into bare strings.

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -748,7 +748,7 @@ class TestRemoteIntegration:
         c.close()
 
     def test_status_merges_remote_confidence_distribution(self, tmp_path: Path, httpx_mock):
-        """status() maps remote bracketed buckets to local labels and sums them per bucket."""
+        """status() sums remote confidence buckets into the local distribution per bucket."""
         httpx_mock.add_response(
             url=httpx.URL("http://test-remote/api/v1/knowledge/stats"),
             json={
@@ -793,6 +793,31 @@ class TestRemoteIntegration:
         assert "0.5-0.9" not in stats.confidence_distribution
         assert any("0.5-0.9" in record.message for record in caplog.records)
         assert any("0.5-0.9" in warning for warning in stats.warnings)
+        c.close()
+
+    def test_status_skips_non_object_remote_section(
+        self, tmp_path: Path, httpx_mock, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A non-object stats section (e.g. null) degrades to a warning, not a crash;
+        the other sections still merge."""
+        httpx_mock.add_response(
+            url=httpx.URL("http://test-remote/api/v1/knowledge/stats"),
+            json={
+                "total_count": 3,
+                "tier_counts": {"private": 3},
+                "domain_counts": {"api": 2},
+                "confidence_distribution": None,
+            },
+        )
+
+        c = Client(addr="http://test-remote", local_db_path=tmp_path / "test.db")
+        with caplog.at_level(logging.WARNING, logger="cq.client"):
+            stats = c.status()
+        # The malformed section is dropped with a warning; siblings still merge.
+        assert stats.tier_counts[Tier.PRIVATE] == 3
+        assert stats.domain_counts["api"] == 2
+        assert any("confidence_distribution" in warning for warning in stats.warnings)
+        assert any("confidence_distribution" in record.message for record in caplog.records)
         c.close()
 
     def test_status_remote_unreachable_surfaces_warning(self, tmp_path: Path, httpx_mock, caplog):

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -101,6 +101,9 @@ class TestLocalOnlyMode:
         stats = client.status()
         assert stats.total_count == 1
         assert "api" in stats.domain_counts
+        # Local buckets use this SDK's unbracketed labels; a fresh unit sits at
+        # the default 0.5 confidence.
+        assert stats.confidence_distribution["0.5-0.7"] == 1
 
     def test_status_local_only_has_tier_counts(self, client: Client):
         client.propose(
@@ -744,6 +747,54 @@ class TestRemoteIntegration:
         assert stats.domain_counts["db"] == 2
         c.close()
 
+    def test_status_merges_remote_confidence_distribution(self, tmp_path: Path, httpx_mock):
+        """status() maps remote bracketed buckets to local labels and sums them per bucket."""
+        httpx_mock.add_response(
+            url=httpx.URL("http://test-remote/api/v1/knowledge/stats"),
+            json={
+                "total_count": 5,
+                "tier_counts": {"private": 5, "public": 0},
+                "domain_counts": {},
+                "confidence_distribution": {"0.5-0.7": 4, "0.7-1.0": 1},
+            },
+        )
+
+        # Local unit sits at the default 0.5 confidence, sharing a bucket with
+        # the remote's "0.5-0.7" so we can verify accumulation.
+        local_client = Client(local_db_path=tmp_path / "test.db")
+        local_client.propose(summary="S", detail="D", action="A", domains=["api"])
+        local_client.close()
+
+        c = Client(addr="http://test-remote", local_db_path=tmp_path / "test.db")
+        stats = c.status()
+        assert stats.confidence_distribution["0.5-0.7"] == 5  # local 1 + remote 4
+        assert stats.confidence_distribution["0.7-1.0"] == 1
+        c.close()
+
+    def test_status_skips_and_logs_unknown_remote_confidence_bucket(
+        self, tmp_path: Path, httpx_mock, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A remote bucket label this SDK does not recognize is skipped, logged, and
+        surfaced as a warning; never carried as an unknown key nor summed in."""
+        httpx_mock.add_response(
+            url=httpx.URL("http://test-remote/api/v1/knowledge/stats"),
+            json={
+                "total_count": 5,
+                "tier_counts": {"private": 5},
+                "domain_counts": {},
+                "confidence_distribution": {"0.5-0.7": 4, "0.5-0.9": 2},
+            },
+        )
+
+        c = Client(addr="http://test-remote", local_db_path=tmp_path / "test.db")
+        with caplog.at_level(logging.WARNING, logger="cq.client"):
+            stats = c.status()
+        assert stats.confidence_distribution["0.5-0.7"] == 4
+        assert "0.5-0.9" not in stats.confidence_distribution
+        assert any("0.5-0.9" in record.message for record in caplog.records)
+        assert any("0.5-0.9" in warning for warning in stats.warnings)
+        c.close()
+
     def test_status_remote_unreachable_surfaces_warning(self, tmp_path: Path, httpx_mock, caplog):
         """A remote stats failure surfaces a warning + log, not a silent local-only result
         indistinguishable from a genuinely empty store."""
@@ -843,6 +894,8 @@ class TestRemoteIntegration:
             total_count=7,
             domain_counts={"api": 4, "ci": 3},
             tier_counts={"private": 6, "public": 1},
+            # The server emits the canonical bucket labels, shared with the SDK.
+            confidence_distribution={"0.5-0.7": 6, "0.7-1.0": 1},
         )
         httpx_mock.add_response(
             url=httpx.URL("http://test-remote/api/v1/knowledge/stats"),
@@ -860,6 +913,10 @@ class TestRemoteIntegration:
         # "api" appears locally (1) and remotely (4); counts must accumulate.
         assert stats.domain_counts["api"] == 5
         assert stats.domain_counts["ci"] == 3
+        # Local and remote share bucket labels; the local unit at 0.5
+        # accumulates with the remote's 6 in the same bucket.
+        assert stats.confidence_distribution["0.5-0.7"] == 7
+        assert stats.confidence_distribution["0.7-1.0"] == 1
         c.close()
 
     def test_flag_local_ignores_remote_rejection(self, tmp_path: Path, httpx_mock):

--- a/server/backend/src/cq_server/models/knowledge.py
+++ b/server/backend/src/cq_server/models/knowledge.py
@@ -34,8 +34,13 @@ class StatsResponse(BaseModel):
 
     Field names follow the canonical ``StoreStats`` wire vocabulary shared
     with the SDK clients; renaming them is a breaking wire change.
+
+    NOTE: ``confidence_distribution`` covers the units this store reports to
+    the caller (their private/org tier), not the public commons. Clients merge
+    it with their local distribution and label the combined scope accordingly.
     """
 
     total_count: int
     tier_counts: dict[str, int]
     domain_counts: dict[str, int]
+    confidence_distribution: dict[str, int]

--- a/server/backend/src/cq_server/repositories/knowledge.py
+++ b/server/backend/src/cq_server/repositories/knowledge.py
@@ -15,6 +15,7 @@ from ._queries import (
     INSERT_UNIT,
     INSERT_UNIT_DOMAIN,
     SELECT_APPROVED_BY_ID,
+    SELECT_APPROVED_DATA,
     SELECT_BY_ID,
     SELECT_COUNTS_BY_TIER,
     SELECT_DOMAIN_COUNTS,
@@ -22,6 +23,17 @@ from ._queries import (
     SELECT_TOTAL_COUNT,
     UPDATE_UNIT_DATA,
 )
+
+# Mirrors `cq.store._CONFIDENCE_BUCKETS`. Each entry is `(exclusive upper
+# bound, label)`, ordered low to high; the last entry's `inf` upper bound is
+# the catch-all. Single source for both the bucket assignment and the result
+# dict's key set.
+_CONFIDENCE_BUCKETS: list[tuple[float, str]] = [
+    (0.3, "0.0-0.3"),
+    (0.5, "0.3-0.5"),
+    (0.7, "0.5-0.7"),
+    (float("inf"), "0.7-1.0"),
+]
 
 
 class KnowledgeRepository:
@@ -34,6 +46,10 @@ class KnowledgeRepository:
     async def count(self) -> int:
         """Return the total number of stored units across all review statuses."""
         return await self._db.run_sync(self._count_sync)
+
+    async def confidence_distribution(self) -> dict[str, int]:
+        """Return approved-unit counts grouped into the canonical confidence buckets."""
+        return await self._db.run_sync(self._confidence_distribution_sync)
 
     async def counts_by_tier(self) -> dict[str, int]:
         """Return approved-unit counts grouped by tier."""
@@ -81,6 +97,16 @@ class KnowledgeRepository:
     def _count_sync(self) -> int:
         with self._db.engine.connect() as conn:
             return int(conn.execute(SELECT_TOTAL_COUNT).scalar() or 0)
+
+    def _confidence_distribution_sync(self) -> dict[str, int]:
+        buckets = {label: 0 for _, label in _CONFIDENCE_BUCKETS}
+        with self._db.engine.connect() as conn:
+            rows = conn.execute(SELECT_APPROVED_DATA).fetchall()
+        for row in rows:
+            confidence = KnowledgeUnit.model_validate_json(row[0]).evidence.confidence
+            label = next(label for upper, label in _CONFIDENCE_BUCKETS if confidence < upper)
+            buckets[label] += 1
+        return buckets
 
     def _counts_by_tier_sync(self) -> dict[str, int]:
         with self._db.engine.connect() as conn:

--- a/server/backend/src/cq_server/services/knowledge.py
+++ b/server/backend/src/cq_server/services/knowledge.py
@@ -91,9 +91,10 @@ class KnowledgeService:
         )
 
     async def stats(self) -> StatsResponse:
-        """Return overall knowledge-store stats (totals, tiers, domains)."""
+        """Return overall knowledge-store stats (totals, tiers, domains, confidence)."""
         return StatsResponse(
             total_count=await self._knowledge.count(),
             tier_counts=await self._knowledge.counts_by_tier(),
             domain_counts=await self._knowledge.domain_counts(),
+            confidence_distribution=await self._knowledge.confidence_distribution(),
         )

--- a/server/backend/tests/test_app.py
+++ b/server/backend/tests/test_app.py
@@ -290,6 +290,12 @@ class TestStats:
         assert body["total_count"] == 0
         assert body["tier_counts"] == {}
         assert body["domain_counts"] == {}
+        assert body["confidence_distribution"] == {
+            "0.0-0.3": 0,
+            "0.3-0.5": 0,
+            "0.5-0.7": 0,
+            "0.7-1.0": 0,
+        }
 
     def test_stats_after_inserts(self, client: TestClient) -> None:
         r1 = client.post("/api/v1/knowledge", json=_propose_payload(domains=["api", "auth"]))
@@ -305,6 +311,8 @@ class TestStats:
         assert body["domain_counts"]["api"] == 2
         assert body["domain_counts"]["auth"] == 1
         assert body["domain_counts"]["payments"] == 1
+        # Freshly approved units sit at the default 0.5 confidence.
+        assert body["confidence_distribution"]["0.5-0.7"] == 2
 
     def test_stats_body_decodes_as_store_stats(self, client: TestClient) -> None:
         """The stats body validates against the SDK's public StoreStats model.
@@ -319,6 +327,7 @@ class TestStats:
         assert stats.total_count == 1
         assert stats.tier_counts == {"private": 1}
         assert stats.domain_counts == {"api": 1}
+        assert stats.confidence_distribution["0.5-0.7"] == 1
 
 
 class TestReviewLifecycleEndToEnd:


### PR DESCRIPTION
## Summary

`status()` computed `confidence_distribution` from the local store only, so a remote-backed store could never surface the confidence breakdown of its own private/org units (a remote-backed empty local store showed all zeros). This adds `confidence_distribution` to the knowledge-stats contract and merges the remote's buckets into the local distribution, mirroring how `tier_counts` and `domain_counts` already aggregate.

Closes #405.

## Changes

- **Server** — `StatsResponse` gains `confidence_distribution`; the knowledge repository computes per-bucket counts over approved units, and the service wires it into `stats()`.
- **Go SDK** — `Status()` decodes and sums the remote `confidence_distribution` per bucket; unrecognized bucket labels are skipped and surfaced as warnings. Buckets are now a label-keyed map (membership is a direct lookup), with `ConfidenceBucketLabels()` exposing the canonical low-to-high order for display.
- **Python SDK** — `status()` merges the remote buckets the same way, skipping and warning on unrecognized labels.
- **CLI** — the text view prints the confidence distribution (labeled as excluding the public commons) in canonical bucket order, and renders domains last as a compact `N total` line with the most-tagged few inline and the remainder truncated. The MCP `status` tool description drops the stale "local only" wording.
- **Plugin** — the `/cq:status` display template is updated to match.

## Bucket label convention

The canonical bucket labels are unbracketed (`0.0-0.3`, `0.3-0.5`, `0.5-0.7`, `0.7-1.0`), shared by the server and both SDKs so a remote distribution merges without translation. The Go SDK and CLI previously used a bracketed form; this aligns them.

## Notes

- `cli/go.mod` activates the local `replace` so the CLI builds against the new `ConfidenceBucketLabels` API. Re-pin to a released SDK version on the next release (per the directive's existing comment).

## Validation

`make lint` and `make test` pass across the Go SDK, CLI, Python SDK, server, and frontend.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Status now shows a merged confidence distribution (local + private/org remotes, excludes public commons).
  * API now includes confidence_distribution in stats responses.

* **Improvements**
  * Domains list is compacted and truncated with "… +N more", showing top domains and a total count.
  * Status output sections reordered for clearer reading; unknown remote confidence buckets are ignored and surfaced as warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->