### PR TITLE
sdk: align query validation bounds and clarify ranker limit contract

### DIFF
--- a/sdk/go/scoring.go
+++ b/sdk/go/scoring.go
@@ -12,7 +12,9 @@ import (
 // RankCandidates scores each candidate by relevance * confidence, sorts the
 // candidates by descending score, and truncates to the parameter limit.
 // Tags in params are normalized before scoring so a store may pass the raw
-// query parameters. A non-positive limit defaults to defaultStoreQueryLimit.
+// query parameters. A zero limit defaults to defaultStoreQueryLimit.
+// NOTE: callers must validate that Limit is non-negative before calling;
+// this helper does not reject negative values (it treats them as zero).
 // Stores call this so ranking stays shared rather than duplicated per backend.
 func RankCandidates(candidates []KnowledgeUnit, params QueryParams) []KnowledgeUnit {
 	domains := normalizeDomains(params.Domains)

--- a/sdk/python/src/cq/store.py
+++ b/sdk/python/src/cq/store.py
@@ -43,8 +43,13 @@ _CONFIDENCE_BUCKETS: list[tuple[float, str]] = [
 ]
 
 _FTS_MAX_TERMS = 20
-_MAX_QUERY_DOMAINS = 50
 _FTS_MAX_TERM_LENGTH = 200
+
+# Store-level query bounds, aligned with the Go SDK.
+_MAX_QUERY_DOMAINS = 50
+_MAX_QUERY_FRAMEWORKS = 50
+_MAX_QUERY_LANGUAGES = 50
+_MAX_QUERY_LIMIT = 500
 
 
 def _default_db_path() -> Path:
@@ -251,7 +256,9 @@ def rank_candidates(candidates: list[KnowledgeUnit], params: QueryParams) -> lis
     hands them here, and returns the result. Scoring multiplies each
     unit's relevance (domain overlap plus language/framework/pattern
     boosts) by its confidence, sorts descending, and keeps the top
-    ``params.limit`` units.
+    ``params.limit`` units. A zero limit defaults to ``_DEFAULT_QUERY_LIMIT``.
+    NOTE: callers must validate that limit is non-negative before calling;
+    this helper does not reject negative values (it treats them as zero).
     """
     scored: list[tuple[float, KnowledgeUnit]] = []
     for unit in candidates:
@@ -522,10 +529,12 @@ class SqliteStore:
         ``StoreQueryResult.warnings`` rather than raised.
 
         Raises:
-            ValueError: If limit is negative.
+            ValueError: If limit is negative or exceeds the maximum.
         """
         if params.limit < 0:
             raise ValueError("limit must be positive")
+        if params.limit > _MAX_QUERY_LIMIT:
+            raise ValueError(f"limit must be at most {_MAX_QUERY_LIMIT}")
 
         normalized = _normalize_domains(params.domains)
         if not normalized:
@@ -537,6 +546,14 @@ class SqliteStore:
                 _MAX_QUERY_DOMAINS,
             )
             normalized = normalized[:_MAX_QUERY_DOMAINS]
+
+        languages = _normalize_domains(params.languages)
+        if len(languages) > _MAX_QUERY_LANGUAGES:
+            raise ValueError(f"maximum number of languages ({_MAX_QUERY_LANGUAGES}) exceeded")
+
+        frameworks = _normalize_domains(params.frameworks)
+        if len(frameworks) > _MAX_QUERY_FRAMEWORKS:
+            raise ValueError(f"maximum number of frameworks ({_MAX_QUERY_FRAMEWORKS}) exceeded")
 
         # Safe: placeholders is only '?' characters, never user input.
         placeholders = ",".join("?" for _ in normalized)

--- a/sdk/python/src/cq/store.py
+++ b/sdk/python/src/cq/store.py
@@ -529,7 +529,8 @@ class SqliteStore:
         ``StoreQueryResult.warnings`` rather than raised.
 
         Raises:
-            ValueError: If limit is negative or exceeds the maximum.
+            ValueError: If limit is negative, exceeds the maximum, or
+                language/framework counts exceed their bounds.
         """
         if params.limit < 0:
             raise ValueError("limit must be positive")
@@ -598,7 +599,10 @@ class SqliteStore:
                 seen.add(unit.id)
                 candidates.append(unit)
 
-        ranked = rank_candidates(candidates, params.model_copy(update={"domains": normalized}))
+        ranked = rank_candidates(
+            candidates,
+            params.model_copy(update={"domains": normalized, "languages": languages, "frameworks": frameworks}),
+        )
         return StoreQueryResult(units=ranked, warnings=warnings)
 
     def stats(self, *, recent_limit: int = 5) -> StoreStats:

--- a/sdk/python/src/cq/stores/memory.py
+++ b/sdk/python/src/cq/stores/memory.py
@@ -155,7 +155,10 @@ class InMemoryStore:
             self._check_open()
             candidates = [u.model_copy(deep=True) for u in self._units.values() if wanted & set(u.domains)]
 
-        ranked = rank_candidates(candidates, params.model_copy(update={"domains": normalized}))
+        ranked = rank_candidates(
+            candidates,
+            params.model_copy(update={"domains": normalized, "languages": languages, "frameworks": frameworks}),
+        )
         return StoreQueryResult(units=ranked)
 
     def stats(self, *, recent_limit: int = 5) -> StoreStats:

--- a/sdk/python/src/cq/stores/memory.py
+++ b/sdk/python/src/cq/stores/memory.py
@@ -16,6 +16,9 @@ from ..store import (
     _CONFIDENCE_BUCKETS,
     _EPOCH_UTC,
     _MAX_QUERY_DOMAINS,
+    _MAX_QUERY_FRAMEWORKS,
+    _MAX_QUERY_LANGUAGES,
+    _MAX_QUERY_LIMIT,
     DuplicateUnitError,
     QueryParams,
     StoreQueryResult,
@@ -125,16 +128,27 @@ class InMemoryStore:
         full-text), then scores and ranks via the shared ranker.
 
         Raises:
-            ValueError: If limit is negative.
+            ValueError: If limit is negative, exceeds the maximum, or
+                language/framework counts exceed their bounds.
         """
         if params.limit < 0:
             raise ValueError("limit must be positive")
