### PR TITLE
feat(cli): add `cq install` command with Windsurf host

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -1,0 +1,110 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/mozilla-ai/cq/cli/internal/install"
+)
+
+// installFlags holds the parsed flag state for one `cq install` invocation.
+type installFlags struct {
+	// dryRun reports planned changes without writing.
+	dryRun bool
+
+	// project installs into the given project directory; empty means global.
+	project string
+
+	// uninstall removes cq instead of installing it.
+	uninstall bool
+
+	// windsurf targets the Windsurf host.
+	windsurf bool
+}
+
+// NewInstallCmd returns the install command.
+func NewInstallCmd() *cobra.Command {
+	f := &installFlags{}
+	cmd := &cobra.Command{
+		Use:   "install",
+		Short: "Install cq into a coding-agent host.",
+		Long: "Install cq into one or more coding-agent hosts (skill, MCP " +
+			"configuration, and any host-specific assets). Re-running is " +
+			"idempotent; pass --uninstall to remove.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runInstallCmd(cmd, f)
+		},
+	}
+	flags := cmd.Flags()
+	flags.BoolVar(&f.dryRun, "dry-run", false, "report planned changes without writing")
+	flags.StringVar(&f.project, "project", "", "install into the given project directory rather than globally")
+	flags.BoolVar(&f.uninstall, "uninstall", false, "remove cq from the selected hosts")
+	flags.BoolVar(&f.windsurf, "windsurf", false, "target the Windsurf host")
+	return cmd
+}
+
+// runInstallCmd resolves the selected hosts and applies the requested action.
+func runInstallCmd(cmd *cobra.Command, f *installFlags) error {
+	hosts := install.SelectHosts(install.Selection{Windsurf: f.windsurf})
+	if len(hosts) == 0 {
+		return fmt.Errorf("select at least one host (e.g. --windsurf)")
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("resolving home directory: %w", err)
+	}
+	var binary string
+	if !f.uninstall {
+		// Uninstall does not write the binary path into host config, so only
+		// resolve it for installs.
+		binary, err = install.BinaryPath()
+		if err != nil {
+			return fmt.Errorf("resolving binary path: %w", err)
+		}
+	}
+
+	for _, h := range hosts {
+		if f.project != "" && !h.SupportsProject() {
+			return fmt.Errorf("host %s does not support project installs", h.Name())
+		}
+		ctx := install.Context{
+			Target:     h.GlobalTarget(home),
+			SkillsDir:  install.SharedSkillsDir(home),
+			BinaryPath: binary,
+			DryRun:     f.dryRun,
+		}
+		var changes []install.Change
+		if f.uninstall {
+			changes, err = h.Uninstall(ctx)
+		} else {
+			changes, err = h.Install(ctx)
+		}
+		if err != nil {
+			return fmt.Errorf("%s: %w", h.Name(), err)
+		}
+		printChanges(cmd, h.Name(), changes)
+	}
+	return nil
+}
+
+// printChanges writes a per-host summary of applied changes.
+func printChanges(cmd *cobra.Command, host string, changes []install.Change) {
+	marker := map[install.Action]string{
+		install.ActionCreated:   "+",
+		install.ActionUpdated:   "~",
+		install.ActionUnchanged: "=",
+		install.ActionRemoved:   "-",
+		install.ActionSkipped:   "!",
+	}
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "[%s]\n", host)
+	for _, c := range changes {
+		suffix := ""
+		if c.Detail != "" {
+			suffix = "  (" + c.Detail + ")"
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  %s %s%s\n", marker[c.Action], c.Path, suffix)
+	}
+}

--- a/cli/install_test.go
+++ b/cli/install_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func runInstall(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	root := newRootCmd()
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs(append([]string{"install"}, args...))
+	err := root.Execute()
+	return out.String(), err
+}
+
+func TestInstallRequiresAHost(t *testing.T) {
+	_, err := runInstall(t)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "select at least one host")
+}
+
+func TestInstallWindsurfEndToEnd(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	bin := filepath.Join(t.TempDir(), "cq")
+	t.Setenv("CQ_INSTALL_BINARY", bin)
+
+	_, err := runInstall(t, "--windsurf")
+	require.NoError(t, err)
+
+	require.FileExists(t, filepath.Join(home, ".agents", "skills", "cq", "SKILL.md"))
+	cfg := filepath.Join(home, ".codeium", "windsurf", "mcp_config.json")
+	data, err := os.ReadFile(cfg)
+	require.NoError(t, err)
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(data, &m))
+	require.Equal(t, bin,
+		m["mcpServers"].(map[string]any)["cq"].(map[string]any)["command"])
+
+	// Re-run is idempotent.
+	_, err = runInstall(t, "--windsurf")
+	require.NoError(t, err)
+
+	// Uninstall reverses the MCP entry.
+	_, err = runInstall(t, "--windsurf", "--uninstall")
+	require.NoError(t, err)
+	data, err = os.ReadFile(cfg)
+	require.NoError(t, err)
+	m = nil
+	require.NoError(t, json.Unmarshal(data, &m))
+	require.NotContains(t, m, "mcpServers")
+}

