### PR TITLE
feat(cli): add Cursor host, cq _hook handler, and --target flag

### DIFF
--- a/cli/cmd/hook.go
+++ b/cli/cmd/hook.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/mozilla-ai/cq/cli/internal/hook"
+)
+
+// NewHookCmd returns the hidden command a host's hook configuration invokes for
+// each lifecycle event. It binds its flags into a hook.Invocation and runs it.
+//
+// NOTE: this command is internal wiring written into host config by
+// `cq install`; it is not part of the user-facing command surface.
+func NewHookCmd() *cobra.Command {
+	var inv hook.Invocation
+	cmd := &cobra.Command{
+		Use:    "_hook",
+		Short:  "Handle a coding-agent lifecycle hook event.",
+		Hidden: true,
+		Args:   cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := hook.Run(inv, cmd.InOrStdin(), cmd.OutOrStdout()); err != nil {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "cq: hook internal error: %v\n", err)
+			}
+			return nil
+		},
+	}
+	flags := cmd.Flags()
+	flags.Var(&inv.Host, "host", fmt.Sprintf("host whose hook fired (one of: %s)", hook.AllowedHosts()))
+	flags.Var(&inv.Mode, "mode", fmt.Sprintf("lifecycle event mode (one of: %s)", hook.AllowedModes()))
+	flags.StringVar(&inv.StateDir, "state-dir", "", "directory for cross-event hook state")
+	_ = cmd.MarkFlagRequired("host")
+	_ = cmd.MarkFlagRequired("mode")
+	_ = cmd.MarkFlagRequired("state-dir")
+	return cmd
+}

--- a/cli/cmd/hook_test.go
+++ b/cli/cmd/hook_test.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHookCmdRoutesStopOutput(t *testing.T) {
+	dir := t.TempDir()
+	// Seed a failure via the command itself.
+	failCmd := NewHookCmd()
+	failCmd.SetIn(bytes.NewBufferString(
+		`{"conversation_id":"c1","tool_name":"Bash","tool_input":{"command":"go build"},"error_message":"boom"}`))
+	failCmd.SetArgs([]string{"--host", "cursor", "--mode", "post-tool-use-failure", "--state-dir", dir})
+	require.NoError(t, failCmd.Execute())
+	require.FileExists(t, filepath.Join(dir, "c1-failure.json"))
+
+	var out bytes.Buffer
+	stopCmd := NewHookCmd()
+	stopCmd.SetIn(bytes.NewBufferString(`{"conversation_id":"c1","status":"completed"}`))
+	stopCmd.SetOut(&out)
+	stopCmd.SetArgs([]string{"--host", "cursor", "--mode", "stop", "--state-dir", dir})
+	require.NoError(t, stopCmd.Execute())
+	require.Contains(t, out.String(), "previous tool Bash failed: boom")
+}
+
+func TestHookCmdRequiresFlags(t *testing.T) {
+	cmd := NewHookCmd()
+	cmd.SetArgs([]string{"--host", "cursor", "--mode", "stop"})
+	require.Error(t, cmd.Execute())
+}
+
+func TestHookCmdIsHidden(t *testing.T) {
+	require.True(t, NewHookCmd().Hidden)
+}
+
+func TestHookCmdSwallowsInternalErrors(t *testing.T) {
+	dir := t.TempDir()
+	// Point --state-dir at a file, not a directory, so MkdirAll fails.
+	statePath := filepath.Join(dir, "not-a-dir")
+	require.NoError(t, os.WriteFile(statePath, []byte("x"), 0o644))
+
+	cmd := NewHookCmd()
+	cmd.SetIn(bytes.NewBufferString(`{}`))
+	cmd.SetArgs([]string{"--host", "cursor", "--mode", "stop", "--state-dir", statePath})
+	require.NoError(t, cmd.Execute())
+}

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -2,7 +2,10 @@ package cmd
 
 import (
 	"fmt"
+	"maps"
 	"os"
+	"slices"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -17,16 +20,53 @@ type installFlags struct {
 	// project installs into the given project directory; empty means global.
 	project string
 
+	// targets names the hosts to install into; set via the repeatable --target.
+	targets targets
+
 	// uninstall removes cq instead of installing it.
 	uninstall bool
+}
 
-	// windsurf targets the Windsurf host.
-	windsurf bool
+// targets is the set of hosts selected by the repeatable --target flag.
+// It implements pflag.Value.
+type targets map[install.Target]struct{}
+
+// Set validates one --target occurrence, which may itself be a comma-separated
+// list, and adds each target to the set, ignoring blanks.
+func (t *targets) Set(v string) error {
+	names := parseTargetNames(v)
+	if len(names) == 0 {
+		return nil
+	}
+	for _, name := range names {
+		if !install.ValidTarget(name) {
+			return fmt.Errorf("unknown target %s, supported: %s", name, install.AllowedTargets())
+		}
+		(*t)[name] = struct{}{}
+	}
+	return nil
+}
+
+// String renders the selected targets as a sorted, comma-separated list.
+func (t targets) String() string {
+	return t.names().String()
+}
+
+// Type names the value kind shown in help output.
+func (t targets) Type() string {
+	return "target"
+}
+
+// names returns the selected targets as a sorted set.
+func (t targets) names() install.Targets {
+	return install.Targets(slices.Sorted(maps.Keys(t)))
 }
 
 // NewInstallCmd returns the install command.
 func NewInstallCmd() *cobra.Command {
-	f := &installFlags{}
+	f := &installFlags{
+		targets: targets{},
+	}
 	cmd := &cobra.Command{
 		Use:   "install",
 		Short: "Install cq into a coding-agent host.",
@@ -40,30 +80,66 @@ func NewInstallCmd() *cobra.Command {
 	flags := cmd.Flags()
 	flags.BoolVar(&f.dryRun, "dry-run", false, "report planned changes without writing")
 	flags.StringVar(&f.project, "project", "", "install into the given project directory rather than globally")
+	flags.Var(&f.targets, "target", fmt.Sprintf(
+		"coding-agent host to install into; repeatable (supported: %s)",
+		install.AllowedTargets(),
+	))
 	flags.BoolVar(&f.uninstall, "uninstall", false, "remove cq from the selected hosts")
-	flags.BoolVar(&f.windsurf, "windsurf", false, "target the Windsurf host")
 	return cmd
+}
+
+// parseTargetNames splits, trims, lowercases, and dedupes the raw flag value,
+// discarding blanks.
+func parseTargetNames(v string) []install.Target {
+	var names []install.Target
+	seen := map[install.Target]struct{}{}
+	for _, raw := range strings.Split(v, ",") {
+		name := install.Target(strings.ToLower(strings.TrimSpace(raw)))
+		if name == "" {
+			continue
+		}
+		if _, dup := seen[name]; dup {
+			continue
+		}
+		seen[name] = struct{}{}
+		names = append(names, name)
+	}
+	return names
+}
+
+// printChanges writes a per-host summary of applied changes.
+func printChanges(cmd *cobra.Command, host install.Target, changes []install.Change) {
+	marker := map[install.Action]string{
+		install.ActionCreated:   "+",
+		install.ActionUpdated:   "~",
+		install.ActionUnchanged: "=",
+		install.ActionRemoved:   "-",
+		install.ActionSkipped:   "!",
+	}
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "[%s]\n", host)
+	for _, c := range changes {
+		suffix := ""
+		if c.Detail != "" {
+			suffix = "  (" + c.Detail + ")"
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  %s %s%s\n", marker[c.Action], c.Path, suffix)
+	}
 }
 
 // runInstallCmd resolves the selected hosts and applies the requested action.
 func runInstallCmd(cmd *cobra.Command, f *installFlags) error {
-	hosts := install.SelectHosts(install.Selection{Windsurf: f.windsurf})
-	if len(hosts) == 0 {
-		return fmt.Errorf("select at least one host (e.g. --windsurf)")
+	hosts := install.SelectHosts(f.targets.names())
+	if len(hosts) < 1 {
+		return fmt.Errorf("select at least one --target (one of: %s)", install.AllowedTargets())
 	}
 
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return fmt.Errorf("resolving home directory: %w", err)
 	}
-	var binary string
-	if !f.uninstall {
-		// Uninstall does not write the binary path into host config, so only
-		// resolve it for installs.
-		binary, err = install.BinaryPath()
-		if err != nil {
-			return fmt.Errorf("resolving binary path: %w", err)
-		}
+	binary, err := install.BinaryPath()
+	if err != nil {
+		return fmt.Errorf("resolving binary path: %w", err)
 	}
 
 	for _, h := range hosts {
@@ -88,23 +164,4 @@ func runInstallCmd(cmd *cobra.Command, f *installFlags) error {
 		printChanges(cmd, h.Name(), changes)
 	}
 	return nil
-}
-
-// printChanges writes a per-host summary of applied changes.
-func printChanges(cmd *cobra.Command, host string, changes []install.Change) {
-	marker := map[install.Action]string{
-		install.ActionCreated:   "+",
-		install.ActionUpdated:   "~",
-		install.ActionUnchanged: "=",
-		install.ActionRemoved:   "-",
-		install.ActionSkipped:   "!",
-	}
-	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "[%s]\n", host)
-	for _, c := range changes {
-		suffix := ""
-		if c.Detail != "" {
-			suffix = "  (" + c.Detail + ")"
-		}
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  %s %s%s\n", marker[c.Action], c.Path, suffix)
-	}
 }

--- a/cli/cmd/install_test.go
+++ b/cli/cmd/install_test.go
@@ -1,0 +1,57 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mozilla-ai/cq/cli/internal/install"
+)
+
+func TestTargetsSetAccumulatesAndDedupes(t *testing.T) {
+	sel := targets{}
+	require.NoError(t, sel.Set("cursor"))
+	require.NoError(t, sel.Set("windsurf"))
+	require.NoError(t, sel.Set("cursor"))
+	require.Equal(t, install.Targets{install.TargetCursor, install.TargetWindsurf}, sel.names())
+}
+
+func TestTargetsSetSplitsCommasAndTrims(t *testing.T) {
+	sel := targets{}
+	require.NoError(t, sel.Set(" cursor , windsurf "))
+	require.Equal(t, install.Targets{install.TargetCursor, install.TargetWindsurf}, sel.names())
+}
+
+func TestTargetsSetGarbageInputIsNoOp(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		input string
+	}{
+		{"empty", ""},
+		{"whitespace", "   "},
+		{"bare commas", ", , , ,, ,,"},
+		{"comma only", ","},
+		{"tabs and newlines", " \t , \n "},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sel := targets{}
+			require.NoError(t, sel.Set(tc.input))
+			require.Empty(t, sel)
+		})
+	}
+}
+
+func TestTargetsSetRejectsUnknown(t *testing.T) {
+	sel := targets{}
+	err := sel.Set("emacs")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown target emacs")
+	require.Contains(t, err.Error(), "cursor")
+}
+
+func TestTargetsStringAndType(t *testing.T) {
+	sel := targets{}
+	require.NoError(t, sel.Set("windsurf,cursor"))
+	require.Equal(t, "target", sel.Type())
+	require.Equal(t, "cursor, windsurf", sel.String())
+}

