### PR TITLE
feat(cli): add Claude Code host to cq install

### DIFF
--- a/cli/install_test.go
+++ b/cli/install_test.go
@@ -27,6 +27,18 @@ func TestInstallRequiresAHost(t *testing.T) {
 	require.Contains(t, err.Error(), "select at least one --target")
 }
 
+func TestInstallClaudeDryRun(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	bin := filepath.Join(t.TempDir(), "cq")
+	t.Setenv("CQ_INSTALL_BINARY", bin)
+
+	out, err := runInstall(t, "--target", "claude", "--dry-run")
+	require.NoError(t, err)
+	require.Contains(t, out, "[claude]")
+	require.Contains(t, out, "claude marketplace")
+}
+
 func TestInstallCursorEndToEnd(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/cli/internal/install/claude.go
+++ b/cli/internal/install/claude.go
@@ -1,0 +1,137 @@
+package install
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const (
+	// claudeCLI is the command name for the Claude Code CLI.
+	claudeCLI = "claude"
+
+	// claudeMarketplaceID is the plugin identifier used by
+	// `claude plugin install` and `claude plugin marketplace remove`.
+	claudeMarketplaceID = "cq"
+
+	// claudeMarketplaceSource is the GitHub source slug used by
+	// `claude plugin marketplace add`.
+	claudeMarketplaceSource = "mozilla-ai/cq"
+)
+
+// claudeHost installs the cq plugin into Claude Code via the marketplace CLI.
+//
+// Unlike the other adapters, Claude Code manages its own plugin config through
+// `claude plugin marketplace` subcommands, so this adapter is a thin shell-out
+// rather than a filesystem writer.
+type claudeHost struct {
+	// lookPath resolves a binary on PATH.
+	//
+	// Nil uses the default (exec.LookPath); tests inject a stub.
+	lookPath func(file string) (string, error)
+
+	// run executes an external command.
+	//
+	// Nil uses the default (exec.Command); tests inject a stub.
+	run func(name string, args ...string) error
+}
+
+// GlobalTarget returns a sentinel path.
+//
+// Claude Code manages its own config; the install package never writes to
+// this path.
+func (claudeHost) GlobalTarget(string) string {
+	return os.DevNull
+}
+
+// Install runs `claude plugin marketplace add` and `claude plugin install`.
+func (h claudeHost) Install(ctx Context) ([]Change, error) {
+	if err := h.requireCLI(ctx.DryRun); err != nil {
+		return nil, err
+	}
+	commands := [][]string{
+		{claudeCLI, "plugin", "marketplace", "add", claudeMarketplaceSource},
+		{claudeCLI, "plugin", "install", claudeMarketplaceID},
+	}
+	if err := h.runAll(commands, ctx.DryRun); err != nil {
+		return nil, err
+	}
+	return []Change{{Action: ActionCreated, Path: "claude marketplace"}}, nil
+}
+
+// Name returns the host identifier.
+func (claudeHost) Name() Target { return TargetClaude }
+
+// SupportsProject reports that Claude Code is global-only.
+func (claudeHost) SupportsProject() bool { return false }
+
+// Uninstall runs `claude plugin marketplace remove`.
+//
+// Removing the marketplace entry unregisters the plugin as well, so no
+// separate `claude plugin uninstall` call is needed.
+func (h claudeHost) Uninstall(ctx Context) ([]Change, error) {
+	if err := h.requireCLI(ctx.DryRun); err != nil {
+		return nil, err
+	}
+	commands := [][]string{
+		{claudeCLI, "plugin", "marketplace", "remove", claudeMarketplaceID},
+	}
+	if err := h.runAll(commands, ctx.DryRun); err != nil {
+		return nil, err
+	}
+	return []Change{{Action: ActionRemoved, Path: "claude marketplace"}}, nil
+}
+
+// requireCLI verifies the claude CLI is on PATH.
+func (h claudeHost) requireCLI(dryRun bool) error {
+	if dryRun {
+		return nil
+	}
+	lookup := h.lookPath
+	if lookup == nil {
+		lookup = exec.LookPath
+	}
+	if _, err := lookup(claudeCLI); err != nil {
+		return fmt.Errorf("claude CLI not found on PATH; install Claude Code first: %w", err)
+	}
+	return nil
+}
+
+// runAll executes each command in sequence, skipping all in dry-run mode.
+func (h claudeHost) runAll(commands [][]string, dryRun bool) error {
+	if dryRun {
+		return nil
+	}
+	runner := h.runner()
+	for _, cmd := range commands {
+		if err := runner(cmd[0], cmd[1:]...); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// runner returns the command executor, defaulting to exec.Command when none
+// was injected.
+func (h claudeHost) runner() func(string, ...string) error {
+	if h.run != nil {
+		return h.run
+	}
+	return execRun
+}
+
+// execRun runs an external command, returning a descriptive error on non-zero
+// exit.
+func execRun(name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		detail := strings.TrimSpace(string(out))
+		if detail != "" {
+			return fmt.Errorf("running %s: %w\n%s", strings.Join(cmd.Args, " "), err, detail)
+		}
+		return fmt.Errorf("running %s: %w", strings.Join(cmd.Args, " "), err)
+	}
+	return nil
+}

--- a/cli/internal/install/claude_test.go
+++ b/cli/internal/install/claude_test.go
@@ -1,0 +1,96 @@
+package install
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// stubLookPath returns a lookPath function that always succeeds.
+func stubLookPath(string) (string, error) { return "/usr/bin/claude", nil }
+
+func TestClaudeInstallRunsMarketplaceCommands(t *testing.T) {
+	var ran [][]string
+	h := claudeHost{
+		lookPath: stubLookPath,
+		run: func(name string, args ...string) error {
+			ran = append(ran, append([]string{name}, args...))
+			return nil
+		},
+	}
+
+	changes, err := h.Install(Context{DryRun: false})
+	require.NoError(t, err)
+	require.Len(t, changes, 1)
+	require.Equal(t, ActionCreated, changes[0].Action)
+
+	require.Len(t, ran, 2)
+	require.Equal(t, []string{"claude", "plugin", "marketplace", "add", claudeMarketplaceSource}, ran[0])
+	require.Equal(t, []string{"claude", "plugin", "install", claudeMarketplaceID}, ran[1])
+}
+
+func TestClaudeUninstallRunsMarketplaceRemove(t *testing.T) {
+	var ran [][]string
+	h := claudeHost{
+		lookPath: stubLookPath,
+		run: func(name string, args ...string) error {
+			ran = append(ran, append([]string{name}, args...))
+			return nil
+		},
+	}
+
+	changes, err := h.Uninstall(Context{DryRun: false})
+	require.NoError(t, err)
+	require.Len(t, changes, 1)
+	require.Equal(t, ActionRemoved, changes[0].Action)
+
+	require.Len(t, ran, 1)
+	require.Equal(t, []string{"claude", "plugin", "marketplace", "remove", claudeMarketplaceID}, ran[0])
+}
+
+func TestClaudeInstallDryRunSkipsExecution(t *testing.T) {
+	var ran [][]string
+	h := claudeHost{run: func(name string, args ...string) error {
+		ran = append(ran, append([]string{name}, args...))
+		return nil
+	}}
+
+	changes, err := h.Install(Context{DryRun: true})
+	require.NoError(t, err)
+	require.Len(t, changes, 1)
+	require.Equal(t, ActionCreated, changes[0].Action)
+	require.Empty(t, ran)
+}
+
+func TestClaudeInstallPropagatesCommandFailure(t *testing.T) {
+	h := claudeHost{
+		lookPath: stubLookPath,
+		run: func(name string, args ...string) error {
+			return fmt.Errorf("running %s: exit status 1", name)
+		},
+	}
+
+	_, err := h.Install(Context{DryRun: false})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "claude")
+}
+
+func TestClaudeInstallFailsWhenCLIMissing(t *testing.T) {
+	h := claudeHost{
+		lookPath: func(string) (string, error) {
+			return "", fmt.Errorf("not found")
+		},
+	}
+
+	_, err := h.Install(Context{DryRun: false})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "claude CLI not found on PATH")
+}
+
+func TestClaudeRegisteredAndProject(t *testing.T) {
+	h, ok := hosts[TargetClaude]
+	require.True(t, ok)
+	require.Equal(t, TargetClaude, h.Name())
+	require.False(t, h.SupportsProject())
+}