--- a/cli/internal/install/binary.go
+++ b/cli/internal/install/binary.go
@@ -1,0 +1,30 @@
+package install
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// binaryOverrideEnv forces the binary path written into host config.
+//
+// NOTE: set it to an absolute path to override the auto-resolved binary
+// location, for example when a wrapper sits in front of the real binary.
+const binaryOverrideEnv = "CQ_INSTALL_BINARY"
+
+// BinaryPath returns the absolute path to write into a host's MCP config so
+// the host can spawn `cq mcp` regardless of its PATH at launch time.
+//
+// NOTE: the path is intentionally NOT symlink-resolved. On Homebrew the
+// resolved path points into a versioned Cellar directory that moves on
+// upgrade; the stable invocation path survives upgrades. Verify on
+// Homebrew and Scoop when changing this.
+func BinaryPath() (string, error) {
+	if override := os.Getenv(binaryOverrideEnv); override != "" {
+		if !filepath.IsAbs(override) {
+			return "", fmt.Errorf("%s must be an absolute path: %s", binaryOverrideEnv, override)
+		}
+		return override, nil
+	}
+	return os.Executable()
+}

--- a/cli/internal/install/binary_test.go
+++ b/cli/internal/install/binary_test.go
@@ -1,0 +1,29 @@
+package install
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBinaryPathHonorsOverride(t *testing.T) {
+	abs := filepath.Join(t.TempDir(), "cq")
+	t.Setenv(binaryOverrideEnv, abs)
+	got, err := BinaryPath()
+	require.NoError(t, err)
+	require.Equal(t, abs, got)
+}
+
+func TestBinaryPathIsAbsolute(t *testing.T) {
+	t.Setenv(binaryOverrideEnv, "")
+	got, err := BinaryPath()
+	require.NoError(t, err)
+	require.True(t, filepath.IsAbs(got))
+}
+
+func TestBinaryPathRejectsRelativeOverride(t *testing.T) {
+	t.Setenv(binaryOverrideEnv, "relative/cq")
+	_, err := BinaryPath()
+	require.Error(t, err)
+}

--- a/cli/internal/install/files.go
+++ b/cli/internal/install/files.go
@@ -1,0 +1,204 @@
+package install
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// manifestName is the file recording installer-owned files in a directory.
+const manifestName = ".cq-install-manifest.json"
+
+// removeManagedFiles deletes the files recorded in dir's manifest, leaving any
+// the user has modified in place and reporting SKIPPED when it does.
+func removeManagedFiles(dir string, dryRun bool) (Change, error) {
+	manifestPath := filepath.Join(dir, manifestName)
+	m, err := loadManifest(manifestPath)
+	if err != nil {
+		return Change{}, err
+	}
+	if m == nil {
+		return Change{Action: ActionUnchanged, Path: dir}, nil
+	}
+	skipped := false
+	for _, e := range m.Files {
+		target, joinErr := safeJoin(dir, e.Path)
+		if joinErr != nil {
+			return Change{}, joinErr
+		}
+		digest, hashErr := hashFile(target)
+		if os.IsNotExist(hashErr) {
+			continue
+		}
+		if hashErr != nil {
+			return Change{}, hashErr
+		}
+		if digest != e.SHA256 {
+			skipped = true
+			continue
+		}
+		if !dryRun {
+			if err := os.Remove(target); err != nil {
+				return Change{}, fmt.Errorf("removing installed file: %w", err)
+			}
+		}
+	}
+	if skipped {
+		return Change{Action: ActionSkipped, Path: dir, Detail: "user-modified files left in place"}, nil
+	}
+	if !dryRun {
+		if err := os.Remove(manifestPath); err != nil && !os.IsNotExist(err) {
+			return Change{}, fmt.Errorf("removing install manifest: %w", err)
+		}
+	}
+	return Change{Action: ActionRemoved, Path: dir}, nil
+}
+
+// writeManagedFiles writes rel→content into dir, tracked by a manifest.
+//
+// Re-runs are idempotent: files whose content already matches are left
+// UNCHANGED, and files written previously but absent from the new set are
+// pruned.
+// A file that differs from the desired content is overwritten only when it is
+// our own previously-written file (e.g. a version bump); a file the user or
+// another tool has created or edited is left untouched and reported SKIPPED.
+//
+// NOTE: the manifest is the source of truth for ownership; never overwrite or
+// remove a file it does not record as ours.
+func writeManagedFiles(dir string, files map[string]string, dryRun bool) (Change, error) {
+	manifestPath := filepath.Join(dir, manifestName)
+	previous, err := loadManifest(manifestPath)
+	if err != nil {
+		return Change{}, err
+	}
+	firstInstall := previous == nil
+
+	prevHash := make(map[string]string, len(files))
+	if previous != nil {
+		for _, e := range previous.Files {
+			prevHash[e.Path] = e.SHA256
+		}
+	}
+
+	desired := make(map[string]bool, len(files))
+	rels := make([]string, 0, len(files))
+	for rel := range files {
+		desired[rel] = true
+		rels = append(rels, rel)
+	}
+	sort.Strings(rels)
+
+	entries := make([]manifestEntry, 0, len(rels))
+	changed := false
+	skipped := false
+	for _, rel := range rels {
+		content := files[rel]
+		sum := sha256.Sum256([]byte(content))
+		digest := hex.EncodeToString(sum[:])
+
+		target, joinErr := safeJoin(dir, rel)
+		if joinErr != nil {
+			return Change{}, joinErr
+		}
+		existing, readErr := os.ReadFile(target)
+		if readErr != nil && !os.IsNotExist(readErr) {
+			return Change{}, fmt.Errorf("reading existing file: %w", readErr)
+		}
+		if readErr == nil {
+			cur := sha256.Sum256(existing)
+			onDisk := hex.EncodeToString(cur[:])
+			if onDisk == digest {
+				if _, owned := prevHash[rel]; !owned {
+					// A pre-existing file we never wrote, even if its content
+					// matches: leave it unmanaged so uninstall never deletes it.
+					skipped = true
+					continue
+				}
+				entries = append(entries, manifestEntry{Path: rel, SHA256: digest})
+				continue
+			}
+			if prev, owned := prevHash[rel]; !owned || onDisk != prev {
+				// The user or another tool owns this file; do not overwrite it.
+				skipped = true
+				continue
+			}
+		}
+		changed = true
+		if !dryRun {
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return Change{}, fmt.Errorf("creating skill directory: %w", err)
+			}
+			if err := os.WriteFile(target, []byte(content), 0o644); err != nil {
+				return Change{}, fmt.Errorf("writing skill file: %w", err)
+			}
+		}
+		entries = append(entries, manifestEntry{Path: rel, SHA256: digest})
+	}
+
+	if previous != nil {
+		for _, e := range previous.Files {
+			if desired[e.Path] {
+				continue
+			}
+			stale, joinErr := safeJoin(dir, e.Path)
+			if joinErr != nil {
+				return Change{}, joinErr
+			}
+			digest, hashErr := hashFile(stale)
+			if os.IsNotExist(hashErr) {
+				continue
+			}
+			if hashErr != nil {
+				return Change{}, hashErr
+			}
+			if digest != e.SHA256 {
+				// The user modified a now-stale file; leave it in place and
+				// surface that a managed prune was skipped.
+				skipped = true
+				continue
+			}
+			changed = true
+			if !dryRun {
+				if err := os.Remove(stale); err != nil {
+					return Change{}, fmt.Errorf("pruning stale file: %w", err)
+				}
+			}
+		}
+	}
+
+	if !changed {
+		if skipped {
+			return Change{Action: ActionSkipped, Path: dir, Detail: "user-modified files left in place"}, nil
+		}
+		if !firstInstall {
+			return Change{Action: ActionUnchanged, Path: dir}, nil
+		}
+	}
+	if !dryRun {
+		if err := writeManifest(manifestPath, entries); err != nil {
+			return Change{}, err
+		}
+	}
+	action := ActionUpdated
+	if firstInstall {
+		action = ActionCreated
+	}
+	return Change{Action: action, Path: dir}, nil
+}
+
+// safeJoin joins rel onto dir and rejects results that escape dir.
+//
+// NOTE: manifest paths are read from an on-disk file other local processes
+// can write, so they must be treated as untrusted.
+func safeJoin(dir, rel string) (string, error) {
+	joined := filepath.Join(dir, rel)
+	root := filepath.Clean(dir)
+	if joined != root && !strings.HasPrefix(joined, root+string(os.PathSeparator)) {
+		return "", fmt.Errorf("managed file path escapes its directory: %s", rel)
+	}
+	return joined, nil
+}