--- a/cli/install_test.go
+++ b/cli/install_test.go
@@ -24,7 +24,29 @@ func runInstall(t *testing.T, args ...string) (string, error) {
 func TestInstallRequiresAHost(t *testing.T) {
 	_, err := runInstall(t)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "select at least one host")
+	require.Contains(t, err.Error(), "select at least one --target")
+}
+
+func TestInstallCursorEndToEnd(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	bin := filepath.Join(t.TempDir(), "cq")
+	t.Setenv("CQ_INSTALL_BINARY", bin)
+
+	out, err := runInstall(t, "--target", "cursor")
+	require.NoError(t, err)
+	require.Contains(t, out, "[cursor]")
+
+	require.FileExists(t, filepath.Join(home, ".agents", "skills", "cq", "SKILL.md"))
+	require.FileExists(t, filepath.Join(home, ".cursor", "mcp.json"))
+	require.FileExists(t, filepath.Join(home, ".cursor", "hooks.json"))
+	require.FileExists(t, filepath.Join(home, ".cursor", "rules", "cq.mdc"))
+
+	_, err = runInstall(t, "--target", "cursor", "--uninstall")
+	require.NoError(t, err)
+	require.NoFileExists(t, filepath.Join(home, ".cursor", "rules", "cq.mdc"))
+	// Shared skill survives uninstall.
+	require.FileExists(t, filepath.Join(home, ".agents", "skills", "cq", "SKILL.md"))
 }
 
 func TestInstallWindsurfEndToEnd(t *testing.T) {
@@ -33,7 +55,7 @@ func TestInstallWindsurfEndToEnd(t *testing.T) {
 	bin := filepath.Join(t.TempDir(), "cq")
 	t.Setenv("CQ_INSTALL_BINARY", bin)
 
-	_, err := runInstall(t, "--windsurf")
+	_, err := runInstall(t, "--target", "windsurf")
 	require.NoError(t, err)
 
 	require.FileExists(t, filepath.Join(home, ".agents", "skills", "cq", "SKILL.md"))
@@ -46,11 +68,11 @@ func TestInstallWindsurfEndToEnd(t *testing.T) {
 		m["mcpServers"].(map[string]any)["cq"].(map[string]any)["command"])
 
 	// Re-run is idempotent.
-	_, err = runInstall(t, "--windsurf")
+	_, err = runInstall(t, "--target", "windsurf")
 	require.NoError(t, err)
 
 	// Uninstall reverses the MCP entry.
-	_, err = runInstall(t, "--windsurf", "--uninstall")
+	_, err = runInstall(t, "--target", "windsurf", "--uninstall")
 	require.NoError(t, err)
 	data, err = os.ReadFile(cfg)
 	require.NoError(t, err)

--- a/cli/internal/hook/cursor.go
+++ b/cli/internal/hook/cursor.go
@@ -1,0 +1,265 @@
+package hook
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	// maxPayloadBytes bounds hook stdin processing to avoid unbounded memory use.
+	maxPayloadBytes = 1 << 20 // 1 MiB
+
+	// maxSnippetLength bounds the captured command/error text surfaced at stop.
+	maxSnippetLength = 200
+
+	// stateTTL is how long a per-conversation failure record is retained
+	// before session-start sweeps it.
+	stateTTL = 24 * time.Hour
+
+	// failureSuffix names a per-conversation failure record within the state dir.
+	failureSuffix = "-failure.json"
+
+	// sentinelKey is used when a payload carries no conversation id.
+	sentinelKey = "session"
+)
+
+// cursorPayload is the subset of a Cursor hook's stdin payload cq reads.
+//
+// NOTE: field names match Cursor's wire format (snake_case); do not rename them
+// to a Go convention — they are the external contract.
+type cursorPayload struct {
+	// ConversationID is Cursor's stable conversation identifier, used to key state.
+	ConversationID string `json:"conversation_id"`
+
+	// ToolName is the name of the tool the event concerns.
+	ToolName string `json:"tool_name"`
+
+	// ToolInput is the tool's raw input arguments.
+	ToolInput map[string]any `json:"tool_input"`
+
+	// ErrorMessage is the failure text on a post-tool-use-failure event.
+	ErrorMessage string `json:"error_message"`
+
+	// IsInterrupt reports whether the failure was a user interrupt rather than a real error.
+	IsInterrupt bool `json:"is_interrupt"`
+}
+
+// failureRecord is cq's own state persisted between the post-tool-use-failure
+// and stop events.
+//
+// NOTE: distinct from cursorPayload, which is Cursor's inbound wire schema; this
+// record is ours, so it is not host-named.
+type failureRecord struct {
+	// ToolName is the tool that failed.
+	ToolName string `json:"tool_name"`
+
+	// Input is the formatted, length-bounded tool input.
+	Input string `json:"input"`
+
+	// Error is the truncated failure message.
+	Error string `json:"error"`
+}
+
+// runCursor handles one Cursor lifecycle event.
+//
+// NOTE: the per-event helpers below are unprefixed because Cursor is the only
+// host today.
+// When a second host handler joins this package, give the host-specific helpers
+// a host prefix or move each host into its own subpackage.
+func runCursor(inv Invocation, in io.Reader, out io.Writer) error {
+	if inv.Mode == ModePostToolUse {
+		return nil
+	}
+	if err := os.MkdirAll(inv.StateDir, 0o700); err != nil {
+		return fmt.Errorf("creating hook state directory: %w", err)
+	}
+	payload := readPayload(in)
+
+	switch inv.Mode {
+	case ModeSessionStart:
+		return sweepState(inv.StateDir)
+	case ModePostToolUseFailure:
+		return recordFailure(inv.StateDir, payload)
+	case ModeStop:
+		return reportFailure(inv.StateDir, payload, out)
+	default:
+		return fmt.Errorf("unsupported cursor hook mode: %s", inv.Mode)
+	}
+}
+
+// readPayload parses the event payload, degrading to an empty payload on empty
+// or unparseable input so a hook never fails the agent over malformed stdin.
+func readPayload(in io.Reader) cursorPayload {
+	var p cursorPayload
+	raw, err := io.ReadAll(io.LimitReader(in, maxPayloadBytes+1))
+	if err != nil || len(raw) > maxPayloadBytes {
+		return p
+	}
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return p
+	}
+	// Fail open: unparseable stdin yields a zero payload rather than an error.
+	_ = json.Unmarshal(trimmed, &p)
+	return p
+}
+
+// recordFailure persists a failed tool call, skipping user interrupts.
+func recordFailure(stateDir string, p cursorPayload) error {
+	if p.IsInterrupt {
+		return nil
+	}
+	if p.ToolName == "" && p.ErrorMessage == "" {
+		return nil
+	}
+	path, err := statePath(stateDir, p)
+	if err != nil {
+		return err
+	}
+	data, err := json.Marshal(failureRecord{
+		ToolName: p.ToolName,
+		Input:    formatToolInput(p.ToolName, p.ToolInput),
+		Error:    truncate(p.ErrorMessage, maxSnippetLength),
+	})
+	if err != nil {
+		return fmt.Errorf("encoding hook failure record: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("writing hook failure record: %w", err)
+	}
+	return nil
+}
+
+// reportFailure prints any recorded failure for the conversation, then clears it.
+func reportFailure(stateDir string, p cursorPayload, out io.Writer) error {
+	path, err := statePath(stateDir, p)
+	if err != nil {
+		return err
+	}
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("reading hook failure record: %w", err)
+	}
+	var record failureRecord
+	if err := json.Unmarshal(data, &record); err != nil {
+		// A corrupt record is unrecoverable state cq wrote itself; discard it
+		// rather than surface noise or fail the stop hook on every turn.
+		return clearState(path)
+	}
+	_, _ = fmt.Fprintf(out, "cq: previous tool %s failed: %s\n  input: %s\n",
+		record.ToolName, record.Error, record.Input)
+	return clearState(path)
+}
+
+// clearState removes a consumed failure record, tolerating a concurrent delete.
+func clearState(path string) error {
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("clearing hook failure record: %w", err)
+	}
+	return nil
+}
+
+// sweepState removes failure records older than the TTL.
+func sweepState(stateDir string) error {
+	entries, err := os.ReadDir(stateDir)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("reading hook state directory: %w", err)
+	}
+	cutoff := time.Now().Add(-stateTTL)
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), failureSuffix) {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		if info.ModTime().Before(cutoff) {
+			// Best-effort cleanup: a record that resists removal is swept next time.
+			_ = os.Remove(filepath.Join(stateDir, entry.Name()))
+		}
+	}
+	return nil
+}
+
+// statePath returns the failure-record path for a conversation, guarding the
+// untrusted conversation id against directory traversal.
+func statePath(stateDir string, p cursorPayload) (string, error) {
+	name := stateKey(p.ConversationID) + failureSuffix
+	joined := filepath.Join(stateDir, name)
+	if filepath.Dir(joined) != filepath.Clean(stateDir) {
+		return "", fmt.Errorf("hook state path escapes the state directory")
+	}
+	return joined, nil
+}
+
+// stateKey reduces an untrusted conversation id to a filesystem-safe token,
+// falling back to a sentinel when nothing usable remains.
+func stateKey(id string) string {
+	var b strings.Builder
+	for _, r := range id {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-', r == '_':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('_')
+		}
+	}
+	token := strings.Trim(b.String(), "_")
+	if token == "" {
+		return sentinelKey
+	}
+	return token
+}
+
+// formatToolInput renders a one-line, length-bounded summary of a tool call.
+//
+// NOTE: the tool-name set is best-effort; unrecognized tools fall through to a
+// generic rendering, so an unknown or renamed Cursor tool degrades gracefully.
+func formatToolInput(toolName string, input map[string]any) string {
+	switch toolName {
+	case "Shell", "Bash":
+		return truncate(stringField(input, "command"), maxSnippetLength)
+	case "Edit":
+		return truncate(stringField(input, "file_path"), maxSnippetLength)
+	case "Write":
+		path := stringField(input, "path")
+		if path == "" {
+			path = stringField(input, "file_path")
+		}
+		return truncate(path+": "+stringField(input, "content"), maxSnippetLength)
+	case "Read":
+		return truncate(stringField(input, "file_path"), maxSnippetLength)
+	default:
+		return truncate(fmt.Sprintf("%s(%v)", toolName, input), maxSnippetLength)
+	}
+}
+
+// stringField returns m[key] when it is a string, else the empty string.
+func stringField(m map[string]any, key string) string {
+	if v, ok := m[key].(string); ok {
+		return v
+	}
+	return ""
+}
+
+// truncate shortens s to limit runes, appending an ellipsis when it was cut.
+func truncate(s string, limit int) string {
+	runes := []rune(s)
+	if len(runes) <= limit {
+		return s
+	}
+	return string(runes[:limit]) + "…"
+}

