### PR TITLE
(cli) Bump Go SDK version in CLI to v0.11.0

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -4,7 +4,7 @@ go 1.26.1
 
 require (
 	github.com/mark3labs/mcp-go v0.46.0
-	github.com/mozilla-ai/cq/sdk/go v0.10.0
+	github.com/mozilla-ai/cq/sdk/go v0.11.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.9
 	github.com/stretchr/testify v1.11.1
@@ -36,4 +36,4 @@ require (
 
 // Monorepo: the SDK is consumed locally. Re-pin to a published version
 // when the SDK is released alongside the CLI.
-replace github.com/mozilla-ai/cq/sdk/go => ../sdk/go
+//replace github.com/mozilla-ai/cq/sdk/go => ../sdk/go

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -31,8 +31,8 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mozilla-ai/cq/schema v0.0.1 h1:jPoZAYbU7/b3R3CEghmwuG0A3NrqczWsMkIWjXeFI94=
 github.com/mozilla-ai/cq/schema v0.0.1/go.mod h1:trKUR0o8hGYkQ26XAb3HFVHcQOct7lP/cS8beS5v2eE=
-github.com/mozilla-ai/cq/sdk/go v0.10.0 h1:khvipCWhv7vouMAlegWgT8E3klDCY5EbpFnrHL1mv5Y=
-github.com/mozilla-ai/cq/sdk/go v0.10.0/go.mod h1:0lsVnbeeJS76z9Q2AYMBndYPhuYDtZdovLAAvmZDA74=
+github.com/mozilla-ai/cq/sdk/go v0.11.0 h1:HDw7ihqJNT4cUaet174d+wuoBQeJNUuT2lH03Fi6pQ4=
+github.com/mozilla-ai/cq/sdk/go v0.11.0/go.mod h1:0lsVnbeeJS76z9Q2AYMBndYPhuYDtZdovLAAvmZDA74=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated SDK dependency to the latest version (v0.11.0) to ensure compatibility and access to the latest improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->