--- a/cli/internal/install/files_test.go
+++ b/cli/internal/install/files_test.go
@@ -1,0 +1,112 @@
+package install
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteManagedFilesCreatesThenUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	files := map[string]string{"cq/SKILL.md": "body"}
+
+	c1, err := writeManagedFiles(dir, files, false)
+	require.NoError(t, err)
+	require.Equal(t, ActionCreated, c1.Action)
+	body, err := os.ReadFile(filepath.Join(dir, "cq", "SKILL.md"))
+	require.NoError(t, err)
+	require.Equal(t, "body", string(body))
+
+	c2, err := writeManagedFiles(dir, files, false)
+	require.NoError(t, err)
+	require.Equal(t, ActionUnchanged, c2.Action)
+}
+
+func TestWriteManagedFilesPrunesStale(t *testing.T) {
+	dir := t.TempDir()
+	_, err := writeManagedFiles(dir, map[string]string{"a.md": "x", "b.md": "y"}, false)
+	require.NoError(t, err)
+	_, err = writeManagedFiles(dir, map[string]string{"a.md": "x"}, false)
+	require.NoError(t, err)
+	_, err = os.Stat(filepath.Join(dir, "b.md"))
+	require.True(t, os.IsNotExist(err))
+}
+
+func TestRemoveManagedFilesSkipsUserModified(t *testing.T) {
+	dir := t.TempDir()
+	_, err := writeManagedFiles(dir, map[string]string{"cq/SKILL.md": "body"}, false)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "cq", "SKILL.md"), []byte("edited"), 0o644))
+
+	c, err := removeManagedFiles(dir, false)
+	require.NoError(t, err)
+	require.Equal(t, ActionSkipped, c.Action)
+	_, err = os.Stat(filepath.Join(dir, "cq", "SKILL.md"))
+	require.NoError(t, err)
+}
+
+func TestRemoveManagedFilesRemovesClean(t *testing.T) {
+	dir := t.TempDir()
+	_, err := writeManagedFiles(dir, map[string]string{"cq/SKILL.md": "body"}, false)
+	require.NoError(t, err)
+
+	c, err := removeManagedFiles(dir, false)
+	require.NoError(t, err)
+	require.Equal(t, ActionRemoved, c.Action)
+	_, err = os.Stat(filepath.Join(dir, "cq", "SKILL.md"))
+	require.True(t, os.IsNotExist(err))
+}
+
+func TestWriteManagedFilesKeepsUserModifiedStale(t *testing.T) {
+	dir := t.TempDir()
+	_, err := writeManagedFiles(dir, map[string]string{"a.md": "x", "b.md": "y"}, false)
+	require.NoError(t, err)
+	// The user edits b.md, then a re-install drops it from the set.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "b.md"), []byte("edited"), 0o644))
+	c, err := writeManagedFiles(dir, map[string]string{"a.md": "x"}, false)
+	require.NoError(t, err)
+	require.Equal(t, ActionSkipped, c.Action)
+	body, err := os.ReadFile(filepath.Join(dir, "b.md"))
+	require.NoError(t, err)
+	require.Equal(t, "edited", string(body))
+}
+
+func TestSafeJoinRejectsEscape(t *testing.T) {
+	_, err := safeJoin("/home/dev/.agents/skills", "../../etc/shadow")
+	require.Error(t, err)
+	got, err := safeJoin("/home/dev/.agents/skills", "cq/SKILL.md")
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join("/home/dev/.agents/skills", "cq", "SKILL.md"), got)
+}
+
+func TestWriteManagedFilesKeepsUserModified(t *testing.T) {
+	dir := t.TempDir()
+	files := map[string]string{"cq/SKILL.md": "body"}
+	_, err := writeManagedFiles(dir, files, false)
+	require.NoError(t, err)
+
+	// The user edits the installed skill, then re-runs install.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "cq", "SKILL.md"), []byte("hacked"), 0o644))
+	c, err := writeManagedFiles(dir, files, false)
+	require.NoError(t, err)
+	require.Equal(t, ActionSkipped, c.Action)
+	body, err := os.ReadFile(filepath.Join(dir, "cq", "SKILL.md"))
+	require.NoError(t, err)
+	require.Equal(t, "hacked", string(body))
+}
+
+func TestWriteManagedFilesDoesNotAdoptPreexisting(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "cq"), 0o755))
+	// A file with our exact content exists before any install.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "cq", "SKILL.md"), []byte("body"), 0o644))
+
+	c, err := writeManagedFiles(dir, map[string]string{"cq/SKILL.md": "body"}, false)
+	require.NoError(t, err)
+	require.Equal(t, ActionSkipped, c.Action)
+	// We never wrote it, so we do not claim it: no manifest, nothing for
+	// uninstall to remove.
+	require.NoFileExists(t, filepath.Join(dir, manifestName))
+}