--- a/cli/internal/hook/cursor_test.go
+++ b/cli/internal/hook/cursor_test.go
@@ -1,0 +1,152 @@
+package hook
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// invoke runs one Cursor lifecycle event through Run.
+func invoke(mode Mode, stateDir string, in io.Reader, out io.Writer) error {
+	return Run(Invocation{Host: HostCursor, Mode: mode, StateDir: stateDir}, in, out)
+}
+
+func TestAllowedHostsListsRegistered(t *testing.T) {
+	require.Equal(t, Hosts{HostCursor}, AllowedHosts())
+}
+
+func TestHostSetValidatesAndNormalizes(t *testing.T) {
+	var h Host
+	require.NoError(t, h.Set("CURSOR"))
+	require.Equal(t, HostCursor, h)
+
+	err := (&h).Set("emacs")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unsupported hook host emacs")
+	require.Contains(t, err.Error(), "cursor")
+}
+
+func TestModeSetValidates(t *testing.T) {
+	var m Mode
+	require.NoError(t, m.Set("stop"))
+	require.Equal(t, ModeStop, m)
+
+	err := (&m).Set("no-such-mode")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unsupported hook mode no-such-mode")
+	require.Contains(t, err.Error(), "session-start")
+}
+
+func TestRunRejectsUnknownHostAndMode(t *testing.T) {
+	dir := t.TempDir()
+	require.Error(
+		t,
+		Run(Invocation{Host: "nope", Mode: ModeStop, StateDir: dir}, strings.NewReader("{}"), &bytes.Buffer{}),
+	)
+	require.Error(t, invoke("no-such-mode", dir, strings.NewReader("{}"), &bytes.Buffer{}))
+}
+
+func TestCursorCaptureThenSurfaceAtStop(t *testing.T) {
+	dir := t.TempDir()
+	payload := `{"conversation_id":"abc","tool_name":"Bash","tool_input":{"command":"make test"},"error_message":"exit 1","is_interrupt":false}`
+
+	require.NoError(t, invoke(ModePostToolUseFailure, dir, strings.NewReader(payload), &bytes.Buffer{}))
+	require.FileExists(t, filepath.Join(dir, "abc-failure.json"))
+
+	var out bytes.Buffer
+	require.NoError(t, invoke(ModeStop, dir, strings.NewReader(`{"conversation_id":"abc","status":"completed"}`), &out))
+	require.Contains(t, out.String(), "previous tool Bash failed: exit 1")
+	require.Contains(t, out.String(), "make test")
+	require.NoFileExists(t, filepath.Join(dir, "abc-failure.json"))
+}
+
+func TestCursorInterruptIsNotCaptured(t *testing.T) {
+	dir := t.TempDir()
+	payload := `{"conversation_id":"abc","tool_name":"Bash","is_interrupt":true}`
+	require.NoError(t, invoke(ModePostToolUseFailure, dir, strings.NewReader(payload), &bytes.Buffer{}))
+	require.NoFileExists(t, filepath.Join(dir, "abc-failure.json"))
+}
+
+func TestCursorStopWithoutFailureIsSilent(t *testing.T) {
+	dir := t.TempDir()
+	var out bytes.Buffer
+	require.NoError(t, invoke(ModeStop, dir, strings.NewReader(`{"conversation_id":"abc"}`), &out))
+	require.Empty(t, out.String())
+}
+
+func TestCursorMissingConversationIDUsesSentinel(t *testing.T) {
+	dir := t.TempDir()
+	payload := `{"tool_name":"Read","tool_input":{"file_path":"a.go"},"error_message":"boom"}`
+	require.NoError(t, invoke(ModePostToolUseFailure, dir, strings.NewReader(payload), &bytes.Buffer{}))
+	require.FileExists(t, filepath.Join(dir, "session-failure.json"))
+}
+
+func TestCursorConversationIDCannotEscapeStateDir(t *testing.T) {
+	dir := t.TempDir()
+	payload := `{"conversation_id":"../../etc/evil","tool_name":"X","error_message":"e"}`
+	require.NoError(t, invoke(ModePostToolUseFailure, dir, strings.NewReader(payload), &bytes.Buffer{}))
+	// No file is written outside the state dir.
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	for _, e := range entries {
+		require.True(t, strings.HasSuffix(e.Name(), "-failure.json"))
+	}
+	parent := filepath.Dir(dir)
+	_, statErr := os.Stat(filepath.Join(parent, "etc", "evil-failure.json"))
+	require.True(t, os.IsNotExist(statErr))
+}
+
+func TestCursorStopDiscardsCorruptRecord(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "abc-failure.json"), []byte("{not json"), 0o644))
+	var out bytes.Buffer
+	require.NoError(t, invoke(ModeStop, dir, strings.NewReader(`{"conversation_id":"abc"}`), &out))
+	require.Empty(t, out.String())
+	require.NoFileExists(t, filepath.Join(dir, "abc-failure.json"))
+}
+
+func TestCursorEmptyStdinDoesNotPanic(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, invoke(ModePostToolUseFailure, dir, strings.NewReader(""), &bytes.Buffer{}))
+	require.NoError(t, invoke(ModeStop, dir, strings.NewReader("   "), &bytes.Buffer{}))
+}
+
+func TestCursorSessionStartSweepsStaleState(t *testing.T) {
+	dir := t.TempDir()
+	stale := filepath.Join(dir, "old-failure.json")
+	require.NoError(t, os.WriteFile(stale, []byte("{}"), 0o644))
+	old := time.Now().Add(-48 * time.Hour)
+	require.NoError(t, os.Chtimes(stale, old, old))
+
+	fresh := filepath.Join(dir, "new-failure.json")
+	require.NoError(t, os.WriteFile(fresh, []byte("{}"), 0o644))
+
+	require.NoError(t, invoke(ModeSessionStart, dir, strings.NewReader(`{"conversation_id":"x"}`), &bytes.Buffer{}))
+	require.NoFileExists(t, stale)
+	require.FileExists(t, fresh)
+}
+
+func TestFormatToolInputShapes(t *testing.T) {
+	require.Equal(t, "make test", formatToolInput("Bash", map[string]any{"command": "make test"}))
+	require.Equal(t, "a.go", formatToolInput("Edit", map[string]any{"file_path": "a.go"}))
+	require.Equal(t, "a.go: hi", formatToolInput("Write", map[string]any{"path": "a.go", "content": "hi"}))
+	require.Equal(t, "x.go", formatToolInput("Read", map[string]any{"file_path": "x.go"}))
+	require.Contains(t, formatToolInput("Other", map[string]any{"k": "v"}), "Other(")
+}
+
+func TestTruncateIsRuneSafe(t *testing.T) {
+	require.Equal(t, "ab", truncate("ab", 5))
+	require.Equal(t, "ab…", truncate("abcde", 2))
+	// Marshalable check: the record round-trips through JSON.
+	rec := failureRecord{ToolName: "Bash", Input: "x", Error: "y"}
+	data, err := json.Marshal(rec)
+	require.NoError(t, err)
+	require.Contains(t, string(data), `"tool_name":"Bash"`)
+}

