### PR TITLE
feat(cli): add OpenCode host to cq install

### DIFF
--- a/cli/install_test.go
+++ b/cli/install_test.go
@@ -49,6 +49,52 @@ func TestInstallCursorEndToEnd(t *testing.T) {
 	require.FileExists(t, filepath.Join(home, ".agents", "skills", "cq", "SKILL.md"))
 }
 
+func TestInstallOpencodeEndToEnd(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("OPENCODE_CONFIG_DIR", "")
+	bin := filepath.Join(t.TempDir(), "cq")
+	t.Setenv("CQ_INSTALL_BINARY", bin)
+
+	out, err := runInstall(t, "--target", "opencode")
+	require.NoError(t, err)
+	require.Contains(t, out, "[opencode]")
+
+	require.FileExists(t, filepath.Join(home, ".agents", "skills", "cq", "SKILL.md"))
+	require.FileExists(t, filepath.Join(home, ".config", "opencode", "opencode.json"))
+	require.FileExists(t, filepath.Join(home, ".config", "opencode", "commands", "reflect.md"))
+	require.FileExists(t, filepath.Join(home, ".config", "opencode", "commands", "status.md"))
+	require.FileExists(t, filepath.Join(home, ".config", "opencode", "AGENTS.md"))
+
+	cfg := filepath.Join(home, ".config", "opencode", "opencode.json")
+	data, err := os.ReadFile(cfg)
+	require.NoError(t, err)
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(data, &m))
+	mcp := m["mcp"].(map[string]any)
+	cq := mcp["cq"].(map[string]any)
+	require.Equal(t, "local", cq["type"])
+	cmd := cq["command"].([]any)
+	require.Equal(t, bin, cmd[0])
+	require.Equal(t, "mcp", cmd[1])
+
+	// Re-run is idempotent.
+	_, err = runInstall(t, "--target", "opencode")
+	require.NoError(t, err)
+
+	// Uninstall reverses config and commands but keeps shared skill.
+	_, err = runInstall(t, "--target", "opencode", "--uninstall")
+	require.NoError(t, err)
+	data, err = os.ReadFile(cfg)
+	require.NoError(t, err)
+	m = nil
+	require.NoError(t, json.Unmarshal(data, &m))
+	require.NotContains(t, m, "mcp")
+	require.NoDirExists(t, filepath.Join(home, ".config", "opencode", "commands"))
+	require.NoFileExists(t, filepath.Join(home, ".config", "opencode", "AGENTS.md"))
+	require.FileExists(t, filepath.Join(home, ".agents", "skills", "cq", "SKILL.md"))
+}
+
 func TestInstallWindsurfEndToEnd(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/cli/internal/install/command.go
+++ b/cli/internal/install/command.go
@@ -1,0 +1,35 @@
+package install
+
+import "strings"
+
+// transformCommand converts a Claude Code command file to OpenCode format by
+// stripping the `name:` frontmatter line and inserting `agent: build`.
+//
+// Returns the source unchanged when YAML frontmatter is absent or unclosed.
+func transformCommand(source string) string {
+	lines := strings.SplitAfter(source, "\n")
+	if len(lines) == 0 || strings.TrimRight(lines[0], "\r\n") != "---" {
+		return source
+	}
+
+	out := []string{lines[0]}
+	inFrontmatter := true
+	closed := false
+	for _, line := range lines[1:] {
+		if inFrontmatter && strings.TrimRight(line, "\r\n") == "---" {
+			out = append(out, "agent: build\n", line)
+			inFrontmatter = false
+			closed = true
+			continue
+		}
+		if inFrontmatter && strings.HasPrefix(line, "name:") {
+			continue
+		}
+		out = append(out, line)
+	}
+
+	if !closed {
+		return source
+	}
+	return strings.Join(out, "")
+}

--- a/cli/internal/install/command_test.go
+++ b/cli/internal/install/command_test.go
@@ -1,0 +1,50 @@
+package install
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransformCommandStripsNameAddsAgent(t *testing.T) {
+	source := "---\nname: cq:reflect\ndescription: Mine the session.\n---\n\n# Reflect\n\nBody.\n"
+	got := transformCommand(source)
+	require.NotContains(t, got, "name:")
+	require.Contains(t, got, "agent: build\n")
+	require.Contains(t, got, "description: Mine the session.\n")
+	require.Contains(t, got, "# Reflect")
+}
+
+func TestTransformCommandPreservesBodyAndDescription(t *testing.T) {
+	source := "---\nname: cq:status\ndescription: Show stats.\n---\n\n# Status\n\nBody content.\n"
+	got := transformCommand(source)
+	require.Equal(t, "---\ndescription: Show stats.\nagent: build\n---\n\n# Status\n\nBody content.\n", got)
+}
+
+func TestTransformCommandReturnsUnchangedWithoutFrontmatter(t *testing.T) {
+	source := "# No Frontmatter\n\nJust content.\n"
+	require.Equal(t, source, transformCommand(source))
+}
+
+func TestTransformCommandReturnsUnchangedWithUnclosedFrontmatter(t *testing.T) {
+	source := "---\nname: broken\ndescription: oops\n"
+	require.Equal(t, source, transformCommand(source))
+}
+
+func TestTransformCommandHandlesNoNameLine(t *testing.T) {
+	source := "---\ndescription: No name field.\n---\n\nBody.\n"
+	got := transformCommand(source)
+	require.Equal(t, "---\ndescription: No name field.\nagent: build\n---\n\nBody.\n", got)
+}
+
+func TestTransformCommandHandlesCRLF(t *testing.T) {
+	source := "---\r\nname: cq:reflect\r\ndescription: Mine the session.\r\n---\r\n\r\n# Reflect\r\n"
+	got := transformCommand(source)
+	require.NotContains(t, got, "name:")
+	require.Contains(t, got, "agent: build\n")
+	require.Contains(t, got, "description: Mine the session.")
+}
+
+func TestTransformCommandEmptyInput(t *testing.T) {
+	require.Equal(t, "", transformCommand(""))
+}

--- a/cli/internal/install/markdown.go
+++ b/cli/internal/install/markdown.go
@@ -1,0 +1,168 @@
+package install
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// cqBlock is the marker pair used by all cq-managed blocks in instruction
+// files (AGENTS.md).
+var cqBlock = blockMarkers{
+	start: "<!-- cq:start -->",
+	end:   "<!-- cq:end -->",
+}
+
+// blockMarkers identifies the start and end delimiters of a managed block
+// within a markdown file.
+type blockMarkers struct {
+	start string
+	end   string
+}
+
+// upsertMarkdownBlock inserts or replaces a delimited block in a markdown file.
+//
+// content must include the start and end markers.
+// When the file is absent, it is created with content as the body.
+// When the file exists but contains no start marker, the block is appended
+// with a blank-line separator.
+// When the block is present but unchanged, UNCHANGED is returned.
+// When the start marker is present without a matching end marker, the file
+// is left untouched and SKIPPED is returned.
+func upsertMarkdownBlock(file string, markers blockMarkers, content string, dryRun bool) (Change, error) {
+	text, err := readFileOrEmpty(file)
+	if err != nil {
+		return Change{}, fmt.Errorf("reading instruction file: %w", err)
+	}
+	if text == "" {
+		return writeNewFile(file, content+"\n", dryRun)
+	}
+
+	startIdx := strings.Index(text, markers.start)
+	if startIdx == -1 {
+		return writeFile(file, strings.TrimRight(text, "\r\n")+"\n\n"+content+"\n", ActionUpdated, dryRun)
+	}
+
+	endRel := strings.Index(text[startIdx+len(markers.start):], markers.end)
+	if endRel == -1 {
+		return Change{
+			Action: ActionSkipped,
+			Path:   file,
+			Detail: "start marker present without matching end marker",
+		}, nil
+	}
+	endIdx := startIdx + len(markers.start) + endRel
+
+	blockEnd := endIdx + len(markers.end)
+	if text[startIdx:blockEnd] == content {
+		return Change{Action: ActionUnchanged, Path: file}, nil
+	}
+	return writeFile(file, text[:startIdx]+content+text[blockEnd:], ActionUpdated, dryRun)
+}
+
+// removeMarkdownBlock removes a delimited block from a markdown file.
+//
+// When the file becomes empty after removal, it is deleted.
+// When the start marker is present without a matching end marker, the file
+// is left untouched and SKIPPED is returned.
+func removeMarkdownBlock(file string, markers blockMarkers, dryRun bool) (Change, error) {
+	data, err := os.ReadFile(file)
+	if os.IsNotExist(err) {
+		return Change{Action: ActionUnchanged, Path: file}, nil
+	}
+	if err != nil {
+		return Change{}, fmt.Errorf("reading instruction file: %w", err)
+	}
+
+	text := string(data)
+	startIdx := strings.Index(text, markers.start)
+	if startIdx == -1 {
+		return Change{Action: ActionUnchanged, Path: file}, nil
+	}
+
+	endRel := strings.Index(text[startIdx+len(markers.start):], markers.end)
+	if endRel == -1 {
+		return Change{
+			Action: ActionSkipped,
+			Path:   file,
+			Detail: "start marker present without matching end marker",
+		}, nil
+	}
+	endIdx := startIdx + len(markers.start) + endRel
+
+	newText := joinSurrounding(
+		strings.TrimRight(text[:startIdx], "\r\n"),
+		strings.TrimLeft(text[endIdx+len(markers.end):], "\r\n"),
+	)
+
+	newText = strings.TrimRight(newText, "\r\n")
+	if newText == "" {
+		return removeFile(file, dryRun)
+	}
+	return writeFile(file, newText+"\n", ActionRemoved, dryRun)
+}
+
+// joinSurrounding reassembles the text before and after a removed block,
+// collapsing to a single blank-line separator when both are non-empty.
+func joinSurrounding(before string, after string) string {
+	switch {
+	case before == "" && after == "":
+		return ""
+	case before == "":
+		return after
+	case after == "":
+		return before
+	default:
+		return before + "\n\n" + after
+	}
+}
+
+// readFileOrEmpty reads file and returns its content, or "" when absent.
+func readFileOrEmpty(file string) (string, error) {
+	data, err := os.ReadFile(file)
+	if os.IsNotExist(err) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+// removeFile deletes a file, reporting REMOVED.
+func removeFile(file string, dryRun bool) (Change, error) {
+	if dryRun {
+		return Change{Action: ActionRemoved, Path: file}, nil
+	}
+	if err := os.Remove(file); err != nil {
+		return Change{}, fmt.Errorf("removing empty instruction file: %w", err)
+	}
+	return Change{Action: ActionRemoved, Path: file}, nil
+}
+
+// writeFile overwrites an existing file with content, reporting the given action.
+func writeFile(file string, content string, action Action, dryRun bool) (Change, error) {
+	if dryRun {
+		return Change{Action: action, Path: file}, nil
+	}
+	if err := os.WriteFile(file, []byte(content), 0o644); err != nil {
+		return Change{}, fmt.Errorf("writing instruction file: %w", err)
+	}
+	return Change{Action: action, Path: file}, nil
+}
+
+// writeNewFile creates a new file with the given content, creating parent
+// directories as needed.
+func writeNewFile(file string, content string, dryRun bool) (Change, error) {
+	if dryRun {
+		return Change{Action: ActionCreated, Path: file}, nil
+	}
+	if err := os.MkdirAll(filepath.Dir(file), 0o755); err != nil {
+		return Change{}, fmt.Errorf("creating directory for instruction file: %w", err)
+	}
+	if err := os.WriteFile(file, []byte(content), 0o644); err != nil {
+		return Change{}, fmt.Errorf("writing instruction file: %w", err)
+	}
+	return Change{Action: ActionCreated, Path: file}, nil
+}

--- a/cli/internal/install/markdown_test.go
+++ b/cli/internal/install/markdown_test.go
@@ -1,0 +1,135 @@
+package install
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var testMarkers = blockMarkers{start: "<!-- cq:start -->", end: "<!-- cq:end -->"}
+
+func TestUpsertMarkdownBlockCreatesFile(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "AGENTS.md")
+	c, err := upsertMarkdownBlock(p, testMarkers,
+		"<!-- cq:start -->\n## CQ\n<!-- cq:end -->", false)
+	require.NoError(t, err)
+	require.Equal(t, ActionCreated, c.Action)
+	got, err := os.ReadFile(p)
+	require.NoError(t, err)
+	require.Equal(t, "<!-- cq:start -->\n## CQ\n<!-- cq:end -->\n", string(got))
+}
+
+func TestUpsertMarkdownBlockAppendsToExisting(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "AGENTS.md")
+	require.NoError(t, os.WriteFile(p, []byte("# My Agents\n\nExisting content.\n"), 0o644))
+	c, err := upsertMarkdownBlock(p, testMarkers,
+		"<!-- cq:start -->\n## CQ\n<!-- cq:end -->", false)
+	require.NoError(t, err)
+	require.Equal(t, ActionUpdated, c.Action)
+	got, err := os.ReadFile(p)
+	require.NoError(t, err)
+	require.Equal(t, "# My Agents\n\nExisting content.\n\n<!-- cq:start -->\n## CQ\n<!-- cq:end -->\n", string(got))
+}
+
+func TestUpsertMarkdownBlockIsIdempotent(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "AGENTS.md")
+	block := "<!-- cq:start -->\n## CQ\n<!-- cq:end -->"
+	_, err := upsertMarkdownBlock(p, testMarkers, block, false)
+	require.NoError(t, err)
+	c, err := upsertMarkdownBlock(p, testMarkers, block, false)
+	require.NoError(t, err)
+	require.Equal(t, ActionUnchanged, c.Action)
+}
+
+func TestUpsertMarkdownBlockReplacesChanged(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "AGENTS.md")
+	require.NoError(t, os.WriteFile(p,
+		[]byte("preamble\n\n<!-- cq:start -->\nold body\n<!-- cq:end -->\n\npostamble\n"), 0o644))
+	c, err := upsertMarkdownBlock(p, testMarkers,
+		"<!-- cq:start -->\nnew body\n<!-- cq:end -->", false)
+	require.NoError(t, err)
+	require.Equal(t, ActionUpdated, c.Action)
+	got, err := os.ReadFile(p)
+	require.NoError(t, err)
+	require.Equal(t, "preamble\n\n<!-- cq:start -->\nnew body\n<!-- cq:end -->\n\npostamble\n", string(got))
+}
+
+func TestUpsertMarkdownBlockSkipsMalformed(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "AGENTS.md")
+	require.NoError(t, os.WriteFile(p, []byte("<!-- cq:start -->\nno end marker\n"), 0o644))
+	c, err := upsertMarkdownBlock(p, testMarkers,
+		"<!-- cq:start -->\nbody\n<!-- cq:end -->", false)
+	require.NoError(t, err)
+	require.Equal(t, ActionSkipped, c.Action)
+}
+
+func TestUpsertMarkdownBlockIgnoresStrayEndMarkerBeforeBlock(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "AGENTS.md")
+	require.NoError(t, os.WriteFile(p, []byte(
+		"intro <!-- cq:end --> note\n\n<!-- cq:start -->\nold\n<!-- cq:end -->\n"), 0o644))
+	c, err := upsertMarkdownBlock(p, testMarkers, "<!-- cq:start -->\nnew\n<!-- cq:end -->", false)
+	require.NoError(t, err)
+	require.Equal(t, ActionUpdated, c.Action)
+	got, err := os.ReadFile(p)
+	require.NoError(t, err)
+	require.Contains(t, string(got), "<!-- cq:start -->\nnew\n<!-- cq:end -->")
+	require.Contains(t, string(got), "intro <!-- cq:end --> note")
+}
+
+func TestUpsertMarkdownBlockDryRunWritesNothing(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "AGENTS.md")
+	c, err := upsertMarkdownBlock(p, testMarkers,
+		"<!-- cq:start -->\nbody\n<!-- cq:end -->", true)
+	require.NoError(t, err)
+	require.Equal(t, ActionCreated, c.Action)
+	_, statErr := os.Stat(p)
+	require.True(t, os.IsNotExist(statErr))
+}
+
+func TestRemoveMarkdownBlockDeletesBlock(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "AGENTS.md")
+	require.NoError(t, os.WriteFile(p,
+		[]byte("preamble\n\n<!-- cq:start -->\ncq block\n<!-- cq:end -->\n\npostamble\n"), 0o644))
+	c, err := removeMarkdownBlock(p, testMarkers, false)
+	require.NoError(t, err)
+	require.Equal(t, ActionRemoved, c.Action)
+	got, err := os.ReadFile(p)
+	require.NoError(t, err)
+	require.Equal(t, "preamble\n\npostamble\n", string(got))
+}
+
+func TestRemoveMarkdownBlockDeletesFileWhenEmpty(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "AGENTS.md")
+	require.NoError(t, os.WriteFile(p,
+		[]byte("<!-- cq:start -->\ncq block\n<!-- cq:end -->\n"), 0o644))
+	c, err := removeMarkdownBlock(p, testMarkers, false)
+	require.NoError(t, err)
+	require.Equal(t, ActionRemoved, c.Action)
+	_, statErr := os.Stat(p)
+	require.True(t, os.IsNotExist(statErr))
+}
+
+func TestRemoveMarkdownBlockAbsentFileIsUnchanged(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "AGENTS.md")
+	c, err := removeMarkdownBlock(p, testMarkers, false)
+	require.NoError(t, err)
+	require.Equal(t, ActionUnchanged, c.Action)
+}
+
+func TestRemoveMarkdownBlockAbsentMarkerIsUnchanged(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "AGENTS.md")
+	require.NoError(t, os.WriteFile(p, []byte("# Agents\n\nNo cq block here.\n"), 0o644))
+	c, err := removeMarkdownBlock(p, testMarkers, false)
+	require.NoError(t, err)
+	require.Equal(t, ActionUnchanged, c.Action)
+}
+
+func TestRemoveMarkdownBlockSkipsMalformed(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "AGENTS.md")
+	require.NoError(t, os.WriteFile(p, []byte("<!-- cq:start -->\nno end\n"), 0o644))
+	c, err := removeMarkdownBlock(p, testMarkers, false)
+	require.NoError(t, err)
+	require.Equal(t, ActionSkipped, c.Action)
+}

