### PR TITLE
feat: add cq:status to the prompt-sync pipeline and expose `cq prompt status`

### DIFF
--- a/cli/cmd/prompt.go
+++ b/cli/cmd/prompt.go
@@ -40,6 +40,7 @@ func NewPromptCmd() *cobra.Command {
 
 	cmd.AddCommand(newPromptReflectCmd())
 	cmd.AddCommand(newPromptSkillCmd())
+	cmd.AddCommand(newPromptStatusCmd())
 
 	return cmd
 }
@@ -65,6 +66,18 @@ func newPromptSkillCmd() *cobra.Command {
 			"agent should interact with the knowledge commons.",
 		jsonKey: "prompt",
 		body:    prompts.Skill,
+	})
+}
+
+// newPromptStatusCmd prints the /cq:status slash-command prompt.
+func newPromptStatusCmd() *cobra.Command {
+	return newPromptSubCmd(promptSubCmd{
+		use:   "status",
+		short: "Print the /cq:status slash-command prompt.",
+		long: "Print the /cq:status slash-command prompt, which guides an agent " +
+			"through summarizing the cq knowledge store.",
+		jsonKey: "prompt",
+		body:    prompts.Status,
 	})
 }
 

--- a/cli/cmd/prompt_test.go
+++ b/cli/cmd/prompt_test.go
@@ -75,3 +75,14 @@ func TestPromptBareInvocationShowsHelp(t *testing.T) {
 	require.Contains(t, buf.String(), "skill")
 	require.Contains(t, buf.String(), "reflect")
 }
+
+func TestPromptStatusEmitsBody(t *testing.T) {
+	cmd := NewPromptCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"status"})
+	require.NoError(t, cmd.Execute())
+	require.Contains(t, out.String(), "name: cq:status")
+	require.Contains(t, out.String(), "# /cq:status")
+}

--- a/sdk/go/Makefile
+++ b/sdk/go/Makefile
@@ -37,13 +37,16 @@ help:
 
 PROMPT_SRC_SKILL := ../../plugins/cq/skills/cq/SKILL.md
 PROMPT_SRC_REFLECT := ../../plugins/cq/commands/reflect.md
+PROMPT_SRC_STATUS := ../../plugins/cq/commands/status.md
 PROMPT_DST_SKILL := prompts/SKILL.md
 PROMPT_DST_REFLECT := prompts/reflect.md
+PROMPT_DST_STATUS := prompts/status.md
 
 .PHONY: sync-prompts
 sync-prompts:
 	@cp $(PROMPT_SRC_SKILL) $(PROMPT_DST_SKILL)
 	@cp $(PROMPT_SRC_REFLECT) $(PROMPT_DST_REFLECT)
+	@cp $(PROMPT_SRC_STATUS) $(PROMPT_DST_STATUS)
 	@echo "✓ Prompts synced."
 
 .PHONY: check-prompts-sync
@@ -52,6 +55,8 @@ check-prompts-sync:
 		|| (echo "$(PROMPT_DST_SKILL) is out of sync. Run: make sync-prompts" && exit 1)
 	@diff -q $(PROMPT_SRC_REFLECT) $(PROMPT_DST_REFLECT) > /dev/null 2>&1 \
 		|| (echo "$(PROMPT_DST_REFLECT) is out of sync. Run: make sync-prompts" && exit 1)
+	@diff -q $(PROMPT_SRC_STATUS) $(PROMPT_DST_STATUS) > /dev/null 2>&1 \
+		|| (echo "$(PROMPT_DST_STATUS) is out of sync. Run: make sync-prompts" && exit 1)
 	@echo "✓ Prompts are in sync."
 
 .PHONY: lint

--- a/sdk/go/prompts/prompts.go
+++ b/sdk/go/prompts/prompts.go
@@ -12,6 +12,9 @@ var reflect string
 //go:embed SKILL.md
 var skill string
 