--- a/cli/internal/hook/doc.go
+++ b/cli/internal/hook/doc.go
@@ -1,0 +1,7 @@
+// Package hook handles coding-agent lifecycle events dispatched to the cq
+// binary by a host's hook configuration.
+//
+// NOTE: handlers report errors to their caller, but the cq _hook command
+// swallows them and exits 0, so a hook never blocks the agent on internal
+// failure. Payload parsing degrades to an empty payload rather than erroring.
+package hook

--- a/cli/internal/hook/hook.go
+++ b/cli/internal/hook/hook.go
@@ -1,0 +1,161 @@
+package hook
+
+import (
+	"fmt"
+	"io"
+	"maps"
+	"slices"
+	"strings"
+)
+
+// HostCursor is the Cursor editor host.
+const HostCursor Host = "cursor"
+
+const (
+	// ModeSessionStart fires when an agent session begins.
+	ModeSessionStart Mode = "session-start"
+
+	// ModePostToolUse fires after any tool call.
+	ModePostToolUse Mode = "post-tool-use"
+
+	// ModePostToolUseFailure fires after a failed tool call.
+	ModePostToolUseFailure Mode = "post-tool-use-failure"
+
+	// ModeStop fires when an agent turn ends.
+	ModeStop Mode = "stop"
+)
+
+// handlers maps each host to its hook handler.
+//
+// It is the single source of truth for the hosts cq dispatches hooks for;
+// adding an entry extends ValidHost, AllowedHosts, and Run.
+var handlers = map[Host]handler{
+	HostCursor: runCursor,
+}
+
+// modes is the set of canonical lifecycle modes.
+//
+// NOTE: use ValidMode for membership checks; AllowedModes for display.
+var modes = map[Mode]struct{}{
+	ModeSessionStart:       {},
+	ModePostToolUse:        {},
+	ModePostToolUseFailure: {},
+	ModeStop:               {},
+}
+
+// handler runs one lifecycle invocation for a single host, reading the event
+// payload from in and writing any user-facing output to out.
+type handler func(inv Invocation, in io.Reader, out io.Writer) error
+
+// Host names a coding-agent host with a registered hook handler. It implements
+// pflag.Value so it can back a validated --host flag.
+type Host string
+
+// Hosts is a set of hosts that renders as a comma-separated list.
+type Hosts []Host
+
+// Invocation is a single lifecycle hook call: which host fired, which event,
+// and where cross-event state is kept.
+type Invocation struct {
+	// Host is the coding-agent host whose hook fired.
+	Host Host
+
+	// Mode is the lifecycle event that fired.
+	Mode Mode
+
+	// StateDir is the directory holding cross-event hook state.
+	StateDir string
+}
+
+// Mode is a canonical lifecycle event a host reports to cq. It implements
+// pflag.Value so it can back a validated --mode flag.
+type Mode string
+
+// Modes is a set of modes that renders as a comma-separated list.
+type Modes []Mode
+
+// Set validates v against the registered hosts and records it.
+func (h *Host) Set(v string) error {
+	host := Host(strings.ToLower(strings.TrimSpace(v)))
+	if _, ok := handlers[host]; !ok {
+		return fmt.Errorf("unsupported hook host %s, supported: %s", v, AllowedHosts())
+	}
+	*h = host
+	return nil
+}
+
+// String returns the host name.
+func (h *Host) String() string { return string(*h) }
+
+// Type names the value kind shown in help output.
+func (h *Host) Type() string { return "host" }
+
+// String renders the hosts as a comma-separated list.
+func (hs Hosts) String() string {
+	parts := make([]string, len(hs))
+	for i, h := range hs {
+		parts[i] = string(h)
+	}
+	return strings.Join(parts, ", ")
+}
+
+// Set validates v against the canonical modes and records it.
+func (m *Mode) Set(v string) error {
+	mode := Mode(strings.ToLower(strings.TrimSpace(v)))
+	if !ValidMode(mode) {
+		return fmt.Errorf("unsupported hook mode %s, supported: %s", v, AllowedModes())
+	}
+	*m = mode
+	return nil
+}
+
+// String returns the mode name.
+func (m *Mode) String() string { return string(*m) }
+
+// Type names the value kind shown in help output.
+func (m *Mode) Type() string { return "mode" }
+
+// String renders the modes as a comma-separated list.
+func (ms Modes) String() string {
+	parts := make([]string, len(ms))
+	for i, m := range ms {
+		parts[i] = string(m)
+	}
+	return strings.Join(parts, ", ")
+}
+
+// AllowedHosts returns the registered hook hosts as a sorted display list.
+//
+// NOTE: use ValidHost for membership checks.
+func AllowedHosts() Hosts {
+	return Hosts(slices.Sorted(maps.Keys(handlers)))
+}
+
+// AllowedModes returns the canonical lifecycle modes as a sorted display list.
+//
+// NOTE: use ValidMode for membership checks.
+func AllowedModes() Modes {
+	return Modes(slices.Sorted(maps.Keys(modes)))
+}
+
+// Run dispatches one lifecycle invocation to its host's registered handler,
+// reading the event payload from in and writing any user-facing output to out.
+func Run(inv Invocation, in io.Reader, out io.Writer) error {
+	h, ok := handlers[inv.Host]
+	if !ok {
+		return fmt.Errorf("unsupported hook host %s, supported: %s", inv.Host, AllowedHosts())
+	}
+	return h(inv, in, out)
+}
+
+// ValidHost reports whether name is a registered hook host.
+func ValidHost(name Host) bool {
+	_, ok := handlers[name]
+	return ok
+}
+
+// ValidMode reports whether name is a canonical lifecycle mode.
+func ValidMode(name Mode) bool {
+	_, ok := modes[name]
+	return ok
+}