--- a/cli/internal/install/json.go
+++ b/cli/internal/install/json.go
@@ -1,0 +1,170 @@
+package install
+
+import (
+	"encoding/json"
+	"fmt"
+	"maps"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+)
+
+// removeJSONEntry deletes the entry at the given key path, pruning parents that
+// become empty.
+//
+// Returns UNCHANGED when the entry is absent.
+func removeJSONEntry(file string, keys []string, dryRun bool) (Change, error) {
+	if err := validateKeys(keys); err != nil {
+		return Change{}, err
+	}
+	if _, err := os.Stat(file); os.IsNotExist(err) {
+		return Change{Action: ActionUnchanged, Path: file}, nil
+	}
+	root, err := loadJSONObject(file)
+	if err != nil {
+		return Change{}, err
+	}
+	parents := make([]map[string]any, 0, len(keys))
+	cursor := root
+	for _, key := range keys[:len(keys)-1] {
+		child, ok := cursor[key].(map[string]any)
+		if !ok {
+			return Change{Action: ActionUnchanged, Path: file}, nil
+		}
+		parents = append(parents, cursor)
+		cursor = child
+	}
+	leaf := keys[len(keys)-1]
+	if _, ok := cursor[leaf]; !ok {
+		return Change{Action: ActionUnchanged, Path: file}, nil
+	}
+	delete(cursor, leaf)
+	// Walk back up: parents[i] is the object at depth i and keys[i] is the key
+	// within it that led down the path; drop any parent left empty.
+	for i := len(parents) - 1; i >= 0; i-- {
+		key := keys[i]
+		if child, ok := parents[i][key].(map[string]any); ok && len(child) == 0 {
+			delete(parents[i], key)
+		} else {
+			break
+		}
+	}
+	if !dryRun {
+		if err := writeJSONObject(file, root); err != nil {
+			return Change{}, err
+		}
+	}
+	return Change{Action: ActionRemoved, Path: file}, nil
+}
+
+// upsertJSONEntry merges desired into file at the given key path, preserving
+// sibling keys and creating intermediate objects.
+//
+// Returns CREATED when the leaf was absent, UPDATED when a managed field
+// changed, UNCHANGED otherwise.
+func upsertJSONEntry(file string, keys []string, desired map[string]any, dryRun bool) (Change, error) {
+	if err := validateKeys(keys); err != nil {
+		return Change{}, err
+	}
+	root, err := loadJSONObject(file)
+	if err != nil {
+		return Change{}, err
+	}
+	cursor := root
+	for _, key := range keys[:len(keys)-1] {
+		existing, present := cursor[key]
+		if !present || existing == nil {
+			child := map[string]any{}
+			cursor[key] = child
+			cursor = child
+			continue
+		}
+		child, ok := existing.(map[string]any)
+		if !ok {
+			return Change{}, fmt.Errorf("config entry %q is not an object", key)
+		}
+		cursor = child
+	}
+	leaf := keys[len(keys)-1]
+	existing, ok := cursor[leaf].(map[string]any)
+	action := ActionUpdated
+	if !ok {
+		// Clone so the stored entry is not aliased to the caller's map.
+		cursor[leaf] = maps.Clone(desired)
+		action = ActionCreated
+	} else {
+		changed := false
+		for k, v := range desired {
+			if !reflect.DeepEqual(existing[k], v) {
+				existing[k] = v
+				changed = true
+			}
+		}
+		if !changed {
+			return Change{Action: ActionUnchanged, Path: file}, nil
+		}
+	}
+	if !dryRun {
+		if err := writeJSONObject(file, root); err != nil {
+			return Change{}, err
+		}
+	}
+	return Change{Action: action, Path: file}, nil
+}
+
+// loadJSONObject reads the file at path into a map, treating a missing file as empty.
+func loadJSONObject(path string) (map[string]any, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return map[string]any{}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading config file: %w", err)
+	}
+	if len(data) == 0 {
+		return map[string]any{}, nil
+	}
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("config file is not a JSON object: %w", err)
+	}
+	if m == nil {
+		// A file containing literal `null` decodes to a nil map; treat it as
+		// malformed rather than letting callers assign into a nil map.
+		return nil, fmt.Errorf("config file is not a JSON object")
+	}
+	return m, nil
+}
+
+// validateKeys rejects an empty key path or any blank key, which would otherwise
+// index out of range or create a meaningless empty-string object key.
+func validateKeys(keys []string) error {
+	if len(keys) == 0 {
+		return fmt.Errorf("config key path must contain at least one key")
+	}
+	for _, k := range keys {
+		if strings.TrimSpace(k) == "" {
+			return fmt.Errorf("config key path must not contain a blank key")
+		}
+	}
+	return nil
+}
+
+// writeJSONObject writes m to the file at path with two-space indent and a trailing newline.
+//
+// NOTE: Go marshals object keys in sorted order. Phase 1 accepts this; later
+// phases that touch large user-authored config preserve key order.
+func writeJSONObject(path string, m map[string]any) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("creating config directory: %w", err)
+	}
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encoding config file: %w", err)
+	}
+	if err := os.WriteFile(path, append(data, '\n'), 0o644); err != nil {
+		return fmt.Errorf("writing config file: %w", err)
+	}
+	return nil
+}