--- a/cli/internal/install/opencode.go
+++ b/cli/internal/install/opencode.go
@@ -1,0 +1,182 @@
+package install
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/mozilla-ai/cq/sdk/go/prompts"
+)
+
+const (
+	// opencodeConfigFile is the main configuration file OpenCode reads.
+	opencodeConfigFile = "opencode.json"
+
+	// opencodeAgentsFile is the always-loaded instruction file for OpenCode.
+	opencodeAgentsFile = "AGENTS.md"
+
+	// opencodeCommandsDir holds command files within the OpenCode target.
+	opencodeCommandsDir = "commands"
+
+	// opencodeSchemaURL is seeded into a fresh opencode.json for editor
+	// autocomplete and validation.
+	opencodeSchemaURL = "https://opencode.ai/config.json"
+)
+
+// opencodeAgentsBlock is the delimited block written into AGENTS.md.
+var opencodeAgentsBlock = cqBlock.start + "\n## CQ\n\nBefore starting any implementation task, load the `cq` skill and follow its Core Protocol.\n" + cqBlock.end
+
+// opencodeCommands maps each command filename to the SDK accessor that
+// returns its canonical Claude Code source.
+var opencodeCommands = []struct {
+	file string
+	body func() string
+}{
+	{"reflect.md", prompts.Reflect},
+	{"status.md", prompts.Status},
+}
+
+// opencodeHost installs cq into the OpenCode editor: the shared skill, the
+// MCP server entry, command files, and an AGENTS.md instruction block.
+//
+// OpenCode stores its config under ~/.config/opencode on every platform
+// (overridable via OPENCODE_CONFIG_DIR) and is global-only in this phase.
+type opencodeHost struct{}
+
+// GlobalTarget returns the OpenCode config dir.
+func (opencodeHost) GlobalTarget(home string) string {
+	return opencodeTarget(home)
+}
+
+// Install writes the shared skill, the MCP entry, command files, and the
+// AGENTS.md block.
+func (opencodeHost) Install(ctx Context) ([]Change, error) {
+	skill, err := writeManagedFiles(ctx.SkillsDir, map[string]string{
+		filepath.Join("cq", "SKILL.md"): prompts.Skill(),
+	}, ctx.DryRun)
+	if err != nil {
+		return nil, err
+	}
+	changes := []Change{skill}
+
+	mcp, err := opencodeInstallMCP(ctx)
+	if err != nil {
+		return nil, err
+	}
+	changes = append(changes, mcp)
+
+	cmds, err := opencodeInstallCommands(ctx)
+	if err != nil {
+		return nil, err
+	}
+	changes = append(changes, cmds)
+
+	agents, err := upsertMarkdownBlock(
+		filepath.Join(ctx.Target, opencodeAgentsFile),
+		cqBlock,
+		opencodeAgentsBlock,
+		ctx.DryRun,
+	)
+	if err != nil {
+		return nil, err
+	}
+	changes = append(changes, agents)
+
+	return changes, nil
+}
+
+// Name returns the host identifier.
+func (opencodeHost) Name() Target { return TargetOpenCode }
+
+// SupportsProject reports that OpenCode is installed globally in this phase.
+func (opencodeHost) SupportsProject() bool { return false }
+
+// Uninstall removes the MCP entry, command files, and the AGENTS.md block.
+//
+// NOTE: the skill lives in the shared commons (~/.agents/skills), which other
+// hosts may also use, so it is intentionally left in place.
+func (opencodeHost) Uninstall(ctx Context) ([]Change, error) {
+	mcp, err := removeJSONEntry(
+		filepath.Join(ctx.Target, opencodeConfigFile),
+		[]string{"mcp", "cq"},
+		ctx.DryRun,
+	)
+	if err != nil {
+		return nil, err
+	}
+	changes := []Change{mcp}
+
+	commandsPath := filepath.Join(ctx.Target, opencodeCommandsDir)
+	cmds, err := removeManagedFiles(commandsPath, ctx.DryRun)
+	if err != nil {
+		return nil, err
+	}
+	if cmds.Action == ActionRemoved && !ctx.DryRun {
+		// Best-effort: remove the now-empty commands directory.
+		_ = os.Remove(commandsPath)
+	}
+	changes = append(changes, cmds)
+
+	agents, err := removeMarkdownBlock(
+		filepath.Join(ctx.Target, opencodeAgentsFile),
+		cqBlock,
+		ctx.DryRun,
+	)
+	if err != nil {
+		return nil, err
+	}
+	changes = append(changes, agents)
+
+	return changes, nil
+}
+
+// opencodeInstallMCP writes the MCP server entry, seeding $schema on fresh
+// file creation only so editor autocomplete works from the first install.
+func opencodeInstallMCP(ctx Context) (Change, error) {
+	configPath := filepath.Join(ctx.Target, opencodeConfigFile)
+	if err := seedOpenCodeSchema(configPath, ctx.DryRun); err != nil {
+		return Change{}, err
+	}
+	return upsertJSONEntry(
+		configPath,
+		[]string{"mcp", "cq"},
+		map[string]any{
+			"type":    "local",
+			"command": []any{ctx.BinaryPath, "mcp"},
+		},
+		ctx.DryRun,
+	)
+}
+
+// seedOpenCodeSchema writes the $schema URL into a fresh opencode.json so
+// OpenCode's editor autocomplete works from the first install.
+//
+// Existing files are left untouched so user overrides survive re-installs.
+func seedOpenCodeSchema(configPath string, dryRun bool) error {
+	_, err := os.Stat(configPath)
+	if err == nil || dryRun {
+		return nil
+	}
+	if !os.IsNotExist(err) {
+		return fmt.Errorf("checking config file: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		return fmt.Errorf("creating config directory: %w", err)
+	}
+	return writeJSONObject(configPath, map[string]any{"$schema": opencodeSchemaURL})
+}
+
+// opencodeInstallCommands transforms and writes the command files into the
+// target's commands directory, tracked by a manifest for idempotent updates
+// and safe uninstall.
+func opencodeInstallCommands(ctx Context) (Change, error) {
+	files := make(map[string]string, len(opencodeCommands))
+	for _, cmd := range opencodeCommands {
+		files[cmd.file] = transformCommand(cmd.body())
+	}
+	return writeManagedFiles(
+		filepath.Join(ctx.Target, opencodeCommandsDir),
+		files,
+		ctx.DryRun,
+	)
+}

--- a/cli/internal/install/opencode_test.go
+++ b/cli/internal/install/opencode_test.go
@@ -1,0 +1,117 @@
+package install
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mozilla-ai/cq/sdk/go/prompts"
+)
+
+func opencodeCtx(t *testing.T) Context {
+	t.Helper()
+	root := t.TempDir()
+	return Context{
+		Target:     filepath.Join(root, ".config", "opencode"),
+		SkillsDir:  SharedSkillsDir(root),
+		BinaryPath: filepath.Join(root, "bin", "cq"),
+	}
+}
+
+func TestOpencodeInstallWritesAllAssets(t *testing.T) {
+	ctx := opencodeCtx(t)
+	changes, err := opencodeHost{}.Install(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, changes)
+
+	// Shared skill.
+	skill, err := os.ReadFile(filepath.Join(ctx.SkillsDir, "cq", "SKILL.md"))
+	require.NoError(t, err)
+	require.Equal(t, prompts.Skill(), string(skill))
+
+	// MCP entry uses array command and local type.
+	config := readJSON(t, filepath.Join(ctx.Target, "opencode.json"))
+	require.Equal(t, opencodeSchemaURL, config["$schema"])
+	mcp := config["mcp"].(map[string]any)
+	cq := mcp["cq"].(map[string]any)
+	require.Equal(t, "local", cq["type"])
+	cmd := cq["command"].([]any)
+	require.Equal(t, ctx.BinaryPath, cmd[0])
+	require.Equal(t, "mcp", cmd[1])
+
+	// Command files are transformed (name: stripped, agent: build added).
+	for _, name := range []string{"reflect.md", "status.md"} {
+		got, err := os.ReadFile(filepath.Join(ctx.Target, "commands", name))
+		require.NoError(t, err)
+		require.Contains(t, string(got), "agent: build")
+		require.NotContains(t, string(got), "name:")
+	}
+
+	// AGENTS.md block.
+	agents, err := os.ReadFile(filepath.Join(ctx.Target, "AGENTS.md"))
+	require.NoError(t, err)
+	require.Contains(t, string(agents), cqBlock.start)
+	require.Contains(t, string(agents), cqBlock.end)
+	require.Contains(t, string(agents), "Core Protocol")
+}
+
+func TestOpencodeInstallIsIdempotent(t *testing.T) {
+	ctx := opencodeCtx(t)
+	_, err := opencodeHost{}.Install(ctx)
+	require.NoError(t, err)
+	changes, err := opencodeHost{}.Install(ctx)
+	require.NoError(t, err)
+	for _, c := range changes {
+		require.NotEqual(t, ActionCreated, c.Action)
+	}
+}
+
+func TestOpencodeInstallPreservesSchemaOnReinstall(t *testing.T) {
+	ctx := opencodeCtx(t)
+	_, err := opencodeHost{}.Install(ctx)
+	require.NoError(t, err)
+	config := readJSON(t, filepath.Join(ctx.Target, "opencode.json"))
+	require.Equal(t, opencodeSchemaURL, config["$schema"])
+
+	_, err = opencodeHost{}.Install(ctx)
+	require.NoError(t, err)
+	config = readJSON(t, filepath.Join(ctx.Target, "opencode.json"))
+	require.Equal(t, opencodeSchemaURL, config["$schema"])
+}
+
+func TestOpencodeUninstallReversesButKeepsSharedSkill(t *testing.T) {
+	ctx := opencodeCtx(t)
+	_, err := opencodeHost{}.Install(ctx)
+	require.NoError(t, err)
+	_, err = opencodeHost{}.Uninstall(ctx)
+	require.NoError(t, err)
+
+	// MCP entry gone.
+	config := readJSON(t, filepath.Join(ctx.Target, "opencode.json"))
+	require.NotContains(t, config, "mcp")
+	// Commands gone (dir pruned).
+	require.NoDirExists(t, filepath.Join(ctx.Target, "commands"))
+	// AGENTS.md gone (file deleted when only our block).
+	require.NoFileExists(t, filepath.Join(ctx.Target, "AGENTS.md"))
+	// Shared skill REMAINS (it is the cross-host commons).
+	require.FileExists(t, filepath.Join(ctx.SkillsDir, "cq", "SKILL.md"))
+}
+
+func TestOpencodeRegisteredAndProject(t *testing.T) {
+	h, ok := hosts[TargetOpenCode]
+	require.True(t, ok)
+	require.Equal(t, TargetOpenCode, h.Name())
+	require.False(t, h.SupportsProject())
+}
+
+func TestOpencodeTargetHonorsEnvOverride(t *testing.T) {
+	t.Setenv(opencodeConfigDirEnv, "/custom/opencode")
+	require.Equal(t, "/custom/opencode", opencodeTarget("/home/dev"))
+}
+
+func TestOpencodeTargetDefaultPath(t *testing.T) {
+	t.Setenv(opencodeConfigDirEnv, "")
+	require.Equal(t, filepath.Join("/home/dev", ".config", "opencode"), opencodeTarget("/home/dev"))
+}