+//go:embed status.md
+var status string
+
 // Reflect returns the /cq:reflect slash-command prompt.
 func Reflect() string {
 	return reflect
@@ -20,4 +23,9 @@ func Reflect() string {
 // Skill returns the full cq agent skill prompt.
 func Skill() string {
 	return skill
+}
+
+// Status returns the /cq:status slash-command prompt.
+func Status() string {
+	return status
 }

--- a/sdk/go/prompts/prompts_test.go
+++ b/sdk/go/prompts/prompts_test.go
@@ -32,3 +32,16 @@ func TestReflectContainsReflectFrontmatter(t *testing.T) {
 func TestSkillAndReflectAreDistinct(t *testing.T) {
 	require.NotEqual(t, Skill(), Reflect())
 }
+
+func TestStatusContainsStatusFrontmatter(t *testing.T) {
+	body := normalize(Status())
+	require.NotEmpty(t, body)
+	require.True(t, strings.HasPrefix(body, "---\n"), "status prompt must start with frontmatter")
+	require.Contains(t, body, "name: cq:status")
+	require.Contains(t, body, "### Tier Counts")
+}
+
+func TestStatusIsDistinctFromSkillAndReflect(t *testing.T) {
+	require.NotEqual(t, Status(), Skill())
+	require.NotEqual(t, Status(), Reflect())
+}

--- a/sdk/go/prompts/status.md
+++ b/sdk/go/prompts/status.md
@@ -1,0 +1,60 @@
+---
+name: cq:status
+description: Display cq knowledge store statistics — tier counts (local/private/public), domains, recent local additions, and confidence distribution.
+---
+
+# /cq:status
+
+Display a summary of the cq knowledge store.
+
+## Instructions
+
+1. Call the `status` MCP tool (no arguments needed).
+2. Format the response as a readable summary using the sections below.
+
+## Output Format
+
+Present the results using this structure:
+
+```
+## cq Knowledge Store
+
+### Tier Counts
+local: {count} | private: {count} | public: {count}
+
+*local* = on this machine only; *private* = shared with everyone who can reach the same `CQ_ADDR`; *public* = the open commons, shared across every node that participates in it (available when your configured remote serves it).
+
+### Recent Local Additions
+- {id}: "{summary}" ({relative time})
+- ...
+
+### Confidence Distribution
+*(covers local plus your private/org units; excludes the public commons)*
+
+■ 0.7-1.0: {count} units
+■ 0.5-0.7: {count} units
+■ 0.3-0.5: {count} units
+■ 0.0-0.3: {count} units
+
+### Domains
+{distinct count} total
+{domain} ({count}), {domain} ({count}) ... +{remaining} more
+```
+
+The `tier_counts` field contains the tier breakdown. Display all tiers present in the response. Omit tiers with a count of 0.
+
+The `recent` field reflects the local store only. When a remote is configured and reachable, units proposed via `Client.Propose` go directly to the remote and do not appear here. If `recent` is empty, render the section as `(no recent local additions)` so users understand the scope.
+
+The `domain_counts` field maps each domain to its unit count. Domains are the least important section, so render them last and keep them compact: a `{distinct count} total` line, then the most-tagged few on the next line as `{domain} ({count})` (highest count first, ties alphabetical), capped at 8. If more than 8 exist, append the truncation marker after a single space, e.g. `{domain} ({count}) ... +{remaining} more`; do not leave a trailing comma before it.
+
+If the `warnings` field is non-empty, surface each entry prominently above the summary so the counts are not mistaken for the full picture. A warning means stats aggregation degraded; for example, an unreachable or misconfigured remote, in which case the counts reflect the local store only:
+
+```
+> ⚠️ {warning}
+```
+
+## Empty Store
+
+When all tier counts are 0 (or `tier_counts` is absent), display only:
+
+"The cq store is empty. Knowledge units are added via `propose` or the `/cq:reflect` command."

--- a/sdk/python/Makefile
+++ b/sdk/python/Makefile
@@ -2,8 +2,10 @@
 
 PROMPT_SRC_SKILL := ../../plugins/cq/skills/cq/SKILL.md
 PROMPT_SRC_REFLECT := ../../plugins/cq/commands/reflect.md
+PROMPT_SRC_STATUS := ../../plugins/cq/commands/status.md
 PROMPT_DST_SKILL := src/cq/prompts/SKILL.md
 PROMPT_DST_REFLECT := src/cq/prompts/reflect.md
+PROMPT_DST_STATUS := src/cq/prompts/status.md
 
 .PHONY: help
 help:
@@ -26,6 +28,7 @@ setup:
 sync-prompts:
 	cp $(PROMPT_SRC_SKILL) $(PROMPT_DST_SKILL)
 	cp $(PROMPT_SRC_REFLECT) $(PROMPT_DST_REFLECT)
+	cp $(PROMPT_SRC_STATUS) $(PROMPT_DST_STATUS)
 
 .PHONY: check-prompts-sync
 check-prompts-sync:
@@ -33,6 +36,8 @@ check-prompts-sync:
 		|| (echo "$(PROMPT_DST_SKILL) is out of sync. Run: make sync-prompts" && exit 1)
 	@diff -q $(PROMPT_SRC_REFLECT) $(PROMPT_DST_REFLECT) > /dev/null 2>&1 \
 		|| (echo "$(PROMPT_DST_REFLECT) is out of sync. Run: make sync-prompts" && exit 1)
+	@diff -q $(PROMPT_SRC_STATUS) $(PROMPT_DST_STATUS) > /dev/null 2>&1 \
+		|| (echo "$(PROMPT_DST_STATUS) is out of sync. Run: make sync-prompts" && exit 1)
 	@echo "✓ Prompts are in sync."
 
 .PHONY: test

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -46,7 +46,7 @@ namespaces = false
 
 [tool.setuptools.package-data]
 "*" = ["py.typed"]
-"cq.prompts" = ["SKILL.md", "reflect.md"]
+"cq.prompts" = ["SKILL.md", "reflect.md", "status.md"]
 
 # Dynamic versioning via setuptools_scm is configured in the release
 # workflow. The tag pattern is sdk/python/X.Y.Z. During development,

--- a/sdk/python/src/cq/prompts/__init__.py
+++ b/sdk/python/src/cq/prompts/__init__.py
@@ -26,3 +26,13 @@ def skill() -> str:
         ``plugins/cq/skills/cq/SKILL.md`` via ``make sync-prompts``.
     """
     return files("cq.prompts").joinpath("SKILL.md").read_text()
+
+
+def status() -> str:
+    """Return the /cq:status slash-command prompt.
+
+    Returns:
+        The Markdown body of the /cq:status slash command, synced from
+        ``plugins/cq/commands/status.md`` via ``make sync-prompts``.
+    """
+    return files("cq.prompts").joinpath("status.md").read_text()

--- a/sdk/python/src/cq/prompts/status.md
+++ b/sdk/python/src/cq/prompts/status.md
@@ -1,0 +1,60 @@
+---
+name: cq:status
+description: Display cq knowledge store statistics — tier counts (local/private/public), domains, recent local additions, and confidence distribution.
+---
+
+# /cq:status
+
+Display a summary of the cq knowledge store.
+
+## Instructions
+
+1. Call the `status` MCP tool (no arguments needed).
+2. Format the response as a readable summary using the sections below.
+
+## Output Format
+
+Present the results using this structure:
+
+```
+## cq Knowledge Store
+
+### Tier Counts
+local: {count} | private: {count} | public: {count}
+
+*local* = on this machine only; *private* = shared with everyone who can reach the same `CQ_ADDR`; *public* = the open commons, shared across every node that participates in it (available when your configured remote serves it).
+
+### Recent Local Additions
+- {id}: "{summary}" ({relative time})
+- ...
+
+### Confidence Distribution
+*(covers local plus your private/org units; excludes the public commons)*
+
+■ 0.7-1.0: {count} units
+■ 0.5-0.7: {count} units
+■ 0.3-0.5: {count} units
+■ 0.0-0.3: {count} units
+
+### Domains
+{distinct count} total
+{domain} ({count}), {domain} ({count}) ... +{remaining} more
+```
+
+The `tier_counts` field contains the tier breakdown. Display all tiers present in the response. Omit tiers with a count of 0.
+
+The `recent` field reflects the local store only. When a remote is configured and reachable, units proposed via `Client.Propose` go directly to the remote and do not appear here. If `recent` is empty, render the section as `(no recent local additions)` so users understand the scope.
+
+The `domain_counts` field maps each domain to its unit count. Domains are the least important section, so render them last and keep them compact: a `{distinct count} total` line, then the most-tagged few on the next line as `{domain} ({count})` (highest count first, ties alphabetical), capped at 8. If more than 8 exist, append the truncation marker after a single space, e.g. `{domain} ({count}) ... +{remaining} more`; do not leave a trailing comma before it.
+
+If the `warnings` field is non-empty, surface each entry prominently above the summary so the counts are not mistaken for the full picture. A warning means stats aggregation degraded; for example, an unreachable or misconfigured remote, in which case the counts reflect the local store only:
+
+```
+> ⚠️ {warning}
+```
+
+## Empty Store
+
+When all tier counts are 0 (or `tier_counts` is absent), display only:
+
+"The cq store is empty. Knowledge units are added via `propose` or the `/cq:reflect` command."

--- a/sdk/python/tests/test_prompts.py
+++ b/sdk/python/tests/test_prompts.py
@@ -4,7 +4,7 @@ Validates the structure of the canonical cq agent prompts to catch upstream
 changes in the authoring sources.
 """
 
-from cq.prompts import reflect, skill
+from cq.prompts import reflect, skill, status
 
 
 def _normalize(body: str) -> str:
@@ -80,6 +80,26 @@ def test_skill_contains_examples():
     assert "#### Example 1" in p
     assert "#### Example 2" in p
     assert "#### Example 3" in p
+
+
+def test_status_not_empty():
+    assert len(status()) > 0
+
+
+def test_status_has_frontmatter():
+    p = _normalize(status())
+    assert p.startswith("---\n")
+    parts = p.split("---\n", 2)
+    assert len(parts) == 3
+    assert "name: cq:status" in parts[1]
+    assert "description:" in parts[1]
+
+
+def test_status_contains_output_sections():
+    p = status()
+    assert "# /cq:status" in p
+    assert "### Tier Counts" in p
+    assert "## Empty Store" in p
 
 
 def test_reflect_not_empty():


### PR DESCRIPTION
## What

Bring the `/cq:status` command body into the canonical prompt-sync pipeline, mirroring how `skill` and `reflect` already work.

- **Go SDK** (`sdk/go`): sync `status.md`, embed it, and expose `Status()` alongside `Skill()`/`Reflect()`.
- **Python SDK** (`sdk/python`): sync `status.md`, add it to package data, and expose `status()`.
- **CLI**: add `cq prompt status`, mirroring `cq prompt skill`/`reflect`.

The canonical source is `plugins/cq/commands/status.md`; the per-SDK copies are generated by `make sync-prompts` and verified by `make check-prompts-sync`.

## Why

`skill` and `reflect` are already surfaced through both SDKs and `cq prompt`; `status` was the only command missing from that pipeline.
This makes the same `/cq:status` text available to SDK consumers, CLI users, and the forthcoming installer work.

## Testing

- Go: `Status()` frontmatter and distinctness tests; `cq prompt status` emits the body.
- Python: `status()` not-empty, frontmatter, and sections tests.
- `make check-prompts-sync` passes for both SDKs; synced copies are byte-identical to the canonical source.

## Follow-up

`cli/go.mod` keeps the active `replace ... => ../sdk/go` directive (matching the repo's monorepo convention) so the CLI can reference the newly added `Status()` symbol.
Re-pin the CLI to a published SDK version once the SDK is released and tagged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new `status` command that displays comprehensive store information including tier distribution counts across local, private, and public categories, recent local additions, confidence distribution breakdown, and domain overview. The command provides deterministic structured output with appropriate messaging for empty stores and prominent warning display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->