--- a/cli/internal/install/json_test.go
+++ b/cli/internal/install/json_test.go
@@ -1,0 +1,89 @@
+package install
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func readJSON(t *testing.T, path string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(data, &m))
+	return m
+}
+
+func TestUpsertCreatesNestedAndPreservesSiblings(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "mcp_config.json")
+	require.NoError(t, os.WriteFile(p, []byte(`{"mcpServers":{"other":{"command":"x"}}}`), 0o644))
+
+	c, err := upsertJSONEntry(
+		p,
+		[]string{"mcpServers", "cq"},
+		map[string]any{"command": "/bin/cq", "args": []any{"mcp"}},
+		false,
+	)
+	require.NoError(t, err)
+	require.Equal(t, ActionCreated, c.Action)
+
+	m := readJSON(t, p)
+	servers := m["mcpServers"].(map[string]any)
+	require.Contains(t, servers, "other")
+	require.Equal(t, "/bin/cq", servers["cq"].(map[string]any)["command"])
+}
+
+func TestUpsertIdempotent(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "mcp_config.json")
+	desired := map[string]any{"command": "/bin/cq", "args": []any{"mcp"}}
+	_, err := upsertJSONEntry(p, []string{"mcpServers", "cq"}, desired, false)
+	require.NoError(t, err)
+	c, err := upsertJSONEntry(p, []string{"mcpServers", "cq"}, desired, false)
+	require.NoError(t, err)
+	require.Equal(t, ActionUnchanged, c.Action)
+}
+
+func TestRemoveEntryPrunesEmptyParent(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "mcp_config.json")
+	_, err := upsertJSONEntry(p, []string{"mcpServers", "cq"}, map[string]any{"command": "/bin/cq"}, false)
+	require.NoError(t, err)
+	c, err := removeJSONEntry(p, []string{"mcpServers", "cq"}, false)
+	require.NoError(t, err)
+	require.Equal(t, ActionRemoved, c.Action)
+	m := readJSON(t, p)
+	require.NotContains(t, m, "mcpServers")
+}
+
+func TestUpsertRejectsNonObjectIntermediate(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "mcp_config.json")
+	require.NoError(t, os.WriteFile(p, []byte(`{"mcpServers":"oops"}`), 0o644))
+	_, err := upsertJSONEntry(p, []string{"mcpServers", "cq"}, map[string]any{"command": "/bin/cq"}, false)
+	require.Error(t, err)
+}
+
+func TestUpsertRejectsNullConfig(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "mcp_config.json")
+	require.NoError(t, os.WriteFile(p, []byte("null"), 0o644))
+	_, err := upsertJSONEntry(p, []string{"mcpServers", "cq"}, map[string]any{"command": "/bin/cq"}, false)
+	require.Error(t, err)
+}
+
+func TestJSONEntryRejectsEmptyPath(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "mcp_config.json")
+	require.NoError(t, os.WriteFile(p, []byte("{}"), 0o644))
+	_, err := upsertJSONEntry(p, nil, map[string]any{"command": "/bin/cq"}, false)
+	require.Error(t, err)
+	_, err = removeJSONEntry(p, nil, false)
+	require.Error(t, err)
+}
+
+func TestJSONEntryRejectsBlankKey(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "mcp_config.json")
+	require.NoError(t, os.WriteFile(p, []byte("{}"), 0o644))
+	_, err := upsertJSONEntry(p, []string{"mcpServers", "  "}, map[string]any{"command": "/bin/cq"}, false)
+	require.Error(t, err)
+}