--- a/cli/internal/install/cursor.go
+++ b/cli/internal/install/cursor.go
@@ -1,0 +1,179 @@
+package install
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/mozilla-ai/cq/sdk/go/prompts"
+
+	"github.com/mozilla-ai/cq/cli/internal/hook"
+)
+
+const (
+	// cursorMCPFile is the MCP configuration file Cursor reads.
+	cursorMCPFile = "mcp.json"
+
+	// cursorHooksFile is the lifecycle-hook configuration file Cursor reads.
+	cursorHooksFile = "hooks.json"
+
+	// cursorStateDir holds the cq hook's cross-event state within the target.
+	cursorStateDir = "cq-hook-state"
+
+	// cursorRule is the always-applied Cursor rule pointing agents at the cq skill.
+	cursorRule = "---\n" +
+		"description: cq shared knowledge commons\n" +
+		"alwaysApply: true\n" +
+		"---\n\n" +
+		"Before starting any implementation task, load the `cq` skill and follow its Core Protocol.\n"
+)
+
+// cursorRuleRelPath is the always-applied rule file, relative to the target.
+var cursorRuleRelPath = filepath.Join("rules", "cq.mdc")
+
+// cursorHookModes maps each Cursor lifecycle event (the hooks.json key) to the
+// canonical cq hook mode passed to `cq _hook --mode`.
+var cursorHookModes = []struct {
+	// event is the Cursor hooks.json key for the lifecycle event.
+	event string
+
+	// mode is the canonical cq mode passed to cq _hook --mode.
+	mode hook.Mode
+}{
+	{"sessionStart", hook.ModeSessionStart},
+	{"postToolUseFailure", hook.ModePostToolUseFailure},
+	{"postToolUse", hook.ModePostToolUse},
+	{"stop", hook.ModeStop},
+}
+
+// cursorHost installs cq into the Cursor editor: the shared skill, the MCP
+// server entry, an always-applied rule, and the lifecycle hooks.
+//
+// Cursor stores its config under <home>/.cursor on every platform and is
+// global-only; it reads skills from the shared commons.
+type cursorHost struct{}
+
+// GlobalTarget returns the Cursor config dir under home.
+func (cursorHost) GlobalTarget(home string) string {
+	return cursorTarget(home)
+}
+
+// Install writes the shared skill, the MCP entry, the rule, and the hooks.
+func (cursorHost) Install(ctx Context) ([]Change, error) {
+	skill, err := writeManagedFiles(ctx.SkillsDir, map[string]string{
+		filepath.Join("cq", "SKILL.md"): prompts.Skill(),
+	}, ctx.DryRun)
+	if err != nil {
+		return nil, err
+	}
+	changes := []Change{skill}
+
+	mcp, err := upsertJSONEntry(
+		filepath.Join(ctx.Target, cursorMCPFile),
+		[]string{"mcpServers", "cq"},
+		map[string]any{"command": ctx.BinaryPath, "args": []any{"mcp"}},
+		ctx.DryRun,
+	)
+	if err != nil {
+		return nil, err
+	}
+	changes = append(changes, mcp)
+
+	rule, err := writeIfMissing(filepath.Join(ctx.Target, cursorRuleRelPath), cursorRule, ctx.DryRun)
+	if err != nil {
+		return nil, err
+	}
+	changes = append(changes, rule)
+
+	for _, hm := range cursorHookModes {
+		h, err := upsertHookEntry(
+			filepath.Join(ctx.Target, cursorHooksFile),
+			hm.event,
+			cursorHookCommand(ctx, hm.mode),
+			ctx.DryRun,
+		)
+		if err != nil {
+			return nil, err
+		}
+		changes = append(changes, h)
+	}
+	return changes, nil
+}
+
+// Name returns the host identifier.
+func (cursorHost) Name() Target { return TargetCursor }
+
+// SupportsProject reports that Cursor is installed globally in this phase.
+func (cursorHost) SupportsProject() bool { return false }
+
+// Uninstall removes the MCP entry, the rule (when unmodified), the hook
+// entries, and the hook state dir.
+//
+// NOTE: the skill lives in the shared commons (~/.agents/skills), which other
+// hosts may also use, so it is intentionally left in place.
+func (cursorHost) Uninstall(ctx Context) ([]Change, error) {
+	mcp, err := removeJSONEntry(
+		filepath.Join(ctx.Target, cursorMCPFile),
+		[]string{"mcpServers", "cq"},
+		ctx.DryRun,
+	)
+	if err != nil {
+		return nil, err
+	}
+	changes := []Change{mcp}
+
+	rule, err := removeOwnedFile(filepath.Join(ctx.Target, cursorRuleRelPath), sha256Hex(cursorRule), ctx.DryRun)
+	if err != nil {
+		return nil, err
+	}
+	changes = append(changes, rule)
+
+	for _, hm := range cursorHookModes {
+		h, err := removeHookEntry(
+			filepath.Join(ctx.Target, cursorHooksFile),
+			hm.event,
+			cursorHookCommand(ctx, hm.mode),
+			ctx.DryRun,
+		)
+		if err != nil {
+			return nil, err
+		}
+		changes = append(changes, h)
+	}
+
+	stateChange, err := removeCursorStateDir(ctx)
+	if err != nil {
+		return nil, err
+	}
+	changes = append(changes, stateChange)
+	return changes, nil
+}
+
+// cursorHookCommand builds the shell command Cursor runs for one hook event:
+// this binary's hidden _hook handler, with the resolved state dir.
+func cursorHookCommand(ctx Context, mode hook.Mode) string {
+	return shellJoin(
+		ctx.BinaryPath,
+		"_hook",
+		"--host", string(hook.HostCursor),
+		"--mode", string(mode),
+		"--state-dir", filepath.Join(ctx.Target, cursorStateDir),
+	)
+}
+
+// removeCursorStateDir deletes the hook state dir, which the installer and the
+// cq hook own entirely (no user files are ever written there).
+func removeCursorStateDir(ctx Context) (Change, error) {
+	dir := filepath.Join(ctx.Target, cursorStateDir)
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		return Change{Action: ActionUnchanged, Path: dir}, nil
+	} else if err != nil {
+		return Change{}, fmt.Errorf("checking hook state directory: %w", err)
+	}
+	if !ctx.DryRun {
+		if err := os.RemoveAll(dir); err != nil {
+			return Change{}, fmt.Errorf("removing hook state directory: %w", err)
+		}
+	}
+	return Change{Action: ActionRemoved, Path: dir}, nil
+}

--- a/cli/internal/install/cursor_test.go
+++ b/cli/internal/install/cursor_test.go
@@ -1,0 +1,107 @@
+package install
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mozilla-ai/cq/sdk/go/prompts"
+)
+
+func cursorCtx(t *testing.T) Context {
+	t.Helper()
+	root := t.TempDir()
+	return Context{
+		Target:     filepath.Join(root, ".cursor"),
+		SkillsDir:  SharedSkillsDir(root),
+		BinaryPath: filepath.Join(root, "bin", "cq"),
+	}
+}
+
+func TestCursorInstallWritesAllAssets(t *testing.T) {
+	ctx := cursorCtx(t)
+	changes, err := cursorHost{}.Install(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, changes)
+
+	// Shared skill.
+	skill, err := os.ReadFile(filepath.Join(ctx.SkillsDir, "cq", "SKILL.md"))
+	require.NoError(t, err)
+	require.Equal(t, prompts.Skill(), string(skill))
+
+	// MCP entry references the binary and the mcp subcommand.
+	mcp := readJSON(t, filepath.Join(ctx.Target, "mcp.json"))
+	cq := mcp["mcpServers"].(map[string]any)["cq"].(map[string]any)
+	require.Equal(t, ctx.BinaryPath, cq["command"])
+	require.Equal(t, []any{"mcp"}, cq["args"])
+
+	// Rule.
+	rule, err := os.ReadFile(filepath.Join(ctx.Target, "rules", "cq.mdc"))
+	require.NoError(t, err)
+	require.Contains(t, string(rule), "alwaysApply: true")
+
+	// Four hook entries, each pointing at the binary's _hook with the state dir.
+	hooks := readJSON(t, filepath.Join(ctx.Target, "hooks.json"))["hooks"].(map[string]any)
+	for _, key := range []string{"sessionStart", "postToolUseFailure", "postToolUse", "stop"} {
+		entries := hooks[key].([]any)
+		require.Len(t, entries, 1)
+		cmd := entries[0].(map[string]any)["command"].(string)
+		require.Contains(t, cmd, "_hook")
+		require.Contains(t, cmd, "--host cursor")
+		require.Contains(t, cmd, filepath.Join(ctx.Target, "cq-hook-state"))
+	}
+}
+
+func TestCursorInstallIsIdempotent(t *testing.T) {
+	ctx := cursorCtx(t)
+	_, err := cursorHost{}.Install(ctx)
+	require.NoError(t, err)
+	changes, err := cursorHost{}.Install(ctx)
+	require.NoError(t, err)
+	for _, c := range changes {
+		require.NotEqual(t, ActionCreated, c.Action)
+	}
+}
+
+func TestCursorUninstallReversesButKeepsSharedSkill(t *testing.T) {
+	ctx := cursorCtx(t)
+	_, err := cursorHost{}.Install(ctx)
+	require.NoError(t, err)
+
+	_, err = cursorHost{}.Uninstall(ctx)
+	require.NoError(t, err)
+
+	// MCP entry gone.
+	mcp := readJSON(t, filepath.Join(ctx.Target, "mcp.json"))
+	require.NotContains(t, mcp, "mcpServers")
+	// Rule gone.
+	require.NoFileExists(t, filepath.Join(ctx.Target, "rules", "cq.mdc"))
+	// Hook entries gone.
+	hooks := readJSON(t, filepath.Join(ctx.Target, "hooks.json"))["hooks"].(map[string]any)
+	require.Empty(t, hooks)
+	// State dir gone.
+	require.NoDirExists(t, filepath.Join(ctx.Target, "cq-hook-state"))
+	// Shared skill REMAINS (it is the cross-host commons).
+	require.FileExists(t, filepath.Join(ctx.SkillsDir, "cq", "SKILL.md"))
+}
+
+func TestCursorUninstallLeavesUserModifiedRule(t *testing.T) {
+	ctx := cursorCtx(t)
+	_, err := cursorHost{}.Install(ctx)
+	require.NoError(t, err)
+	rulePath := filepath.Join(ctx.Target, "rules", "cq.mdc")
+	require.NoError(t, os.WriteFile(rulePath, []byte("user edited\n"), 0o644))
+
+	_, err = cursorHost{}.Uninstall(ctx)
+	require.NoError(t, err)
+	require.FileExists(t, rulePath)
+}
+
+func TestCursorRegisteredAndProject(t *testing.T) {
+	h, ok := hosts[TargetCursor]
+	require.True(t, ok)
+	require.Equal(t, TargetCursor, h.Name())
+	require.False(t, h.SupportsProject())
+}

