### PR TITLE
perf(server): bucket confidence distribution in SQL

### DIFF
--- a/server/backend/src/cq_server/repositories/knowledge.py
+++ b/server/backend/src/cq_server/repositories/knowledge.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime
 from cq.models import KnowledgeUnit
 from cq.scoring import calculate_relevance
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.sql.expression import TextClause, text
 
 from ..core.db import Database
 from ._normalize import normalize_domains
@@ -15,7 +16,6 @@ from ._queries import (
     INSERT_UNIT,
     INSERT_UNIT_DOMAIN,
     SELECT_APPROVED_BY_ID,
-    SELECT_APPROVED_DATA,
     SELECT_BY_ID,
     SELECT_COUNTS_BY_TIER,
     SELECT_DOMAIN_COUNTS,
@@ -26,14 +26,31 @@ from ._queries import (
 
 # Mirrors `cq.store._CONFIDENCE_BUCKETS`. Each entry is `(exclusive upper
 # bound, label)`, ordered low to high; the last entry's `inf` upper bound is
-# the catch-all. Single source for both the bucket assignment and the result
-# dict's key set.
+# the catch-all. Single source for the result dict's key set and ordering.
 _CONFIDENCE_BUCKETS: list[tuple[float, str]] = [
     (0.3, "0.0-0.3"),
     (0.5, "0.3-0.5"),
     (0.7, "0.5-0.7"),
     (float("inf"), "0.7-1.0"),
 ]
+
+# Bucket approved units by their persisted confidence in SQL rather than
+# parsing every unit into a model to read one float. The CASE thresholds must
+# stay in lockstep with `_CONFIDENCE_BUCKETS` above. SQLite-specific
+# (`json_extract`), so it lives here rather than in the portable `_queries`
+# module; the backend is SQLite-only (see `core.db.Database`).
+_SELECT_CONFIDENCE_DISTRIBUTION: TextClause = text(
+    "SELECT "
+    "CASE "
+    "WHEN confidence < 0.3 THEN '0.0-0.3' "
+    "WHEN confidence < 0.5 THEN '0.3-0.5' "
+    "WHEN confidence < 0.7 THEN '0.5-0.7' "
+    "ELSE '0.7-1.0' "
+    "END AS bucket, COUNT(*) AS cnt "
+    "FROM (SELECT json_extract(data, '$.evidence.confidence') AS confidence "
+    "FROM knowledge_units WHERE status = 'approved') "
+    "GROUP BY bucket"
+)
 
 
 class KnowledgeRepository:
@@ -99,13 +116,13 @@ class KnowledgeRepository:
             return int(conn.execute(SELECT_TOTAL_COUNT).scalar() or 0)
 
     def _confidence_distribution_sync(self) -> dict[str, int]:
+        # Seed every canonical bucket so absent labels report 0; the SQL only
+        # returns rows for buckets that have at least one approved unit.
         buckets = {label: 0 for _, label in _CONFIDENCE_BUCKETS}
         with self._db.engine.connect() as conn:
-            rows = conn.execute(SELECT_APPROVED_DATA).fetchall()
-        for row in rows:
-            confidence = KnowledgeUnit.model_validate_json(row[0]).evidence.confidence
-            label = next(label for upper, label in _CONFIDENCE_BUCKETS if confidence < upper)
-            buckets[label] += 1
+            rows = conn.execute(_SELECT_CONFIDENCE_DISTRIBUTION).fetchall()
+        for label, count in rows:
+            buckets[label] = count
         return buckets
 
     def _counts_by_tier_sync(self) -> dict[str, int]:

--- a/server/backend/src/cq_server/repositories/knowledge.py
+++ b/server/backend/src/cq_server/repositories/knowledge.py
@@ -36,9 +36,11 @@ _CONFIDENCE_BUCKETS: list[tuple[float, str]] = [
 
 # Bucket approved units by their persisted confidence in SQL rather than
 # parsing every unit into a model to read one float. The CASE thresholds must
-# stay in lockstep with `_CONFIDENCE_BUCKETS` above. SQLite-specific
-# (`json_extract`), so it lives here rather than in the portable `_queries`
-# module; the backend is SQLite-only (see `core.db.Database`).
+# stay in lockstep with `_CONFIDENCE_BUCKETS` above. COALESCE to 0.5 mirrors
+# the Evidence.confidence default that model-parsing applied, so a row whose
+# JSON omits the field buckets identically instead of falling to the catch-all.
+# SQLite-specific (`json_extract`), so it lives here rather than in the portable
+# `_queries` module; the backend is SQLite-only (see `core.db.Database`).
 _SELECT_CONFIDENCE_DISTRIBUTION: TextClause = text(
     "SELECT "
     "CASE "
@@ -47,7 +49,7 @@ _SELECT_CONFIDENCE_DISTRIBUTION: TextClause = text(
     "WHEN confidence < 0.7 THEN '0.5-0.7' "
     "ELSE '0.7-1.0' "
     "END AS bucket, COUNT(*) AS cnt "
-    "FROM (SELECT json_extract(data, '$.evidence.confidence') AS confidence "
+    "FROM (SELECT COALESCE(json_extract(data, '$.evidence.confidence'), 0.5) AS confidence "
     "FROM knowledge_units WHERE status = 'approved') "
     "GROUP BY bucket"
 )

--- a/server/backend/src/cq_server/repositories/reviews.py
+++ b/server/backend/src/cq_server/repositories/reviews.py
@@ -25,9 +25,11 @@ from ._queries import (
 # Bucket approved units by their persisted confidence in SQL rather than
 # parsing every unit into a model to read one float. The review dashboard uses
 # different bucket boundaries (0.3/0.6/0.8) than the knowledge stats; keep them
-# distinct unless deliberately unified. SQLite-specific (`json_extract`), so it
-# lives here rather than in the portable `_queries` module; the backend is
-# SQLite-only (see `core.db.Database`).
+# distinct unless deliberately unified. COALESCE to 0.5 mirrors the
+# Evidence.confidence default that model-parsing applied, so a row whose JSON
+# omits the field buckets identically instead of falling to the catch-all.
+# SQLite-specific (`json_extract`), so it lives here rather than in the portable
+# `_queries` module; the backend is SQLite-only (see `core.db.Database`).
 _SELECT_CONFIDENCE_DISTRIBUTION: TextClause = text(
     "SELECT "
     "CASE "
@@ -36,7 +38,7 @@ _SELECT_CONFIDENCE_DISTRIBUTION: TextClause = text(
     "WHEN confidence < 0.8 THEN '0.6-0.8' "
     "ELSE '0.8-1.0' "
     "END AS bucket, COUNT(*) AS cnt "
-    "FROM (SELECT json_extract(data, '$.evidence.confidence') AS confidence "
+    "FROM (SELECT COALESCE(json_extract(data, '$.evidence.confidence'), 0.5) AS confidence "
     "FROM knowledge_units WHERE status = 'approved') "
     "GROUP BY bucket"
 )

--- a/server/backend/src/cq_server/repositories/reviews.py
+++ b/server/backend/src/cq_server/repositories/reviews.py
@@ -6,11 +6,11 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from cq.models import KnowledgeUnit
+from sqlalchemy.sql.expression import TextClause, text
 
 from ..core.db import Database
 from ._queries import (
     SELECT_APPROVED_DAILY,
-    SELECT_APPROVED_DATA,
     SELECT_COUNTS_BY_STATUS,
     SELECT_PENDING_COUNT,
     SELECT_PENDING_QUEUE,
@@ -20,6 +20,25 @@ from ._queries import (
     SELECT_REVIEW_STATUS_BY_ID,
     UPDATE_REVIEW_STATUS,
     select_list_units,
+)
+
+# Bucket approved units by their persisted confidence in SQL rather than
+# parsing every unit into a model to read one float. The review dashboard uses
+# different bucket boundaries (0.3/0.6/0.8) than the knowledge stats; keep them
+# distinct unless deliberately unified. SQLite-specific (`json_extract`), so it
+# lives here rather than in the portable `_queries` module; the backend is
+# SQLite-only (see `core.db.Database`).
+_SELECT_CONFIDENCE_DISTRIBUTION: TextClause = text(
+    "SELECT "
+    "CASE "
+    "WHEN confidence < 0.3 THEN '0.0-0.3' "
+    "WHEN confidence < 0.6 THEN '0.3-0.6' "
+    "WHEN confidence < 0.8 THEN '0.6-0.8' "
+    "ELSE '0.8-1.0' "
+    "END AS bucket, COUNT(*) AS cnt "
+    "FROM (SELECT json_extract(data, '$.evidence.confidence') AS confidence "
+    "FROM knowledge_units WHERE status = 'approved') "
+    "GROUP BY bucket"
 )
 
 
@@ -84,19 +103,13 @@ class ReviewRepository:
         await self._db.run_sync(self._set_status_sync, unit_id, status, reviewed_by)
 
     def _confidence_distribution_sync(self) -> dict[str, int]:
+        # Seed every bucket so absent labels report 0; the SQL only returns
+        # rows for buckets that have at least one approved unit.
         buckets = {"0.0-0.3": 0, "0.3-0.6": 0, "0.6-0.8": 0, "0.8-1.0": 0}
         with self._db.engine.connect() as conn:
-            rows = conn.execute(SELECT_APPROVED_DATA).fetchall()
-        for row in rows:
-            c = KnowledgeUnit.model_validate_json(row[0]).evidence.confidence
-            if c < 0.3:
-                buckets["0.0-0.3"] += 1
-            elif c < 0.6:
-                buckets["0.3-0.6"] += 1
-            elif c < 0.8:
-                buckets["0.6-0.8"] += 1
-            else:
-                buckets["0.8-1.0"] += 1
+            rows = conn.execute(_SELECT_CONFIDENCE_DISTRIBUTION).fetchall()
+        for label, count in rows:
+            buckets[label] = count
         return buckets
 
     def _counts_by_status_sync(self) -> dict[str, int]:

--- a/server/backend/tests/test_sqlite_store.py
+++ b/server/backend/tests/test_sqlite_store.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 import pytest
 from cq.models import Context, Evidence, Insight, KnowledgeUnit, Tier, create_knowledge_unit
+from sqlalchemy import text
 
 from cq_server.core.config import Settings
 from cq_server.core.db import Database
@@ -241,6 +242,34 @@ async def test_confidence_distribution_buckets_across_boundaries(db_path: Path) 
             "0.6-0.8": 2,  # 0.6, 0.7
             "0.8-1.0": 1,  # 0.8
         }
+    finally:
+        await store.close()
+
+
+async def test_confidence_distribution_defaults_missing_field_to_half(db_path: Path) -> None:
+    """A row whose JSON omits ``evidence.confidence`` buckets as 0.5.
+
+    The repository's own writes always serialize the field, so this seeds a
+    raw row directly to mimic a legacy or hand-edited blob. The SQL COALESCE
+    must reproduce the ``Evidence.confidence`` default the prior model-parsing
+    path applied, rather than routing the row to the catch-all bucket.
+    """
+    store = _make_store(db_path)
+    try:
+        ku_id = "ku_" + "0" * 32
+        with store._engine.begin() as conn:
+            conn.execute(
+                text("INSERT INTO knowledge_units (id, data, status) VALUES (:id, :data, 'approved')"),
+                {"id": ku_id, "data": f'{{"id": "{ku_id}", "evidence": {{}}}}'},
+            )
+
+        knowledge_dist = await store.knowledge.confidence_distribution()
+        assert knowledge_dist["0.5-0.7"] == 1
+        assert sum(knowledge_dist.values()) == 1
+
+        review_dist = await store.reviews.confidence_distribution()
+        assert review_dist["0.3-0.6"] == 1
+        assert sum(review_dist.values()) == 1
     finally:
         await store.close()
 

--- a/server/backend/tests/test_sqlite_store.py
+++ b/server/backend/tests/test_sqlite_store.py
@@ -11,7 +11,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
-from cq.models import Context, Insight, KnowledgeUnit, Tier, create_knowledge_unit
+from cq.models import Context, Evidence, Insight, KnowledgeUnit, Tier, create_knowledge_unit
 
 from cq_server.core.config import Settings
 from cq_server.core.db import Database
@@ -207,6 +207,40 @@ async def test_distribution_and_activity_and_daily(db_path: Path) -> None:
 
         with pytest.raises(ValueError):
             await store.daily_counts(days=0)
+    finally:
+        await store.close()
+
+
+async def test_confidence_distribution_buckets_across_boundaries(db_path: Path) -> None:
+    """Both distributions bucket approved units by their persisted confidence.
+
+    Knowledge and review distributions use different bucket boundaries
+    (0.3/0.5/0.7 vs 0.3/0.6/0.8); this seeds units that straddle every
+    boundary and pins each repository's mapping. A pending unit confirms
+    only approved units are counted.
+    """
+    store = _make_store(db_path)
+    try:
+        for confidence in (0.2, 0.3, 0.5, 0.6, 0.7, 0.8):
+            unit = _make_unit().model_copy(update={"evidence": Evidence(confidence=confidence)})
+            await store.insert(unit)
+            await store.set_review_status(unit.id, "approved", "r")
+        # A pending unit must be excluded from both distributions.
+        pending = _make_unit().model_copy(update={"evidence": Evidence(confidence=0.9)})
+        await store.insert(pending)
+
+        assert await store.knowledge.confidence_distribution() == {
+            "0.0-0.3": 1,  # 0.2
+            "0.3-0.5": 1,  # 0.3
+            "0.5-0.7": 2,  # 0.5, 0.6
+            "0.7-1.0": 2,  # 0.7, 0.8
+        }
+        assert await store.reviews.confidence_distribution() == {
+            "0.0-0.3": 1,  # 0.2
+            "0.3-0.6": 2,  # 0.3, 0.5
+            "0.6-0.8": 2,  # 0.6, 0.7
+            "0.8-1.0": 1,  # 0.8
+        }
     finally:
         await store.close()
 


### PR DESCRIPTION
## Summary

Both `_confidence_distribution_sync` aggregations (knowledge stats and the review dashboard) deserialized every approved knowledge unit's full JSON blob into a `KnowledgeUnit` model just to read `evidence.confidence`, then bucketed in Python. That made these status/dashboard reads an O(n) full-model parse on larger stores, while the sibling tier/domain aggregates already grouped in SQL.

This buckets confidence in SQLite via `json_extract(data, '$.evidence.confidence')` and a `CASE` over the thresholds, returning grouped counts directly. The two implementations keep their distinct bucket boundaries (knowledge `0.3/0.5/0.7`, reviews `0.3/0.6/0.8`) per the issue.

## Notes

- The new SQLite-specific query constants live with their repositories rather than in `_queries.py`, which is documented as portable SQLite/PostgreSQL SQL only; this mirrors how `core/db.py` keeps SQLite PRAGMAs out of that module. The backend is SQLite-only at runtime.
- `SELECT_APPROVED_DATA` stays in `_queries.py` (still covered by `test_queries.py`); removing it was out of scope.
- Behavior is preserved: the added boundary-spanning characterization test passes against both the old and new implementations.

## Testing

- `make lint` — passed
- `make test-server-backend` — 282 passed

Fixes #412

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Compute knowledge and review confidence distributions directly in the database for faster, more consistent bucket counting.
  * Confidence values missing from evidence now default to the expected mid-range bucket during distribution calculations.

* **Tests**
  * Added coverage to verify bucket counts across confidence boundary thresholds for both knowledge and review distributions.
  * Added coverage to confirm missing `evidence.confidence` defaults correctly and that pending units are excluded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->