### PR TITLE
feat(cli): add Pi host to cq install

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -126,6 +126,27 @@ func printChanges(cmd *cobra.Command, host install.Target, changes []install.Cha
 	}
 }
 
+// cliVerbs returns the cq CLI verb descriptions derived from the actual cobra
+// command definitions, for hosts that embed CLI invocation instructions.
+func cliVerbs() []install.CLIVerb {
+	cmds := []*cobra.Command{
+		NewQueryCmd(),
+		NewProposeCmd(),
+		NewConfirmCmd(),
+		NewFlagCmd(),
+		NewStatusCmd(),
+	}
+	verbs := make([]install.CLIVerb, len(cmds))
+	for i, c := range cmds {
+		verbs[i] = install.CLIVerb{
+			Name:       c.Name(),
+			UseLine:    c.Use,
+			FlagUsages: c.Flags().FlagUsages(),
+		}
+	}
+	return verbs
+}
+
 // runInstallCmd resolves the selected hosts and applies the requested action.
 func runInstallCmd(cmd *cobra.Command, f *installFlags) error {
 	hosts := install.SelectHosts(f.targets.names())
@@ -151,6 +172,7 @@ func runInstallCmd(cmd *cobra.Command, f *installFlags) error {
 			SkillsDir:  install.SharedSkillsDir(home),
 			BinaryPath: binary,
 			DryRun:     f.dryRun,
+			CLIVerbs:   cliVerbs(),
 		}
 		var changes []install.Change
 		if f.uninstall {

--- a/cli/install_test.go
+++ b/cli/install_test.go
@@ -49,6 +49,39 @@ func TestInstallCursorEndToEnd(t *testing.T) {
 	require.FileExists(t, filepath.Join(home, ".agents", "skills", "cq", "SKILL.md"))
 }
 
+func TestInstallPiEndToEnd(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	bin := filepath.Join(t.TempDir(), "cq")
+	t.Setenv("CQ_INSTALL_BINARY", bin)
+
+	out, err := runInstall(t, "--target", "pi")
+	require.NoError(t, err)
+	require.Contains(t, out, "[pi]")
+
+	require.FileExists(t, filepath.Join(home, ".agents", "skills", "cq", "SKILL.md"))
+	require.FileExists(t, filepath.Join(home, ".pi", "agent", "prompts", "cq-reflect.md"))
+	require.FileExists(t, filepath.Join(home, ".pi", "agent", "prompts", "cq-status.md"))
+	require.FileExists(t, filepath.Join(home, ".pi", "agent", "AGENTS.md"))
+
+	// AGENTS.md embeds the binary path in CLI mappings.
+	agents, err := os.ReadFile(filepath.Join(home, ".pi", "agent", "AGENTS.md"))
+	require.NoError(t, err)
+	require.Contains(t, string(agents), bin)
+	require.Contains(t, string(agents), bin+" query")
+
+	// Re-run is idempotent.
+	_, err = runInstall(t, "--target", "pi")
+	require.NoError(t, err)
+
+	// Uninstall reverses prompts and AGENTS.md but keeps shared skill.
+	_, err = runInstall(t, "--target", "pi", "--uninstall")
+	require.NoError(t, err)
+	require.NoDirExists(t, filepath.Join(home, ".pi", "agent", "prompts"))
+	require.NoFileExists(t, filepath.Join(home, ".pi", "agent", "AGENTS.md"))
+	require.FileExists(t, filepath.Join(home, ".agents", "skills", "cq", "SKILL.md"))
+}
+
 func TestInstallOpencodeEndToEnd(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/cli/internal/install/opencode.go
+++ b/cli/internal/install/opencode.go
@@ -9,14 +9,14 @@ import (
 )
 
 const (
-	// opencodeConfigFile is the main configuration file OpenCode reads.
-	opencodeConfigFile = "opencode.json"
-
 	// opencodeAgentsFile is the always-loaded instruction file for OpenCode.
 	opencodeAgentsFile = "AGENTS.md"
 
 	// opencodeCommandsDir holds command files within the OpenCode target.
 	opencodeCommandsDir = "commands"
+
+	// opencodeConfigFile is the main configuration file OpenCode reads.
+	opencodeConfigFile = "opencode.json"
 
 	// opencodeSchemaURL is seeded into a fresh opencode.json for editor
 	// autocomplete and validation.
@@ -130,6 +130,21 @@ func (opencodeHost) Uninstall(ctx Context) ([]Change, error) {
 	return changes, nil
 }
 
+// opencodeInstallCommands transforms and writes the command files into the
+// target's commands directory, tracked by a manifest for idempotent updates
+// and safe uninstall.
+func opencodeInstallCommands(ctx Context) (Change, error) {
+	files := make(map[string]string, len(opencodeCommands))
+	for _, cmd := range opencodeCommands {
+		files[cmd.file] = transformCommand(cmd.body())
+	}
+	return writeManagedFiles(
+		filepath.Join(ctx.Target, opencodeCommandsDir),
+		files,
+		ctx.DryRun,
+	)
+}
+
 // opencodeInstallMCP writes the MCP server entry, seeding $schema on fresh
 // file creation only so editor autocomplete works from the first install.
 func opencodeInstallMCP(ctx Context) (Change, error) {
@@ -164,19 +179,4 @@ func seedOpenCodeSchema(configPath string, dryRun bool) error {
 		return fmt.Errorf("creating config directory: %w", err)
 	}
 	return writeJSONObject(configPath, map[string]any{"$schema": opencodeSchemaURL})
-}
-
-// opencodeInstallCommands transforms and writes the command files into the
-// target's commands directory, tracked by a manifest for idempotent updates
-// and safe uninstall.
-func opencodeInstallCommands(ctx Context) (Change, error) {
-	files := make(map[string]string, len(opencodeCommands))
-	for _, cmd := range opencodeCommands {
-		files[cmd.file] = transformCommand(cmd.body())
-	}
-	return writeManagedFiles(
-		filepath.Join(ctx.Target, opencodeCommandsDir),
-		files,
-		ctx.DryRun,
-	)
 }

--- a/cli/internal/install/paths.go
+++ b/cli/internal/install/paths.go
@@ -37,6 +37,14 @@ func opencodeTarget(home string) string {
 	return filepath.Join(home, ".config", "opencode")
 }
 
+// piTarget returns the Pi global configuration directory under home.
+//
+// NOTE: Pi's global path has an extra "agent" segment (~/.pi/agent) that the
+// per-project path (.pi/) does not.
+func piTarget(home string) string {
+	return filepath.Join(home, ".pi", "agent")
+}
+
 // windsurfTarget returns the Windsurf configuration directory under home.
 func windsurfTarget(home string) string {
 	return filepath.Join(home, ".codeium", "windsurf")

--- a/cli/internal/install/pi.go
+++ b/cli/internal/install/pi.go
@@ -1,0 +1,179 @@
+package install
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/mozilla-ai/cq/sdk/go/prompts"
+)
+
+const (
+	// piAgentsFile is the always-loaded instruction file for Pi.
+	piAgentsFile = "AGENTS.md"
+
+	// piPromptsDir holds transformed prompt files within the Pi target.
+	piPromptsDir = "prompts"
+)
+
+// piPrompts maps each prompt filename (with the cq- prefix Pi expects) to the
+// SDK accessor that returns its canonical source.
+var piPrompts = []struct {
+	file string
+	body func() string
+}{
+	{"cq-reflect.md", prompts.Reflect},
+	{"cq-status.md", prompts.Status},
+}
+
+// piHost installs cq into the Pi coding agent: the shared skill, transformed
+// prompt files, and an AGENTS.md block that maps each cq action to a CLI
+// invocation.
+//
+// Pi has no native MCP, so the AGENTS.md block instructs the agent to run the
+// cq binary directly through its shell tool.
+type piHost struct{}
+
+// GlobalTarget returns the Pi global config dir under home.
+//
+// NOTE: Pi's global path has an extra "agent" segment (~/.pi/agent) that the
+// per-project path (.pi/) does not.
+func (piHost) GlobalTarget(home string) string {
+	return piTarget(home)
+}
+
+// Install writes the shared skill, prompt files, and the AGENTS.md block.
+func (piHost) Install(ctx Context) ([]Change, error) {
+	skill, err := writeManagedFiles(ctx.SkillsDir, map[string]string{
+		filepath.Join("cq", "SKILL.md"): prompts.Skill(),
+	}, ctx.DryRun)
+	if err != nil {
+		return nil, err
+	}
+	changes := []Change{skill}
+
+	promptChanges, err := piInstallPrompts(ctx)
+	if err != nil {
+		return nil, err
+	}
+	changes = append(changes, promptChanges)
+
+	agents, err := upsertMarkdownBlock(
+		filepath.Join(ctx.Target, piAgentsFile),
+		cqBlock,
+		piAgentsBlock(ctx.BinaryPath, ctx.CLIVerbs),
+		ctx.DryRun,
+	)
+	if err != nil {
+		return nil, err
+	}
+	changes = append(changes, agents)
+
+	return changes, nil
+}
+
+// Name returns the host identifier.
+func (piHost) Name() Target { return TargetPi }
+
+// SupportsProject reports that Pi is installed globally in this phase.
+func (piHost) SupportsProject() bool { return false }
+
+// Uninstall removes the prompt files and the AGENTS.md block.
+//
+// NOTE: the skill lives in the shared commons (~/.agents/skills), which other
+// hosts may also use, so it is intentionally left in place.
+func (piHost) Uninstall(ctx Context) ([]Change, error) {
+	promptsPath := filepath.Join(ctx.Target, piPromptsDir)
+	promptChanges, err := removeManagedFiles(promptsPath, ctx.DryRun)
+	if err != nil {
+		return nil, err
+	}
+	if promptChanges.Action == ActionRemoved && !ctx.DryRun {
+		_ = os.Remove(promptsPath)
+	}
+	changes := []Change{promptChanges}
+
+	agents, err := removeMarkdownBlock(
+		filepath.Join(ctx.Target, piAgentsFile),
+		cqBlock,
+		ctx.DryRun,
+	)
+	if err != nil {
+		return nil, err
+	}
+	changes = append(changes, agents)
+
+	return changes, nil
+}
+
+// piAgentsBlock returns the delimited AGENTS.md block that maps each cq action
+// to a CLI invocation using the given binary path and verb definitions.
+func piAgentsBlock(binaryPath string, verbs []CLIVerb) string {
+	var mapping strings.Builder
+	for _, v := range verbs {
+		fmt.Fprintf(&mapping, "### %s %s\n\n", binaryPath, v.UseLine)
+		if v.FlagUsages != "" {
+			fmt.Fprintf(&mapping, "```\n%s```\n\n", v.FlagUsages)
+		}
+	}
+
+	return cqBlock.start + "\n## CQ\n\n" +
+		"Before starting any implementation task, load the `cq` skill and follow its Core Protocol.\n\n" +
+		"This runtime has no cq MCP server.\n" +
+		"The cq skill and `/cq-*` commands describe the protocol using MCP-tool wording; in this runtime,\n" +
+		"perform every cq action by running the cq CLI through your shell.\n" +
+		"Parse `--format json` output for the commands that support it (query, propose, status); confirm and\n" +
+		"flag return plain text.\n" +
+		"The cq binary is: `" + binaryPath + "`.\n\n" +
+		mapping.String() +
+		cqBlock.end
+}
+
+// piInstallPrompts transforms and writes the prompt files into the target's
+// prompts directory, tracked by a manifest for idempotent updates and safe
+// uninstall.
+func piInstallPrompts(ctx Context) (Change, error) {
+	files := make(map[string]string, len(piPrompts))
+	for _, p := range piPrompts {
+		files[p.file] = transformPiCommand(p.body())
+	}
+	return writeManagedFiles(
+		filepath.Join(ctx.Target, piPromptsDir),
+		files,
+		ctx.DryRun,
+	)
+}
+
+// transformPiCommand converts a Claude Code command file to Pi format by
+// stripping the `name:` frontmatter line and rewriting `/cq:` references to
+// `/cq-` so the body matches Pi's filename-derived command names.
+//
+// Returns the source unchanged when YAML frontmatter is absent or unclosed.
+func transformPiCommand(source string) string {
+	lines := strings.SplitAfter(source, "\n")
+	if len(lines) == 0 || strings.TrimRight(lines[0], "\r\n") != "---" {
+		return source
+	}
+
+	out := []string{lines[0]}
+	inFrontmatter := true
+	closed := false
+	for _, line := range lines[1:] {
+		if inFrontmatter && strings.TrimRight(line, "\r\n") == "---" {
+			out = append(out, line)
+			inFrontmatter = false
+			closed = true
+			continue
+		}
+		if inFrontmatter && strings.HasPrefix(line, "name:") {
+			continue
+		}
+		out = append(out, line)
+	}
+
+	if !closed {
+		return source
+	}
+	return strings.ReplaceAll(strings.Join(out, ""), "/cq:", "/cq-")
+}

--- a/cli/internal/install/pi_test.go
+++ b/cli/internal/install/pi_test.go
@@ -1,0 +1,125 @@
+package install
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mozilla-ai/cq/sdk/go/prompts"
+)
+
+func piCtx(t *testing.T) Context {
+	t.Helper()
+	root := t.TempDir()
+	return Context{
+		Target:     filepath.Join(root, ".pi", "agent"),
+		SkillsDir:  SharedSkillsDir(root),
+		BinaryPath: filepath.Join(root, "bin", "cq"),
+		CLIVerbs: []CLIVerb{
+			{Name: "query", UseLine: "query", FlagUsages: "  --domain\n"},
+			{Name: "propose", UseLine: "propose", FlagUsages: "  --summary\n"},
+			{Name: "confirm", UseLine: "confirm <unit_id>"},
+			{Name: "flag", UseLine: "flag <unit_id>", FlagUsages: "  --reason\n"},
+			{Name: "status", UseLine: "status", FlagUsages: "  --format\n"},
+		},
+	}
+}
+
+func TestPiInstallWritesAllAssets(t *testing.T) {
+	ctx := piCtx(t)
+	changes, err := piHost{}.Install(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, changes)
+
+	// Shared skill.
+	skill, err := os.ReadFile(filepath.Join(ctx.SkillsDir, "cq", "SKILL.md"))
+	require.NoError(t, err)
+	require.Equal(t, prompts.Skill(), string(skill))
+
+	// Prompt files are transformed (name: stripped, /cq: → /cq-).
+	for _, name := range []string{"cq-reflect.md", "cq-status.md"} {
+		got, err := os.ReadFile(filepath.Join(ctx.Target, "prompts", name))
+		require.NoError(t, err)
+		require.NotContains(t, string(got), "name:")
+		require.NotContains(t, string(got), "/cq:")
+	}
+
+	// AGENTS.md block with CLI mappings.
+	agents, err := os.ReadFile(filepath.Join(ctx.Target, "AGENTS.md"))
+	require.NoError(t, err)
+	body := string(agents)
+	require.Contains(t, body, cqBlock.start)
+	require.Contains(t, body, cqBlock.end)
+	require.Contains(t, body, "no cq MCP server")
+	require.Contains(t, body, ctx.BinaryPath)
+	require.Contains(t, body, "### "+ctx.BinaryPath+" query")
+	require.Contains(t, body, "### "+ctx.BinaryPath+" propose")
+	require.Contains(t, body, "### "+ctx.BinaryPath+" confirm <unit_id>")
+	require.Contains(t, body, "### "+ctx.BinaryPath+" flag <unit_id>")
+	require.Contains(t, body, "### "+ctx.BinaryPath+" status")
+}
+
+func TestPiInstallIsIdempotent(t *testing.T) {
+	ctx := piCtx(t)
+	_, err := piHost{}.Install(ctx)
+	require.NoError(t, err)
+	changes, err := piHost{}.Install(ctx)
+	require.NoError(t, err)
+	for _, c := range changes {
+		require.NotEqual(t, ActionCreated, c.Action)
+	}
+}
+
+func TestPiUninstallReversesButKeepsSharedSkill(t *testing.T) {
+	ctx := piCtx(t)
+	_, err := piHost{}.Install(ctx)
+	require.NoError(t, err)
+	_, err = piHost{}.Uninstall(ctx)
+	require.NoError(t, err)
+
+	// Prompts gone (dir pruned).
+	require.NoDirExists(t, filepath.Join(ctx.Target, "prompts"))
+	// AGENTS.md gone (file deleted when only our block).
+	require.NoFileExists(t, filepath.Join(ctx.Target, "AGENTS.md"))
+	// Shared skill REMAINS (it is the cross-host commons).
+	require.FileExists(t, filepath.Join(ctx.SkillsDir, "cq", "SKILL.md"))
+}
+
+func TestPiRegisteredAndProject(t *testing.T) {
+	h, ok := hosts[TargetPi]
+	require.True(t, ok)
+	require.Equal(t, TargetPi, h.Name())
+	require.False(t, h.SupportsProject())
+}
+
+func TestPiTargetPath(t *testing.T) {
+	require.Equal(t, filepath.Join("/home/dev", ".pi", "agent"), piTarget("/home/dev"))
+}
+
+func TestTransformPiCommandStripsNameAndRewritesSlash(t *testing.T) {
+	source := "---\nname: cq:status\ndescription: Show stats.\n---\n\n# /cq:status\n\nBody.\n"
+	got := transformPiCommand(source)
+	require.NotContains(t, got, "name:")
+	require.Contains(t, got, "description: Show stats.")
+	require.Contains(t, got, "# /cq-status")
+	require.NotContains(t, got, "/cq:")
+}
+
+func TestTransformPiCommandHandlesCRLF(t *testing.T) {
+	source := "---\r\nname: cq:reflect\r\ndescription: Mine.\r\n---\r\n\r\n# /cq:reflect\r\n"
+	got := transformPiCommand(source)
+	require.NotContains(t, got, "name:")
+	require.Contains(t, got, "/cq-reflect")
+}
+
+func TestTransformPiCommandReturnsUnchangedWithoutFrontmatter(t *testing.T) {
+	source := "# No Frontmatter\n"
+	require.Equal(t, source, transformPiCommand(source))
+}
+
+func TestTransformPiCommandReturnsUnchangedWithUnclosedFrontmatter(t *testing.T) {
+	source := "---\nname: broken\n"
+	require.Equal(t, source, transformPiCommand(source))
+}

--- a/cli/internal/install/registry.go
+++ b/cli/internal/install/registry.go
@@ -13,6 +13,9 @@ const (
 	// TargetOpenCode is the OpenCode editor.
 	TargetOpenCode Target = "opencode"
 
+	// TargetPi is the Pi coding agent.
+	TargetPi Target = "pi"
+
 	// TargetWindsurf is the Windsurf editor.
 	TargetWindsurf Target = "windsurf"
 )
@@ -24,6 +27,7 @@ const (
 var hosts = map[Target]Host{
 	TargetCursor:   cursorHost{},
 	TargetOpenCode: opencodeHost{},
+	TargetPi:       piHost{},
 	TargetWindsurf: windsurfHost{},
 }
 

--- a/cli/internal/install/types.go
+++ b/cli/internal/install/types.go
@@ -32,6 +32,20 @@ type Change struct {
 	Detail string
 }
 
+// CLIVerb describes one cq CLI verb for hosts that embed CLI invocation
+// instructions instead of MCP config.
+type CLIVerb struct {
+	// Name is the verb (e.g. "query", "propose").
+	Name string
+
+	// UseLine is the cobra Use string (e.g. "query", "confirm <unit_id>").
+	UseLine string
+
+	// FlagUsages is the rendered flag table from cobra (may be empty for
+	// commands with no flags, like confirm).
+	FlagUsages string
+}
+
 // Context carries the resolved per-host paths for one install or uninstall.
 type Context struct {
 	// Target is the host's configuration directory.
@@ -45,6 +59,14 @@ type Context struct {
 
 	// DryRun reports the planned changes without writing.
 	DryRun bool
+
+	// CLIVerbs lists the cq CLI verbs and their argument templates.
+	//
+	// Populated by the install command from the cobra command definitions;
+	// consumed by hosts that embed CLI instructions (e.g. Pi) instead of MCP
+	// config.
+	// Nil for MCP-capable hosts.
+	CLIVerbs []CLIVerb
 }
 
 // Host installs and removes cq for one agent host.


### PR DESCRIPTION
## Summary

- Add Pi host adapter to `cq install --target pi`, writing the shared skill, transformed prompt files (name: stripped, /cq: rewritten to /cq-), and a delimited AGENTS.md block with CLI invocation mappings.
- Pi has no native MCP; the AGENTS.md block maps each cq verb to a shell invocation using the installed binary path.
- CLI verb descriptions (UseLine + FlagUsages) are derived from the actual cobra command definitions at install time, not hand-maintained strings.
- Add `CLIVerb` type to `Context` so command knowledge stays in `cli/cmd` and `cli/internal/install` just renders it.
- Alphabetical ordering fixes in opencode.go constants and paths.go functions (caught by go-effective validator).

## Test plan

- [x] Unit tests for Pi adapter (all assets, idempotency, uninstall reversal, shared skill survives, path, registry)
- [x] Unit tests for Pi command transform (name strip, /cq: rewrite, CRLF, passthrough on missing/unclosed frontmatter)
- [x] E2E test covering install → idempotent re-run → uninstall round-trip
- [x] `make lint` and `make test` pass from repo root
- [x] Pragma validators: go-effective, go-proverbs, state-machine, error-handling — all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a Pi target to the installation flow, generating Pi prompt assets plus a shared skill, and configuring agent command mappings for CQ verbs.
  * The installer now derives verb details from the CLI itself to ensure Pi agent instructions stay aligned with available commands.
  * Uninstall now cleanly removes Pi-specific prompts and configuration while preserving the shared skill.

* **Tests**
  * Added end-to-end and unit coverage for Pi install, uninstall, idempotency, target paths, and prompt transformation rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->