--- a/cli/internal/install/hooks.go
+++ b/cli/internal/install/hooks.go
@@ -1,0 +1,130 @@
+package install
+
+import "fmt"
+
+// hookCommandField is the key Cursor reads for a hook's shell command.
+const hookCommandField = "command"
+
+// eventEntries returns hooks[event] as a slice, treating an absent key as empty
+// and rejecting a non-array value.
+func eventEntries(hooks map[string]any, event string) ([]any, error) {
+	raw, present := hooks[event]
+	if !present || raw == nil {
+		return nil, nil
+	}
+	entries, ok := raw.([]any)
+	if !ok {
+		return nil, fmt.Errorf("hook entries for %q are not a list", event)
+	}
+	return entries, nil
+}
+
+// hooksObject returns root["hooks"] as an object, creating it when absent and
+// rejecting a non-object value.
+func hooksObject(root map[string]any) (map[string]any, error) {
+	raw, present := root["hooks"]
+	if !present || raw == nil {
+		hooks := map[string]any{}
+		root["hooks"] = hooks
+		return hooks, nil
+	}
+	hooks, ok := raw.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("hooks configuration is not an object")
+	}
+	return hooks, nil
+}
+
+// removeHookEntry deletes the entry whose command matches under hooks.<event>,
+// pruning the event key when it becomes empty.
+//
+// Returns UNCHANGED when the file or entry is absent, SKIPPED when the document
+// is malformed (left untouched rather than rewritten).
+func removeHookEntry(file, event, command string, dryRun bool) (Change, error) {
+	root, err := loadJSONObject(file)
+	if err != nil {
+		return Change{}, err
+	}
+	rawHooks, present := root["hooks"]
+	if !present {
+		return Change{Action: ActionUnchanged, Path: file}, nil
+	}
+	hooks, ok := rawHooks.(map[string]any)
+	if !ok {
+		return Change{Action: ActionSkipped, Path: file, Detail: "malformed hooks document; left in place"}, nil
+	}
+	rawEntries, present := hooks[event]
+	if !present {
+		return Change{Action: ActionUnchanged, Path: file}, nil
+	}
+	entries, ok := rawEntries.([]any)
+	if !ok {
+		return Change{Action: ActionSkipped, Path: file, Detail: "malformed hooks document; left in place"}, nil
+	}
+	kept := make([]any, 0, len(entries))
+	for _, e := range entries {
+		if obj, ok := e.(map[string]any); ok {
+			if cmd, ok := obj[hookCommandField].(string); ok && cmd == command {
+				continue
+			}
+		}
+		kept = append(kept, e)
+	}
+	if len(kept) == len(entries) {
+		return Change{Action: ActionUnchanged, Path: file}, nil
+	}
+	if len(kept) == 0 {
+		delete(hooks, event)
+	} else {
+		hooks[event] = kept
+	}
+	if !dryRun {
+		if err := writeJSONObject(file, root); err != nil {
+			return Change{}, err
+		}
+	}
+	return Change{Action: ActionRemoved, Path: file, Detail: event}, nil
+}
+
+// upsertHookEntry adds or updates the {command} entry under hooks.<event> in a
+// Cursor-style hooks file, seeding the required "version": 1 and preserving any
+// foreign entries and sibling keys.
+//
+// Returns CREATED when the command was absent, UNCHANGED when it already
+// matched. An invalid hooks document is rejected with an error rather than
+// being silently overwritten.
+func upsertHookEntry(file, event, command string, dryRun bool) (Change, error) {
+	root, err := loadJSONObject(file)
+	if err != nil {
+		return Change{}, err
+	}
+	if _, ok := root["version"]; !ok {
+		root["version"] = 1
+	}
+	hooks, err := hooksObject(root)
+	if err != nil {
+		return Change{}, err
+	}
+	entries, err := eventEntries(hooks, event)
+	if err != nil {
+		return Change{}, err
+	}
+	for _, e := range entries {
+		if obj, ok := e.(map[string]any); ok {
+			if cmd, ok := obj[hookCommandField].(string); ok && cmd == command {
+				return Change{Action: ActionUnchanged, Path: file}, nil
+			}
+		}
+	}
+	hooks[event] = append(entries, map[string]any{hookCommandField: command})
+	if !dryRun {
+		if err := writeJSONObject(file, root); err != nil {
+			return Change{}, err
+		}
+	}
+	action := ActionUpdated
+	if len(entries) == 0 {
+		action = ActionCreated
+	}
+	return Change{Action: action, Path: file, Detail: event}, nil
+}

--- a/cli/internal/install/hooks_test.go
+++ b/cli/internal/install/hooks_test.go
@@ -1,0 +1,123 @@
+package install
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpsertHookEntrySeedsVersionAndIsIdempotent(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "hooks.json")
+
+	c, err := upsertHookEntry(p, "sessionStart", "cq _hook --mode session-start", false)
+	require.NoError(t, err)
+	require.Equal(t, ActionCreated, c.Action)
+
+	m := readJSON(t, p)
+	require.EqualValues(t, 1, m["version"])
+	hooks := m["hooks"].(map[string]any)
+	entries := hooks["sessionStart"].([]any)
+	require.Len(t, entries, 1)
+	require.Equal(t, "cq _hook --mode session-start", entries[0].(map[string]any)["command"])
+
+	c, err = upsertHookEntry(p, "sessionStart", "cq _hook --mode session-start", false)
+	require.NoError(t, err)
+	require.Equal(t, ActionUnchanged, c.Action)
+}
+
+func TestUpsertHookEntryPreservesForeignEntries(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "hooks.json")
+	require.NoError(t, os.WriteFile(p, []byte(
+		`{"version":1,"hooks":{"sessionStart":[{"command":"other-tool"}]}}`), 0o644))
+
+	c, err := upsertHookEntry(p, "sessionStart", "cq _hook --mode session-start", false)
+	require.NoError(t, err)
+	require.Equal(t, ActionUpdated, c.Action)
+
+	hooks := readJSON(t, p)["hooks"].(map[string]any)
+	entries := hooks["sessionStart"].([]any)
+	require.Len(t, entries, 2)
+}
+
+func TestRemoveHookEntryPrunesEmptyEvent(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "hooks.json")
+	_, err := upsertHookEntry(p, "stop", "cq _hook --mode stop", false)
+	require.NoError(t, err)
+
+	c, err := removeHookEntry(p, "stop", "cq _hook --mode stop", false)
+	require.NoError(t, err)
+	require.Equal(t, ActionRemoved, c.Action)
+
+	hooks := readJSON(t, p)["hooks"].(map[string]any)
+	require.NotContains(t, hooks, "stop")
+}
+
+func TestRemoveHookEntryLeavesForeignEntries(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "hooks.json")
+	require.NoError(t, os.WriteFile(p, []byte(
+		`{"version":1,"hooks":{"stop":[{"command":"other-tool"},{"command":"cq _hook --mode stop"}]}}`), 0o644))
+
+	c, err := removeHookEntry(p, "stop", "cq _hook --mode stop", false)
+	require.NoError(t, err)
+	require.Equal(t, ActionRemoved, c.Action)
+
+	entries := readJSON(t, p)["hooks"].(map[string]any)["stop"].([]any)
+	require.Len(t, entries, 1)
+	require.Equal(t, "other-tool", entries[0].(map[string]any)["command"])
+}
+
+func TestRemoveHookEntryAbsentFileIsUnchanged(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "hooks.json")
+	c, err := removeHookEntry(p, "stop", "cq _hook --mode stop", false)
+	require.NoError(t, err)
+	require.Equal(t, ActionUnchanged, c.Action)
+}
+
+func TestUpsertHookEntryRejectsMalformedHooks(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "hooks.json")
+	require.NoError(t, os.WriteFile(p, []byte(`{"hooks":"oops"}`), 0o644))
+	_, err := upsertHookEntry(p, "stop", "cq _hook --mode stop", false)
+	require.Error(t, err)
+
+	require.NoError(t, os.WriteFile(p, []byte(`{"version":1,"hooks":{"stop":"oops"}}`), 0o644))
+	_, err = upsertHookEntry(p, "stop", "cq _hook --mode stop", false)
+	require.Error(t, err)
+}
+
+func TestRemoveHookEntryMalformedHooksSkips(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "hooks.json")
+	require.NoError(t, os.WriteFile(p, []byte(`{"hooks":"oops"}`), 0o644))
+	c, err := removeHookEntry(p, "stop", "cq _hook --mode stop", false)
+	require.NoError(t, err)
+	require.Equal(t, ActionSkipped, c.Action)
+}
+
+func TestHookEntryHandlesNonStringCommand(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "hooks.json")
+	require.NoError(t, os.WriteFile(p, []byte(
+		`{"version":1,"hooks":{"stop":[{"command":["not","a","string"]}]}}`), 0o644))
+
+	// Upsert treats the non-string entry as foreign and appends ours.
+	c, err := upsertHookEntry(p, "stop", "cq _hook --mode stop", false)
+	require.NoError(t, err)
+	require.Equal(t, ActionUpdated, c.Action)
+
+	// Remove skips the non-string entry and removes only ours.
+	c, err = removeHookEntry(p, "stop", "cq _hook --mode stop", false)
+	require.NoError(t, err)
+	require.Equal(t, ActionRemoved, c.Action)
+
+	// The non-string entry is still there.
+	hooks := readJSON(t, p)["hooks"].(map[string]any)
+	entries := hooks["stop"].([]any)
+	require.Len(t, entries, 1)
+}
+
+func TestUpsertHookEntryRejectsNullConfig(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "hooks.json")
+	require.NoError(t, os.WriteFile(p, []byte("null"), 0o644))
+	_, err := upsertHookEntry(p, "stop", "cq _hook --mode stop", false)
+	require.Error(t, err)
+}