--- a/cli/internal/install/manifest.go
+++ b/cli/internal/install/manifest.go
@@ -1,0 +1,66 @@
+package install
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// manifestEntry records one installed file and its content hash.
+type manifestEntry struct {
+	// Path is the file's path relative to the install directory.
+	Path string `json:"path"`
+
+	// SHA256 is the hex sha256 of the file's content at install time.
+	SHA256 string `json:"sha256"`
+}
+
+// manifest is the set of files an install owns within a directory.
+type manifest struct {
+	// Files lists each owned file with the hash written for it.
+	Files []manifestEntry `json:"files"`
+}
+
+// hashFile returns the lowercase hex sha256 of the file at path.
+func hashFile(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("reading file to hash: %w", err)
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// loadManifest reads the manifest at path, returning nil when it is absent.
+func loadManifest(path string) (*manifest, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading install manifest: %w", err)
+	}
+	var m manifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("parsing install manifest: %w", err)
+	}
+	return &m, nil
+}
+
+// writeManifest writes entries to the manifest at path with a trailing newline.
+func writeManifest(path string, entries []manifestEntry) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("creating manifest directory: %w", err)
+	}
+	data, err := json.MarshalIndent(manifest{Files: entries}, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encoding install manifest: %w", err)
+	}
+	if err := os.WriteFile(path, append(data, '\n'), 0o644); err != nil {
+		return fmt.Errorf("writing install manifest: %w", err)
+	}
+	return nil
+}

--- a/cli/internal/install/manifest_test.go
+++ b/cli/internal/install/manifest_test.go
@@ -1,0 +1,36 @@
+package install
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHashFileIsStable(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "f.txt")
+	require.NoError(t, os.WriteFile(p, []byte("hello"), 0o644))
+	h1, err := hashFile(p)
+	require.NoError(t, err)
+	h2, err := hashFile(p)
+	require.NoError(t, err)
+	require.Equal(t, h1, h2)
+	require.Len(t, h1, 64)
+}
+
+func TestManifestRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	mp := filepath.Join(dir, ".cq-install-manifest.json")
+	require.NoError(t, writeManifest(mp, []manifestEntry{{Path: "cq/SKILL.md", SHA256: "abc"}}))
+	got, err := loadManifest(mp)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, "cq/SKILL.md", got.Files[0].Path)
+}
+
+func TestLoadManifestMissingIsNil(t *testing.T) {
+	got, err := loadManifest(filepath.Join(t.TempDir(), "nope.json"))
+	require.NoError(t, err)
+	require.Nil(t, got)
+}

--- a/cli/internal/install/paths.go
+++ b/cli/internal/install/paths.go
@@ -1,0 +1,16 @@
+package install
+
+import "path/filepath"
+
+// SharedSkillsDir returns the cross-host skills commons under root.
+//
+// All non-Claude hosts read skills from this location, so the skill is
+// written once per scope rather than copied per host.
+func SharedSkillsDir(root string) string {
+	return filepath.Join(root, ".agents", "skills")
+}
+
+// windsurfTarget returns the Windsurf configuration directory under home.
+func windsurfTarget(home string) string {
+	return filepath.Join(home, ".codeium", "windsurf")
+}

--- a/cli/internal/install/paths_test.go
+++ b/cli/internal/install/paths_test.go
@@ -1,0 +1,18 @@
+package install
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSharedSkillsDir(t *testing.T) {
+	got := SharedSkillsDir("/home/dev")
+	require.Equal(t, filepath.Join("/home/dev", ".agents", "skills"), got)
+}
+
+func TestWindsurfTarget(t *testing.T) {
+	got := windsurfTarget("/home/dev")
+	require.Equal(t, filepath.Join("/home/dev", ".codeium", "windsurf"), got)
+}

--- a/cli/internal/install/registry.go
+++ b/cli/internal/install/registry.go
@@ -1,0 +1,21 @@
+package install
+
+// Selection records which hosts a single invocation targets.
+type Selection struct {
+	// Windsurf targets the Windsurf editor.
+	Windsurf bool
+}
+
+// registry maps a host name to its adapter; populated by each adapter's init().
+var registry = map[string]Host{}
+
+// SelectHosts returns the host adapters chosen by sel, in a stable order.
+func SelectHosts(sel Selection) []Host {
+	var hosts []Host
+	if sel.Windsurf {
+		if h, ok := registry["windsurf"]; ok {
+			hosts = append(hosts, h)
+		}
+	}
+	return hosts
+}