+        if params.limit > _MAX_QUERY_LIMIT:
+            raise ValueError(f"limit must be at most {_MAX_QUERY_LIMIT}")
 
         normalized = _normalize_domains(params.domains)
         if not normalized:
             return StoreQueryResult()
         if len(normalized) > _MAX_QUERY_DOMAINS:
             normalized = normalized[:_MAX_QUERY_DOMAINS]
+
+        languages = _normalize_domains(params.languages)
+        if len(languages) > _MAX_QUERY_LANGUAGES:
+            raise ValueError(f"maximum number of languages ({_MAX_QUERY_LANGUAGES}) exceeded")
+
+        frameworks = _normalize_domains(params.frameworks)
+        if len(frameworks) > _MAX_QUERY_FRAMEWORKS:
+            raise ValueError(f"maximum number of frameworks ({_MAX_QUERY_FRAMEWORKS}) exceeded")
 
         wanted = set(normalized)
         with self._lock:

--- a/sdk/python/tests/conformance.py
+++ b/sdk/python/tests/conformance.py
@@ -16,7 +16,15 @@ import pytest
 
 from cq.models import Context, Evidence, Insight, KnowledgeUnit, create_knowledge_unit
 from cq.scoring import apply_confirmation
-from cq.store import DuplicateUnitError, QueryParams, SqliteStore, Store
+from cq.store import (
+    _MAX_QUERY_FRAMEWORKS,
+    _MAX_QUERY_LANGUAGES,
+    _MAX_QUERY_LIMIT,
+    DuplicateUnitError,
+    QueryParams,
+    SqliteStore,
+    Store,
+)
 from cq.stores import InMemoryStore
 
 StoreFactory = Callable[[], Store]
@@ -57,6 +65,7 @@ def run_store_conformance(make_store: StoreFactory) -> None:
     _assert_query_respects_limit(make_store)
     _assert_query_returns_domain_matches(make_store)
     _assert_query_limit_zero_defaults_negative_raises(make_store)
+    _assert_query_bounds_reject_excess(make_store)
     _assert_stats_aggregates(make_store)
     _assert_close_is_idempotent_and_blocks_ops(make_store)
 
@@ -222,6 +231,24 @@ def _assert_query_limit_zero_defaults_negative_raises(make_store: StoreFactory) 
         assert len(result.units) == 5
         with pytest.raises(ValueError, match="limit must be positive"):
             store.query(QueryParams(domains=["databases"], limit=-1))
+    finally:
+        store.close()
+
+
+def _assert_query_bounds_reject_excess(make_store: StoreFactory) -> None:
+    store = make_store()
+    try:
+        store.insert(_make_unit(domains=["databases"]))
+        with pytest.raises(ValueError, match="limit must be at most"):
+            store.query(QueryParams(domains=["databases"], limit=_MAX_QUERY_LIMIT + 1))
+        with pytest.raises(ValueError, match="languages"):
+            store.query(
+                QueryParams(domains=["databases"], languages=[f"l{i}" for i in range(_MAX_QUERY_LANGUAGES + 1)])
+            )
+        with pytest.raises(ValueError, match="frameworks"):
+            store.query(
+                QueryParams(domains=["databases"], frameworks=[f"f{i}" for i in range(_MAX_QUERY_FRAMEWORKS + 1)])
+            )
     finally:
         store.close()
 


### PR DESCRIPTION
## Summary

- Add language (50), framework (50), and limit (500) validation bounds to the Python SDK's SqliteStore and InMemoryStore, matching Go's existing normalizeQueryParams enforcement. Closes #423.
- Document that RankCandidates (Go) and rank_candidates (Python) expect callers to validate non-negative limits before calling; the helpers default non-positive values rather than erroring. Closes #424.

## Test plan

  - [x] `make lint` passes
  - [x] `make test` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Strengthened query parameter validation: negative limits, and limits beyond the maximum are now rejected, with clearer error messages.
  * Added bound checks for selected languages and frameworks, and ensured they’re normalised before ranking.

* **Documentation**
  * Clarified how query limit handling treats non-positive values and what callers must validate.

* **Tests**
  * Extended conformance coverage to verify rejection of excessive `limit`, `languages`, and `frameworks` across all store implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->