--- a/cli/internal/install/json.go
+++ b/cli/internal/install/json.go
@@ -120,19 +120,19 @@ func loadJSONObject(path string) (map[string]any, error) {
 		return map[string]any{}, nil
 	}
 	if err != nil {
-		return nil, fmt.Errorf("reading config file: %w", err)
+		return nil, fmt.Errorf("reading config file %s: %w", path, err)
 	}
 	if len(data) == 0 {
 		return map[string]any{}, nil
 	}
 	var m map[string]any
 	if err := json.Unmarshal(data, &m); err != nil {
-		return nil, fmt.Errorf("config file is not a JSON object: %w", err)
+		return nil, fmt.Errorf("config file %s is not a JSON object: %w", path, err)
 	}
 	if m == nil {
 		// A file containing literal `null` decodes to a nil map; treat it as
 		// malformed rather than letting callers assign into a nil map.
-		return nil, fmt.Errorf("config file is not a JSON object")
+		return nil, fmt.Errorf("config file %s is not a JSON object", path)
 	}
 	return m, nil
 }

--- a/cli/internal/install/ownedfile.go
+++ b/cli/internal/install/ownedfile.go
@@ -1,0 +1,60 @@
+package install
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// removeOwnedFile deletes path only when its content still hashes to
+// wantHash, the value written at install time.
+//
+// Returns SKIPPED when the file has been modified since install (left in
+// place), UNCHANGED when it is already absent.
+func removeOwnedFile(path, wantHash string, dryRun bool) (Change, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return Change{Action: ActionUnchanged, Path: path}, nil
+	}
+	if err != nil {
+		return Change{}, fmt.Errorf("reading target file: %w", err)
+	}
+	if sha256Hex(string(data)) != wantHash {
+		return Change{Action: ActionSkipped, Path: path, Detail: "modified since install; left in place"}, nil
+	}
+	if !dryRun {
+		if err := os.Remove(path); err != nil {
+			return Change{}, fmt.Errorf("removing config file: %w", err)
+		}
+	}
+	return Change{Action: ActionRemoved, Path: path}, nil
+}
+
+// sha256Hex returns the lowercase hex sha256 of s.
+func sha256Hex(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:])
+}
+
+// writeIfMissing creates path with content when it does not yet exist.
+//
+// NOTE: an existing file is never overwritten, so a user's edits to a
+// previously-installed file always survive a re-install.
+func writeIfMissing(path, content string, dryRun bool) (Change, error) {
+	if _, err := os.Stat(path); err == nil {
+		return Change{Action: ActionUnchanged, Path: path}, nil
+	} else if !os.IsNotExist(err) {
+		return Change{}, fmt.Errorf("checking target file: %w", err)
+	}
+	if !dryRun {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			return Change{}, fmt.Errorf("creating config directory: %w", err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			return Change{}, fmt.Errorf("writing config file: %w", err)
+		}
+	}
+	return Change{Action: ActionCreated, Path: path}, nil
+}

--- a/cli/internal/install/ownedfile_test.go
+++ b/cli/internal/install/ownedfile_test.go
@@ -1,0 +1,72 @@
+package install
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteIfMissingCreatesThenLeavesUserEdits(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "rules", "cq.mdc")
+
+	c, err := writeIfMissing(p, "managed body\n", false)
+	require.NoError(t, err)
+	require.Equal(t, ActionCreated, c.Action)
+	got, err := os.ReadFile(p)
+	require.NoError(t, err)
+	require.Equal(t, "managed body\n", string(got))
+
+	// A second call with the same content is a no-op.
+	c, err = writeIfMissing(p, "managed body\n", false)
+	require.NoError(t, err)
+	require.Equal(t, ActionUnchanged, c.Action)
+
+	// A user edit is never clobbered, even with different desired content.
+	require.NoError(t, os.WriteFile(p, []byte("user edit\n"), 0o644))
+	c, err = writeIfMissing(p, "managed body\n", false)
+	require.NoError(t, err)
+	require.Equal(t, ActionUnchanged, c.Action)
+	got, err = os.ReadFile(p)
+	require.NoError(t, err)
+	require.Equal(t, "user edit\n", string(got))
+}
+
+func TestWriteIfMissingDryRunWritesNothing(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "rules", "cq.mdc")
+	c, err := writeIfMissing(p, "body\n", true)
+	require.NoError(t, err)
+	require.Equal(t, ActionCreated, c.Action)
+	_, statErr := os.Stat(p)
+	require.True(t, os.IsNotExist(statErr))
+}
+
+func TestRemoveOwnedFileHashGuards(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "cq.mdc")
+	require.NoError(t, os.WriteFile(p, []byte("managed body\n"), 0o644))
+	hash := sha256Hex("managed body\n")
+
+	// Absent file: unchanged.
+	c, err := removeOwnedFile(filepath.Join(dir, "absent.mdc"), hash, false)
+	require.NoError(t, err)
+	require.Equal(t, ActionUnchanged, c.Action)
+
+	// Unmodified file: removed.
+	c, err = removeOwnedFile(p, hash, false)
+	require.NoError(t, err)
+	require.Equal(t, ActionRemoved, c.Action)
+	_, statErr := os.Stat(p)
+	require.True(t, os.IsNotExist(statErr))
+}
+
+func TestRemoveOwnedFileLeavesUserModified(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "cq.mdc")
+	require.NoError(t, os.WriteFile(p, []byte("user edit\n"), 0o644))
+	c, err := removeOwnedFile(p, sha256Hex("managed body\n"), false)
+	require.NoError(t, err)
+	require.Equal(t, ActionSkipped, c.Action)
+	_, statErr := os.Stat(p)
+	require.NoError(t, statErr)
+}

--- a/cli/internal/install/paths.go
+++ b/cli/internal/install/paths.go
@@ -10,6 +10,13 @@ func SharedSkillsDir(root string) string {
 	return filepath.Join(root, ".agents", "skills")
 }
 