--- a/cli/internal/install/pi.go
+++ b/cli/internal/install/pi.go
@@ -90,6 +90,7 @@ func (piHost) Uninstall(ctx Context) ([]Change, error) {
 		return nil, err
 	}
 	if promptChanges.Action == ActionRemoved && !ctx.DryRun {
+		// Best-effort: remove the now-empty prompts directory.
 		_ = os.Remove(promptsPath)
 	}
 	changes := []Change{promptChanges}

--- a/cli/internal/install/registry.go
+++ b/cli/internal/install/registry.go
@@ -7,6 +7,9 @@ import (
 )
 
 const (
+	// TargetClaude is Claude Code via the plugin marketplace.
+	TargetClaude Target = "claude"
+
 	// TargetCursor is the Cursor editor.
 	TargetCursor Target = "cursor"
 
@@ -25,6 +28,7 @@ const (
 // It is the single source of truth for the targets cq install accepts; adding
 // an entry extends ValidTarget, AllowedTargets, and SelectHosts.
 var hosts = map[Target]Host{
+	TargetClaude:   claudeHost{},
 	TargetCursor:   cursorHost{},
 	TargetOpenCode: opencodeHost{},
 	TargetPi:       piHost{},


### PR DESCRIPTION
## Summary

- Add Claude Code host adapter to `cq install --target claude`, completing Phase 2 of the Go installer.
- Shells out to `claude plugin marketplace add/install/remove` rather than writing config files — Claude Code manages its own plugin config.
- Verifies the `claude` CLI is on PATH before execution; returns a descriptive error if absent.
- Respects dry-run (skips execution, reports planned changes).
- Command runner injected via struct field for testability — no mutable package-level state.

## Test plan

- [x] Unit tests for install (verifies marketplace add + install commands), uninstall (marketplace remove), dry-run skip, error propagation, registry
- [x] E2E dry-run test through the full cobra command wiring
- [x] `make lint` and `make test` pass from repo root
- [x] Pragma validators: go-effective, go-proverbs, security, state-machine, error-handling — all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `claude` install target to install and remove the `cq` plugin via Claude Code’s plugin marketplace.
  * Dry-run now supports Claude installs so you can preview the planned changes before applying them.
* **Tests**
  * Added coverage for Claude marketplace install/uninstall behaviour, correct command sequencing, dry-run execution skipping, failure handling, and missing CLI detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->