--- a/cli/internal/install/types.go
+++ b/cli/internal/install/types.go
@@ -1,0 +1,77 @@
+// Package install installs cq into supported agent hosts by writing each
+// host's skill and MCP configuration.
+//
+// NOTE: every file operation must be idempotent and must not overwrite
+// user-modified files; re-running an install is always safe.
+package install
+
+// Action is the kind of change a primitive applied, or would apply in dry-run.
+type Action string
+
+const (
+	// ActionCreated reports that a new file or config entry was written.
+	ActionCreated Action = "created"
+
+	// ActionRemoved reports that a file or config entry was deleted.
+	ActionRemoved Action = "removed"
+
+	// ActionSkipped reports that a user-modified target was left in place.
+	ActionSkipped Action = "skipped"
+
+	// ActionUnchanged reports that the target already matched; nothing was written.
+	ActionUnchanged Action = "unchanged"
+
+	// ActionUpdated reports that an existing file or config entry was changed.
+	ActionUpdated Action = "updated"
+)
+
+// Change is the outcome of a single primitive call.
+type Change struct {
+	// Action is the kind of change applied, or planned in dry-run.
+	Action Action
+
+	// Path is the file or directory the change targeted.
+	Path string
+
+	// Detail optionally explains the outcome, e.g. why a target was skipped.
+	Detail string
+}
+
+// Context carries the resolved per-host paths for one install or uninstall.
+type Context struct {
+	// Target is the host's configuration directory.
+	Target string
+
+	// SkillsDir is the shared skills commons the skill is written into.
+	SkillsDir string
+
+	// BinaryPath is the absolute cq binary path written into host config.
+	BinaryPath string
+
+	// DryRun reports the planned changes without writing.
+	DryRun bool
+}
+
+// Host installs and removes cq for one agent host.
+//
+// NOTE: implementations must be idempotent and must leave user-modified
+// files in place rather than clobbering them.
+// NOTE: the five methods are intentionally combined because every host adapter
+// must satisfy all of them; splitting into smaller interfaces would force every
+// call site to compose them back together with no benefit.
+type Host interface {
+	// GlobalTarget returns the host's global config dir for the given home.
+	GlobalTarget(home string) string
+
+	// Install writes cq into the host and reports per-step changes.
+	Install(ctx Context) ([]Change, error)
+
+	// Name is the host's stable identifier.
+	Name() string
+
+	// SupportsProject reports whether the host can be installed per-project.
+	SupportsProject() bool
+
+	// Uninstall removes cq from the host and reports per-step changes.
+	Uninstall(ctx Context) ([]Change, error)
+}

