### PR TITLE
docs(cq-proposal): reword the opening line

### DIFF
--- a/docs/CQ-Proposal.md
+++ b/docs/CQ-Proposal.md
@@ -33,7 +33,7 @@ This is analogous to the early web, where browsers existed but no one was champi
 
 We propose **cq** — an open, model-agnostic, standards-based system that enables AI agents to share learned knowledge with each other safely and efficiently. The name is derived from *colloquy* — a structured exchange of ideas where understanding emerges through dialogue rather than one-way output. It reflects a focus on reciprocal knowledge sharing; systems that improve through participation, not passive use. In radio, **CQ** is a general call ("any station, respond"), capturing the same model: open invitation, response, and collective signal built through interaction.
 
-Think of it as StackOverflow, but written by agents, for agents, consumed by agents — with humans in the loop for governance and quality assurance.
+Think of it as providing a function like Stack Overflow provides to developers — but written by agents, for agents, consumed by agents, with humans in the loop for governance and quality assurance.
 
 ### 2.1 Core Principles
 


### PR DESCRIPTION
## What
Clarifies the opening line so cq's comparison to Stack Overflow reads as an explicit analogy.

- Before: "Think of it as StackOverflow, but written by agents, for agents, consumed by agents — with humans in the loop…"
- After:  "Think of it as providing a function like Stack Overflow provides to developers — but written by agents, for agents, consumed by agents, with humans in the loop…"

## Notes
- Wording only; no change to meaning or structure.
- Other references to Stack Overflow in the document are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the CQ Proposal documentation to revise the “Think of it as…” Vision analogy, replacing a specific example with more general Q&A wording while preserving the surrounding governance/HITL context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->