### PR TITLE
refactor: move package doc comments to doc.go files

### DIFF
--- a/cli/internal/install/doc.go
+++ b/cli/internal/install/doc.go
@@ -1,0 +1,6 @@
+// Package install installs cq into supported agent hosts by writing each
+// host's skill and MCP configuration.
+//
+// NOTE: every file operation must be idempotent and must not overwrite
+// user-modified files; re-running an install is always safe.
+package install

--- a/cli/internal/install/types.go
+++ b/cli/internal/install/types.go
@@ -1,8 +1,3 @@
-// Package install installs cq into supported agent hosts by writing each
-// host's skill and MCP configuration.
-//
-// NOTE: every file operation must be idempotent and must not overwrite
-// user-modified files; re-running an install is always safe.
 package install
 
 // Action is the kind of change a primitive applied, or would apply in dry-run.

--- a/cli/internal/version/doc.go
+++ b/cli/internal/version/doc.go
@@ -1,0 +1,2 @@
+// Package version provides build-time version information for the CLI.
+package version

--- a/cli/internal/version/version.go
+++ b/cli/internal/version/version.go
@@ -1,4 +1,3 @@
-// Package version provides build-time version information for the CLI.
 package version
 
 import "fmt"

--- a/cli/mcpserver/doc.go
+++ b/cli/mcpserver/doc.go
@@ -1,0 +1,2 @@
+// Package mcpserver exposes cq operations as MCP tool handlers over stdio.
+package mcpserver

--- a/cli/mcpserver/server.go
+++ b/cli/mcpserver/server.go
@@ -1,4 +1,3 @@
-// Package mcpserver exposes cq operations as MCP tool handlers over stdio.
 package mcpserver
 
 import (

--- a/sdk/go/discovery/doc.go
+++ b/sdk/go/discovery/doc.go
@@ -1,0 +1,4 @@
+// Package discovery resolves a user-supplied cq node address into the
+// concrete API base URL and protocol version that client code should use.
+// It implements the protocol described in docs/node-discovery-protocol.md.
+package discovery

--- a/sdk/go/discovery/types.go
+++ b/sdk/go/discovery/types.go
@@ -1,6 +1,3 @@
-// Package discovery resolves a user-supplied cq node address into the
-// concrete API base URL and protocol version that client code should use.
-// It implements the protocol described in docs/node-discovery-protocol.md.
 package discovery
 
 import "time"

--- a/sdk/go/internal/version/doc.go
+++ b/sdk/go/internal/version/doc.go
@@ -1,0 +1,2 @@
+// Package version provides build-time version information.
+package version

--- a/sdk/go/internal/version/version.go
+++ b/sdk/go/internal/version/version.go
@@ -1,4 +1,3 @@
-// Package version provides build-time version information.
 package version
 
 import "fmt"

--- a/sdk/go/prompts/doc.go
+++ b/sdk/go/prompts/doc.go
@@ -1,0 +1,5 @@
+// Package prompts provides the canonical cq agent prompts embedded from
+// the plugin authoring sources. Each prompt is synced into this package via
+// "make sync-prompts" so SDK consumers can surface the same text that the
+// Claude Code and OpenCode slash commands use.
+package prompts

--- a/sdk/go/prompts/prompts.go
+++ b/sdk/go/prompts/prompts.go
@@ -1,7 +1,3 @@
-// Package prompts provides the canonical cq agent prompts embedded from
-// the plugin authoring sources. Each prompt is synced into this package via
-// "make sync-prompts" so SDK consumers can surface the same text that the
-// Claude Code and OpenCode slash commands use.
 package prompts
 
 import _ "embed"

--- a/sdk/go/ttl/doc.go
+++ b/sdk/go/ttl/doc.go
@@ -1,0 +1,9 @@
+// Package ttl parses the duration grammar shared by the cq platform's
+// API-key TTL field. The grammar is a strict subset of Go's
+// time.ParseDuration: a single positive ASCII integer followed by
+// exactly one unit suffix from {s, m, h, d}. Zero is rejected because
+// a zero-TTL key is meaningless. Parsing is case-insensitive on input
+// but always returns the canonical lower-case form so the value the
+// platform validates and persists is unambiguous regardless of which
+// client emitted it.
+package ttl

--- a/sdk/go/ttl/ttl.go
+++ b/sdk/go/ttl/ttl.go
@@ -1,11 +1,3 @@
-// Package ttl parses the duration grammar shared by the cq platform's
-// API-key TTL field. The grammar is a strict subset of Go's
-// time.ParseDuration: a single positive ASCII integer followed by
-// exactly one unit suffix from {s, m, h, d}. Zero is rejected because
-// a zero-TTL key is meaningless. Parsing is case-insensitive on input
-// but always returns the canonical lower-case form so the value the
-// platform validates and persists is unambiguous regardless of which
-// client emitted it.
 package ttl
 
 import (


### PR DESCRIPTION
## What

Relocates package-level documentation comments from arbitrary implementation files onto dedicated `doc.go` files in each affected package.

| Package | Doc comment moved from |
|---|---|
| `cli/internal/install` | `types.go` |
| `cli/internal/version` | `version.go` |
| `cli/mcpserver` | `server.go` |
| `sdk/go/discovery` | `types.go` |
| `sdk/go/internal/version` | `version.go` |
| `sdk/go/prompts` | `prompts.go` |
| `sdk/go/ttl` | `ttl.go` |

## Why

A package doc comment attached to a non-`doc.go` file is brittle: it travels with whatever implementation file happened to host it, and readers don't expect to find package docs there. This aligns the listed packages with the convention already in use elsewhere in the repo (`cli/internal/auth`, `cli/internal/credstore`, `schema`, and the `sdk/go` root package), where package docs live in `doc.go`.

## Changes

Each package's doc comment now lives in a new `doc.go`; the former host file retains a bare `package` clause. No behavior change.

## Verification

- `make lint` (CI=true) — passes
- `make test` (CI=true) — passes (283 backend, 11 frontend, plus Go suites)
- `go build`/`go vet`/`gofmt` clean across both Go modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganised package documentation into dedicated files.

* **Refactor**
  * Removed TTL string parsing module and associated constants from the SDK.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->