--- a/cli/internal/install/windsurf.go
+++ b/cli/internal/install/windsurf.go
@@ -1,0 +1,69 @@
+package install
+
+import (
+	"path/filepath"
+
+	"github.com/mozilla-ai/cq/sdk/go/prompts"
+)
+
+// windsurfMCPFile is the MCP configuration file Windsurf reads on every platform.
+const windsurfMCPFile = "mcp_config.json"
+
+// windsurfHost installs cq into the Windsurf editor (skill commons + MCP entry).
+//
+// Windsurf stores its config under ~/.codeium/windsurf on every platform and
+// is global-only; it reads skills from the shared commons.
+type windsurfHost struct{}
+
+// init registers the Windsurf adapter so SelectHosts can return it.
+func init() {
+	registry["windsurf"] = windsurfHost{}
+}
+
+// GlobalTarget returns the Windsurf config dir under home.
+func (windsurfHost) GlobalTarget(home string) string {
+	return windsurfTarget(home)
+}
+
+// Install writes the shared skill and the cq MCP server entry.
+func (windsurfHost) Install(ctx Context) ([]Change, error) {
+	skill, err := writeManagedFiles(ctx.SkillsDir, map[string]string{
+		filepath.Join("cq", "SKILL.md"): prompts.Skill(),
+	}, ctx.DryRun)
+	if err != nil {
+		return nil, err
+	}
+	mcp, err := upsertJSONEntry(
+		filepath.Join(ctx.Target, windsurfMCPFile),
+		[]string{"mcpServers", "cq"},
+		map[string]any{"command": ctx.BinaryPath, "args": []any{"mcp"}},
+		ctx.DryRun,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return []Change{skill, mcp}, nil
+}
+
+// Name returns the host identifier.
+func (windsurfHost) Name() string { return "windsurf" }
+
+// SupportsProject reports that Windsurf is global-only.
+func (windsurfHost) SupportsProject() bool { return false }
+
+// Uninstall removes the cq MCP entry.
+//
+// NOTE: the skill lives in the shared commons (~/.agents/skills), which other
+// hosts may also use, so uninstalling one host must not remove it; the shared
+// skill is intentionally left in place.
+func (windsurfHost) Uninstall(ctx Context) ([]Change, error) {
+	mcp, err := removeJSONEntry(
+		filepath.Join(ctx.Target, windsurfMCPFile),
+		[]string{"mcpServers", "cq"},
+		ctx.DryRun,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return []Change{mcp}, nil
+}

--- a/cli/internal/install/windsurf_test.go
+++ b/cli/internal/install/windsurf_test.go
@@ -1,0 +1,60 @@
+package install
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWindsurfInstallWritesSkillAndMCP(t *testing.T) {
+	home := t.TempDir()
+	h := windsurfHost{}
+	ctx := Context{
+		Target:     h.GlobalTarget(home),
+		SkillsDir:  SharedSkillsDir(home),
+		BinaryPath: "/opt/homebrew/bin/cq",
+	}
+	changes, err := h.Install(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, changes)
+
+	require.FileExists(t, filepath.Join(home, ".agents", "skills", "cq", "SKILL.md"))
+	cfg := filepath.Join(home, ".codeium", "windsurf", "mcp_config.json")
+	require.FileExists(t, cfg)
+	m := readJSON(t, cfg)
+	servers := m["mcpServers"].(map[string]any)
+	cq := servers["cq"].(map[string]any)
+	require.Equal(t, "/opt/homebrew/bin/cq", cq["command"])
+	require.Equal(t, []any{"mcp"}, cq["args"])
+}
+
+func TestWindsurfUninstallReverses(t *testing.T) {
+	home := t.TempDir()
+	h := windsurfHost{}
+	ctx := Context{Target: h.GlobalTarget(home), SkillsDir: SharedSkillsDir(home), BinaryPath: "/opt/homebrew/bin/cq"}
+	_, err := h.Install(ctx)
+	require.NoError(t, err)
+	_, err = h.Uninstall(ctx)
+	require.NoError(t, err)
+
+	m := readJSON(t, filepath.Join(home, ".codeium", "windsurf", "mcp_config.json"))
+	require.NotContains(t, m, "mcpServers")
+}
+
+func TestWindsurfRegistered(t *testing.T) {
+	hosts := SelectHosts(Selection{Windsurf: true})
+	require.Len(t, hosts, 1)
+	require.Equal(t, "windsurf", hosts[0].Name())
+}
+
+func TestWindsurfUninstallLeavesSharedSkill(t *testing.T) {
+	home := t.TempDir()
+	h := windsurfHost{}
+	ctx := Context{Target: h.GlobalTarget(home), SkillsDir: SharedSkillsDir(home), BinaryPath: "/opt/homebrew/bin/cq"}
+	_, err := h.Install(ctx)
+	require.NoError(t, err)
+	_, err = h.Uninstall(ctx)
+	require.NoError(t, err)
+	require.FileExists(t, filepath.Join(home, ".agents", "skills", "cq", "SKILL.md"))
+}

--- a/cli/main.go
+++ b/cli/main.go
@@ -50,6 +50,7 @@ func newRootCmd() *cobra.Command {
 		cmd.NewConfirmCmd,
 		cmd.NewDrainCmd,
 		cmd.NewFlagCmd,
+		cmd.NewInstallCmd,
 		cmd.NewMCPCmd,
 		cmd.NewPromptCmd,
 		cmd.NewProposeCmd,


### PR DESCRIPTION
## What

Add a `cq install` command that installs cq into a coding-agent host end to end, proven through the simplest host, Windsurf.

```
cq install --windsurf [--project DIR] [--dry-run] [--uninstall]
```

It writes the shared skill to `~/.agents/skills/cq/SKILL.md` and the cq MCP server entry into Windsurf's `~/.codeium/windsurf/mcp_config.json` (pointing at the binary's own absolute path), idempotently, and reverses both on uninstall.

## Why

This is the foundation for replacing the clone-and-`make` install flow for non-Claude hosts with a single binary-first command.
Windsurf is the first and simplest host (skill + MCP only); the install primitives and host-adapter pattern here are what the remaining hosts build on.

## How it's structured

- **Install primitives** (`cli/internal/install`): a sha256 manifest, an idempotent managed-file writer (path-traversal-guarded; never overwrites or prunes user-modified files), a sibling-preserving JSON deep upsert/remove, binary self-path resolution, and path helpers.
- **Windsurf host adapter**: writes the skill (from the embedded prompt) and the MCP entry; self-registers in the host registry.
- **`cq install` command**: per-host flags, dispatch, a per-host change summary, and an end-to-end test.

The three commits are layered (primitives → host → command) and each builds and tests independently.

## Testing

- Unit tests for every primitive (idempotency, user-modified-file safety, path-escape rejection, JSON merge/prune, binary path resolution).
- An end-to-end test driving the real command in a temp HOME (install → idempotent re-run → uninstall).
- `make lint-cli` clean; full `cli` test suite green.

## Scope and follow-ups

This is the first host only. Subsequent work adds the other hosts: Cursor (with a lifecycle-hook handler), OpenCode and Pi, Claude, and GitHub Copilot.
`cq install` is the only new user-facing command; uninstall is a flag, and scope is project-or-global (no separate global flag).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `cq install` command to install or remove agent skills and configure the MCP server.
  * Added Windsurf integration via `--windsurf`, creating/updating the MCP server entry and uninstalling it on request.
  * Introduced a manifest-backed install/uninstall flow for safe, idempotent updates (including digest-based file management) and support for an optional install binary override.
* **Tests**
  * Added integration and unit tests covering host selection, Windsurf end-to-end install/uninstall, managed-file lifecycle, JSON entry upsert/removal, safe path handling, and binary-path validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->