+// cursorTarget returns the Cursor configuration directory under home.
+//
+// Cursor reads config from <home>/.cursor on every platform.
+func cursorTarget(home string) string {
+	return filepath.Join(home, ".cursor")
+}
+
 // windsurfTarget returns the Windsurf configuration directory under home.
 func windsurfTarget(home string) string {
 	return filepath.Join(home, ".codeium", "windsurf")

--- a/cli/internal/install/registry.go
+++ b/cli/internal/install/registry.go
@@ -1,21 +1,65 @@
 package install
 
-// Selection records which hosts a single invocation targets.
-type Selection struct {
-	// Windsurf targets the Windsurf editor.
-	Windsurf bool
+import (
+	"maps"
+	"slices"
+	"strings"
+)
+
+const (
+	// TargetCursor is the Cursor editor.
+	TargetCursor Target = "cursor"
+
+	// TargetWindsurf is the Windsurf editor.
+	TargetWindsurf Target = "windsurf"
+)
+
+// hosts is every supported install adapter, keyed by target.
+//
+// It is the single source of truth for the targets cq install accepts; adding
+// an entry extends ValidTarget, AllowedTargets, and SelectHosts.
+var hosts = map[Target]Host{
+	TargetCursor:   cursorHost{},
+	TargetWindsurf: windsurfHost{},
 }
 
-// registry maps a host name to its adapter; populated by each adapter's init().
-var registry = map[string]Host{}
+// Target identifies a supported coding-agent host.
+type Target string
 
-// SelectHosts returns the host adapters chosen by sel, in a stable order.
-func SelectHosts(sel Selection) []Host {
-	var hosts []Host
-	if sel.Windsurf {
-		if h, ok := registry["windsurf"]; ok {
-			hosts = append(hosts, h)
+// Targets is a set of targets that renders as a sorted, comma-separated list.
+type Targets []Target
+
+// String renders the targets as a comma-separated list.
+func (ts Targets) String() string {
+	parts := make([]string, len(ts))
+	for i, t := range ts {
+		parts[i] = string(t)
+	}
+	return strings.Join(parts, ", ")
+}
+
+// AllowedTargets returns the supported targets as a sorted display list.
+//
+// NOTE: use ValidTarget for membership checks — this allocates a slice and is
+// intended for rendering help and error messages.
+func AllowedTargets() Targets {
+	return Targets(slices.Sorted(maps.Keys(hosts)))
+}
+
+// SelectHosts returns the adapters for the named targets in stable, sorted
+// order, skipping any name not present in the hosts map.
+func SelectHosts(names Targets) []Host {
+	selected := make([]Host, 0, len(names))
+	for _, name := range slices.Sorted(slices.Values(names)) {
+		if h, ok := hosts[name]; ok {
+			selected = append(selected, h)
 		}
 	}
-	return hosts
+	return selected
+}
+
+// ValidTarget reports whether name is a supported install target.
+func ValidTarget(name Target) bool {
+	_, ok := hosts[name]
+	return ok
 }

--- a/cli/internal/install/shelljoin.go
+++ b/cli/internal/install/shelljoin.go
@@ -1,0 +1,71 @@
+package install
+
+import "strings"
+
+// posixJoin quotes each arg for a POSIX shell, single-quoting any arg with
+// special characters and escaping embedded single quotes as: end-quote, backslash, single-quote, open-quote.
+func posixJoin(args []string) string {
+	quoted := make([]string, len(args))
+	for i, arg := range args {
+		if posixSafe(arg) {
+			quoted[i] = arg
+			continue
+		}
+		quoted[i] = "'" + strings.ReplaceAll(arg, "'", `'\''`) + "'"
+	}
+	return strings.Join(quoted, " ")
+}
+
+// posixSafe reports whether arg needs no quoting in a POSIX shell.
+func posixSafe(arg string) bool {
+	if arg == "" {
+		return false
+	}
+	for _, r := range arg {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+		case r == '-', r == '_', r == '.', r == '/', r == ':', r == '=', r == ',':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// quoteWindows quotes a single argument for the Windows command interpreter.
+func quoteWindows(arg string) string {
+	if arg != "" && !strings.ContainsAny(arg, " \t\n\v\"") {
+		return arg
+	}
+	var b strings.Builder
+	b.WriteByte('"')
+	backslashes := 0
+	for _, r := range arg {
+		switch r {
+		case '\\':
+			backslashes++
+		case '"':
+			b.WriteString(strings.Repeat(`\`, backslashes*2+1))
+			b.WriteByte('"')
+			backslashes = 0
+		default:
+			b.WriteString(strings.Repeat(`\`, backslashes))
+			b.WriteRune(r)
+			backslashes = 0
+		}
+	}
+	b.WriteString(strings.Repeat(`\`, backslashes*2))
+	b.WriteByte('"')
+	return b.String()
+}
+
+// windowsJoin quotes each arg following the CommandLineToArgvW rules used by the
+// Windows command interpreter: double-quote any arg containing a space or quote,
+// escaping embedded quotes and runs of backslashes that precede a quote.
+func windowsJoin(args []string) string {
+	quoted := make([]string, len(args))
+	for i, arg := range args {
+		quoted[i] = quoteWindows(arg)
+	}
+	return strings.Join(quoted, " ")
+}

--- a/cli/internal/install/shelljoin_test.go
+++ b/cli/internal/install/shelljoin_test.go
@@ -1,0 +1,33 @@
+package install
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPosixJoin(t *testing.T) {
+	require.Equal(t, "cq _hook --mode stop", posixJoin([]string{"cq", "_hook", "--mode", "stop"}))
+	require.Equal(t,
+		`/path/to/cq _hook --state-dir '/Users/Ada Lovelace/.cursor/cq-hook-state'`,
+		posixJoin([]string{"/path/to/cq", "_hook", "--state-dir", "/Users/Ada Lovelace/.cursor/cq-hook-state"}))
+	// Embedded single quote is escaped as '\''.
+	require.Equal(t, `'a'\''b'`, posixJoin([]string{"a'b"}))
+	require.Equal(t, "''", posixJoin([]string{""}))
+}
+
+func TestShellJoinDispatchesToPlatform(t *testing.T) {
+	// shellJoin dispatches to posixJoin or windowsJoin based on the host OS;
+	// confirm it at least produces the unquoted form for simple safe args.
+	result := shellJoin("cq", "_hook", "--mode", "stop")
+	require.Equal(t, "cq _hook --mode stop", result)
+}
+
+func TestWindowsJoin(t *testing.T) {
+	require.Equal(t, "cq _hook --mode stop", windowsJoin([]string{"cq", "_hook", "--mode", "stop"}))
+	require.Equal(t,
+		`C:\cq _hook --state-dir "C:\Users\Ada Lovelace\.cursor\cq-hook-state"`,
+		windowsJoin([]string{`C:\cq`, "_hook", "--state-dir", `C:\Users\Ada Lovelace\.cursor\cq-hook-state`}))
+	// A trailing backslash before the closing quote is doubled.
+	require.Equal(t, `"C:\dir with space\\"`, windowsJoin([]string{`C:\dir with space\`}))
+}

--- a/cli/internal/install/shelljoin_unix.go
+++ b/cli/internal/install/shelljoin_unix.go
@@ -1,0 +1,8 @@
+//go:build !windows
+
+package install
+
+// shellJoin quotes args for the host shell a coding-agent will use to run a hook command.
+func shellJoin(args ...string) string {
+	return posixJoin(args)
+}

--- a/cli/internal/install/shelljoin_windows.go
+++ b/cli/internal/install/shelljoin_windows.go
@@ -1,0 +1,8 @@
+//go:build windows
+
+package install
+
+// shellJoin quotes args for the host shell a coding-agent will use to run a hook command.
+func shellJoin(args ...string) string {
+	return windowsJoin(args)
+}

--- a/cli/internal/install/types.go
+++ b/cli/internal/install/types.go
@@ -62,7 +62,7 @@ type Host interface {
 	Install(ctx Context) ([]Change, error)
 
 	// Name is the host's stable identifier.
-	Name() string
+	Name() Target
 
 	// SupportsProject reports whether the host can be installed per-project.
 	SupportsProject() bool

--- a/cli/internal/install/windsurf.go
+++ b/cli/internal/install/windsurf.go
@@ -15,11 +15,6 @@ const windsurfMCPFile = "mcp_config.json"
 // is global-only; it reads skills from the shared commons.
 type windsurfHost struct{}
 
-// init registers the Windsurf adapter so SelectHosts can return it.
-func init() {
-	registry["windsurf"] = windsurfHost{}
-}
-
 // GlobalTarget returns the Windsurf config dir under home.
 func (windsurfHost) GlobalTarget(home string) string {
 	return windsurfTarget(home)
@@ -46,7 +41,7 @@ func (windsurfHost) Install(ctx Context) ([]Change, error) {
 }
 
 // Name returns the host identifier.
-func (windsurfHost) Name() string { return "windsurf" }
+func (windsurfHost) Name() Target { return TargetWindsurf }
 
 // SupportsProject reports that Windsurf is global-only.
 func (windsurfHost) SupportsProject() bool { return false }

--- a/cli/internal/install/windsurf_test.go
+++ b/cli/internal/install/windsurf_test.go
@@ -43,9 +43,9 @@ func TestWindsurfUninstallReverses(t *testing.T) {
 }
 
 func TestWindsurfRegistered(t *testing.T) {
-	hosts := SelectHosts(Selection{Windsurf: true})
-	require.Len(t, hosts, 1)
-	require.Equal(t, "windsurf", hosts[0].Name())
+	selected := SelectHosts(Targets{TargetWindsurf})
+	require.Len(t, selected, 1)
+	require.Equal(t, TargetWindsurf, selected[0].Name())
 }
 
 func TestWindsurfUninstallLeavesSharedSkill(t *testing.T) {

--- a/cli/main.go
+++ b/cli/main.go
@@ -62,6 +62,9 @@ func newRootCmd() *cobra.Command {
 		rootCmd.AddCommand(c)
 	}
 
+	// _hook is internal wiring invoked by host hook configs, not a user command.
+	rootCmd.AddCommand(cmd.NewHookCmd())
+
 	// Assign built-in commands (e.g. help, completion) to the 'system' group.
 	rootCmd.AddGroup(&cobra.Group{
 		ID:    "system",


### PR DESCRIPTION
## Summary

- Add install primitives for single-file ownership (`writeIfMissing`/`removeOwnedFile`), `hooks.json` entry management (`upsertHookEntry`/`removeHookEntry`), and build-tagged cross-platform shell quoting.
- Introduce the `cli/internal/hook` package with strongly-typed `Host`/`Mode` enums, an `Invocation` struct, and a registry-based dispatcher handling Cursor lifecycle events (session-start, post-tool-use, post-tool-use-failure, stop) with per-conversation failure state.
- Add the Cursor host adapter: shared skill, MCP entry, always-applied rule, and four hook entries; uninstall reverses all but leaves the shared skill commons in place.
- Replace per-host boolean flags (`--windsurf`, `--cursor`) with a single repeatable `--target` flag backed by a strongly-typed `Target` enum and map-based set, validated against the install registry.

## Test plan

- [x] `make lint-cli` — 0 issues
- [x] `make test-cli` — all 7 packages pass
- [x] `make lint && make test` — full repo green
- [x] `cq install --target cursor --dry-run` lists skill, mcp.json, rules/cq.mdc, and four hook entries with no writes
- [x] `cq install --target cursor --target windsurf` installs both in one run
- [ ] `cq install --target emacs` rejects with the allowed set listed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**New Features**
* Cursor editor integration: Install now supports Cursor as a target editor alongside Windsurf, configurable via the `--target` flag.
* Lifecycle hooks: Added hook system to capture and surface tool failures within supported editors, improving debugging and error visibility.

**Changes**
* The `cq install` command now uses `--target cursor` or `--target windsurf` instead of the `--windsurf` boolean flag, supporting multiple target selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->