--- a/cli/internal/install/paths.go
+++ b/cli/internal/install/paths.go
@@ -1,6 +1,15 @@
 package install
 
-import "path/filepath"
+import (
+	"os"
+	"path/filepath"
+)
+
+// opencodeConfigDirEnv overrides the default OpenCode config directory.
+//
+// NOTE: OpenCode does not honor XDG_CONFIG_HOME; it always reads from
+// ~/.config/opencode unless this env var is set.
+const opencodeConfigDirEnv = "OPENCODE_CONFIG_DIR"
 
 // SharedSkillsDir returns the cross-host skills commons under root.
 //
@@ -15,6 +24,17 @@ func SharedSkillsDir(root string) string {
 // Cursor reads config from <home>/.cursor on every platform.
 func cursorTarget(home string) string {
 	return filepath.Join(home, ".cursor")
+}
+
+// opencodeTarget returns the OpenCode configuration directory.
+//
+// Honors OPENCODE_CONFIG_DIR the same way OpenCode itself does: if set, the
+// env var wins; otherwise fall back to the default location under home.
+func opencodeTarget(home string) string {
+	if override := os.Getenv(opencodeConfigDirEnv); override != "" {
+		return override
+	}
+	return filepath.Join(home, ".config", "opencode")
 }
 
 // windsurfTarget returns the Windsurf configuration directory under home.

--- a/cli/internal/install/registry.go
+++ b/cli/internal/install/registry.go
@@ -10,6 +10,9 @@ const (
 	// TargetCursor is the Cursor editor.
 	TargetCursor Target = "cursor"
 
+	// TargetOpenCode is the OpenCode editor.
+	TargetOpenCode Target = "opencode"
+
 	// TargetWindsurf is the Windsurf editor.
 	TargetWindsurf Target = "windsurf"
 )
@@ -20,6 +23,7 @@ const (
 // an entry extends ValidTarget, AllowedTargets, and SelectHosts.
 var hosts = map[Target]Host{
 	TargetCursor:   cursorHost{},
+	TargetOpenCode: opencodeHost{},
 	TargetWindsurf: windsurfHost{},
 }
 


### PR DESCRIPTION
## Summary

- Add OpenCode host adapter to `cq install --target opencode`, writing the shared skill, MCP entry (opencode.json with `mcp.cq`, `type: local`, array command), transformed command files (reflect.md, status.md), and a delimited cq block in AGENTS.md.
- Introduce markdown block upsert/remove primitives (`blockMarkers` type) for idempotent management of delimited blocks in instruction files.
- Add command-file frontmatter transform (strip `name:`, insert `agent: build`) for converting Claude Code commands to OpenCode format.
- Honor `OPENCODE_CONFIG_DIR` env override matching OpenCode's own config resolution.
- Seed `$schema` in opencode.json on fresh installs only; preserve user overrides on re-install.
- Uninstall reverses all host-specific assets but leaves the shared skill in the cross-host commons.

## Test plan

- [x] Unit tests for markdown block primitives (create, append, replace, idempotency, malformed markers, dry-run, file deletion on empty)
- [x] Unit tests for command transform (strip name, add agent, passthrough on missing/unclosed frontmatter)
- [x] Unit tests for OpenCode adapter (all assets written, idempotency, schema preservation, uninstall reversal, shared skill survives, env override, registry)
- [x] E2E test covering install → idempotent re-run → uninstall round-trip
- [x] `make lint` and `make test` pass from repo root
- [x] Pragma validators: go-effective, go-proverbs, security, state-machine, error-handling — all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenCode (`opencode`) as a supported installation target for CodeRabbit “cq”, including MCP configuration, shared skill installation, and generated editor command files.
  * Supports a custom OpenCode configuration directory via an environment override.

* **Tests**
  * Added end-to-end and unit tests covering OpenCode install/uninstall, idempotency, markdown block updates, command transformation (including CRLF), and configuration/path selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->