### PR TITLE
docs: document SDK store protocol/interface and remove stale hooks references

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,7 +13,6 @@ flowchart TB
     subgraph cc["Claude Code Process"]
         direction TB
         skill["SKILL.md\nBehavioral instructions"]
-        hook["hooks.json\nPost-error auto-query"]
         cmd_status["/cq:status\nStore statistics"]
         cmd_reflect["/cq:reflect\nSession mining"]
     end
@@ -40,7 +39,7 @@ flowchart TB
     classDef dockerStyle fill:#e6f4ea,stroke:#34a853,color:#1a1a1a
     classDef dbStyle fill:#fce8e6,stroke:#ea4335,color:#1a1a1a
 
-    class skill,hook,cmd_status,cmd_reflect ccStyle
+    class skill,cmd_status,cmd_reflect ccStyle
     class server mcpStyle
     class api dockerStyle
     class local_db,remote_db dbStyle
@@ -356,7 +355,6 @@ flowchart LR
         skill["SKILL.md\nTeaches agent when to\nquery, propose, confirm, flag"]
         reviewer["cq-reviewer.md\nSub-agent for reviewing\ngraduation candidates"]
         mcp_cfg[".mcp.json\nMCP server configuration"]
-        hooks["hooks.json\nPost-error: auto-query\ncommons on failure"]
         commands["Commands\n/cq:status — store stats\n/cq:reflect — session mining"]
     end
 
@@ -368,7 +366,6 @@ flowchart LR
     manifest -.->|"declares"| skill
     manifest -.->|"declares"| reviewer
     manifest -.->|"declares"| mcp_cfg
-    manifest -.->|"declares"| hooks
     manifest -.->|"declares"| commands
     mcp_cfg -->|"spawns via stdio"| server
     skill -->|"instructs agent to call"| tools
@@ -376,17 +373,15 @@ flowchart LR
     classDef pluginStyle fill:#e8f0fe,stroke:#4285f4,color:#1a1a1a
     classDef serverStyle fill:#fef7e0,stroke:#f9ab00,color:#1a1a1a
 
-    class manifest,skill,reviewer,mcp_cfg,hooks,commands pluginStyle
+    class manifest,skill,reviewer,mcp_cfg,commands pluginStyle
     class tools serverStyle
 ```
 
-**SKILL.md** is the behavioral layer. It teaches the agent *when* to use cq tools: query before unfamiliar API calls, propose when discovering undocumented behavior, confirm when knowledge proves correct, flag when it is wrong or stale.
+**SKILL.md** is the behavioral layer. It teaches the agent *when* to use cq tools: query before unfamiliar API calls, propose when discovering undocumented behavior, confirm when knowledge proves correct, flag when it is wrong or stale. The Skill's core protocol instructs the agent to query before acting and propose immediately when a non-obvious insight stabilizes mid-task.
 
 **MCP Server** exposes six tools over stdio. The agent calls these tools based on the Skill's instructions. The server handles local storage, remote API communication, confidence scoring, and query matching.
 
-**Hooks** trigger automatically. The post-error hook instructs the agent to call `query` with the error context before attempting a fix.
-
-**Commands** are developer-facing. `/cq:status` shows store statistics. `/cq:reflect` triggers retrospective session mining — it catches long-tail knowledge that real-time hooks miss, ranks candidates by estimated generalizability, and checks the commons for existing coverage before proposing (surfacing existing KUs rather than creating duplicates). Candidates are presented for human approval.
+**Commands** are developer-facing. `/cq:status` shows store statistics. `/cq:reflect` triggers retrospective session mining — it catches long-tail knowledge that the mid-task propose flow missed, ranks candidates by estimated generalizability, and checks the commons for existing coverage before proposing (surfacing existing KUs rather than creating duplicates). Candidates are presented for human approval.
 
 **plugin.json** is the manifest that declares all components and wires them together for one-command installation.
 
@@ -449,7 +444,7 @@ flowchart TB
 
 2. **Skill via skills.sh** — installs `SKILL.md` and MCP configuration. Works across 30+ agents that support the Agent Skills standard. The Skill adds judgment: it teaches the agent *when* and *why* to call the tools.
 
-3. **Full Plugin** — bundles the Skill, MCP server, hooks, commands, and manifest into a one-command install for Claude Code, OpenCode, and other plugin-compatible agents. This is the richest experience.
+3. **Full Plugin** — bundles the Skill, MCP server, commands, and manifest into a one-command install for Claude Code, OpenCode, and other plugin-compatible agents. This is the richest experience.
 
 The ecosystem convergence on MCP and Agent Skills means cq does not need to convince developers to adopt new protocols. It plugs into the infrastructure they already have.
 

--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -52,12 +52,13 @@ reflectPrompt := prompts.Reflect()
 
 The client works out of the box in local-only mode with no configuration.
 
-| Variable           | Description           | Default                      |
-|--------------------|-----------------------|------------------------------|
-| `CQ_ADDR`          | Remote cq API address | None (local-only)            |
-| `CQ_API_KEY`      | API key               | None                         |
-| `CQ_LOCAL_DB_PATH` | Local SQLite path     | `~/.local/share/cq/local.db` |
+| Variable              | Description                                                       | Default                       |
+|-----------------------|-------------------------------------------------------------------|-------------------------------|
+| `CQ_ADDR`             | Remote cq API address                                             | None (local-only)             |
+| `CQ_API_KEY`          | API key for the remote API                                        | None                          |
 | `CQ_LOCAL_DATABASE_URL` | Local store connection URL (e.g. `sqlite:///abs/path/local.db`) | None (falls back to `CQ_LOCAL_DB_PATH`) |
+| `CQ_LOCAL_DB_PATH`    | Local SQLite file path                                            | `$XDG_DATA_HOME/cq/local.db` |
+| `XDG_DATA_HOME`       | Base directory for the default database path ([XDG spec](https://specifications.freedesktop.org/basedir/latest/)) | `~/.local/share` |
 
 Or pass directly:
 
@@ -68,22 +69,56 @@ c, err := cq.NewClient(
 )
 ```
 
-The default database path follows the [XDG Base Directory spec](https://specifications.freedesktop.org/basedir/latest/).
+### Store interface
 
-### Custom storage
+The local store is pluggable. The SDK defines a `Store` interface that the `Client` depends on; the default SQLite store satisfies it, and you can supply any implementation.
 
-The local store is pluggable. By default the SDK opens a SQLite file at the path above; you can point it at a different backend or supply your own.
+#### Selecting a store
 
-- **By connection string.** Set `CQ_LOCAL_DATABASE_URL` (for example `sqlite:///abs/path/local.db`); it takes precedence over `CQ_LOCAL_DB_PATH`. `cq.StoreFromURL` performs the same resolution programmatically.
-- **By injection.** Pass any `cq.Store` to `cq.WithStore`:
+The client resolves the local store in this precedence order:
 
-  ```go
-  c, err := cq.NewClient(cq.WithStore(cq.NewInMemoryStore()))
-  ```
+1. **`cq.WithStore`** — inject any `cq.Store` directly.
+2. **`CQ_LOCAL_DATABASE_URL`** — a connection-string URL resolved by `cq.StoreFromURL`. Accepted schemes: `sqlite:///abs/path` or `sqlite:path`. A `postgres://` URL returns an error naming the planned adapter module.
+3. **`CQ_LOCAL_DB_PATH` / `cq.WithLocalDBPath`** — path to a SQLite file.
+4. **XDG default** — `$XDG_DATA_HOME/cq/local.db` (typically `~/.local/share/cq/local.db`).
 
-- **Bring your own.** Implement the `cq.Store` interface (`Unit`, `All`, `Insert`, `Update`, `Delete`, `Query`, `Stats`, `Close`) and inject it with `cq.WithStore`. Reuse the shared ranker `cq.RankCandidates` from your `Query`, and verify the implementation against the conformance suite in [`storetest`]({{REPO_TREE_URL}}/sdk/go/storetest).
+#### Interface
 
-Selection precedence: `WithStore` > `CQ_LOCAL_DATABASE_URL` > `CQ_LOCAL_DB_PATH`/`WithLocalDBPath` > XDG default. A first-party PostgreSQL adapter is planned as a separate module; until then a `postgres://` URL returns a clear error.
+The `cq.Store` interface requires eight methods. Implementations must be safe for concurrent use.
+
+| Method   | Signature                                            | Semantics |
+|----------|------------------------------------------------------|-----------|
+| `Unit`   | `(id string) (*KnowledgeUnit, error)`                | Retrieve by ID, or `nil` if absent. |
+| `All`    | `() ([]KnowledgeUnit, error)`                        | Return every unit in the store. |
+| `Insert` | `(ku KnowledgeUnit) error`                           | Insert a unit. Error on duplicate ID or empty domains after normalization. |
+| `Update` | `(ku KnowledgeUnit) error`                           | Replace an existing unit. Error when the ID is absent or domains are empty. |
+| `Delete` | `(id string) error`                                  | Remove by ID. Error when absent. |
+| `Query`  | `(params QueryParams) (StoreQueryResult, error)`     | Return units matching the query, ranked most-relevant first. |
+| `Stats`  | `(recentLimit int) (StoreStats, error)`              | Return aggregated store statistics. |
+| `Close`  | `() error`                                           | Release resources. Must be safe to call more than once. |
+
+#### Built-in implementations
+
+- **SQLite store** (default, unexported) — opens a SQLite file with FTS5 full-text search, WAL journaling, and domain-tag indexing.
+- **`NewInMemoryStore()`** — map-backed, no persistence. Useful for tests and as a worked example for custom stores (domain-tag matching only, no full-text).
+
+```go
+c, err := cq.NewClient(cq.WithStore(cq.NewInMemoryStore()))
+```
+
+#### Bring your own
+
+Implement the `cq.Store` interface and inject it with `cq.WithStore`. Reuse the shared ranker `cq.RankCandidates` from your `Query` implementation so ranking stays consistent across backends. Verify the implementation against the conformance suite in [`storetest`]({{REPO_TREE_URL}}/sdk/go/storetest):
+
+```go
+import "github.com/mozilla-ai/cq/sdk/go/storetest"
+
+func TestMyStore(t *testing.T) {
+    storetest.RunConformance(t, func() cq.Store {
+        return NewMyCustomStore()
+    })
+}
+```
 
 ## Knowledge tiers
 

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -49,12 +49,13 @@ reflect_prompt = prompts.reflect()
 
 The client reads configuration from environment variables:
 
-| Variable           | Description           | Default                      |
-|--------------------|-----------------------|------------------------------|
-| `CQ_ADDR`          | Remote cq API address | None (local-only)            |
-| `CQ_API_KEY`       | API key               | None                         |
-| `CQ_LOCAL_DB_PATH` | Local SQLite path     | `~/.local/share/cq/local.db` |
+| Variable              | Description                                                       | Default                       |
+|-----------------------|-------------------------------------------------------------------|-------------------------------|
+| `CQ_ADDR`             | Remote cq API address                                             | None (local-only)             |
+| `CQ_API_KEY`          | API key for the remote API                                        | None                          |
 | `CQ_LOCAL_DATABASE_URL` | Local store connection URL (e.g. `sqlite:///abs/path/local.db`) | None (falls back to `CQ_LOCAL_DB_PATH`) |
+| `CQ_LOCAL_DB_PATH`    | Local SQLite file path                                            | `$XDG_DATA_HOME/cq/local.db` |
+| `XDG_DATA_HOME`       | Base directory for the default database path ([XDG spec](https://specifications.freedesktop.org/basedir/latest/)) | `~/.local/share` |
 
 Or pass directly:
 
@@ -65,22 +66,54 @@ cq = Client(
 )
 ```
 
-### Custom storage
+### Store protocol
 
-The local store is pluggable. By default the SDK opens a SQLite file at the path above; you can point it at a different backend or supply your own.
+The local store is pluggable. The SDK defines a `Store` runtime-checkable Protocol that the `Client` depends on; the default `SqliteStore` satisfies it, and you can supply any implementation.
 
-- **By connection string.** Set `CQ_LOCAL_DATABASE_URL` (for example `sqlite:///abs/path/local.db`); it takes precedence over `CQ_LOCAL_DB_PATH`. `cq.create_store` performs the same resolution programmatically.
-- **By injection.** Pass any `cq.Store` to the `store` argument:
+#### Selecting a store
 
-  ```python
-  from cq import Client, InMemoryStore
+The client resolves the local store in this precedence order:
 
-  client = Client(store=InMemoryStore())
-  ```
+1. **`store=` argument** — inject any `cq.Store` directly.
+2. **`CQ_LOCAL_DATABASE_URL`** — a connection-string URL resolved by `cq.create_store`. Accepted schemes: `sqlite:///abs/path` or `sqlite:path`. A `postgresql://` URL raises `NotImplementedError` naming the planned `cq-sdk[postgres]` extra.
+3. **`local_db_path=` argument / `CQ_LOCAL_DB_PATH` env var** — path to a SQLite file.
+4. **XDG default** — `$XDG_DATA_HOME/cq/local.db` (typically `~/.local/share/cq/local.db`).
 
-- **Bring your own.** Implement the `cq.Store` protocol (`get`, `all`, `insert`, `update`, `delete`, `query`, `stats`, `close`) and inject it via `store=`. Reuse the shared ranker `cq.rank_candidates` from your `query`, and verify the implementation against the conformance suite in `tests/conformance.py`.
+#### Interface
 
-Selection precedence: `store=` > `CQ_LOCAL_DATABASE_URL` > `local_db_path`/`CQ_LOCAL_DB_PATH` > XDG default. A first-party PostgreSQL adapter is planned as the `cq-sdk[postgres]` extra; until then a `postgresql://` URL raises `NotImplementedError` naming the install.
+The `cq.Store` Protocol requires eight methods. Implementations must be safe for use across `asyncio.to_thread` executor threads.
+
+| Method   | Signature                                           | Semantics |
+|----------|-----------------------------------------------------|-----------|
+| `get`    | `(unit_id: str) -> KnowledgeUnit \| None`           | Retrieve by ID, or `None` if absent. |
+| `all`    | `() -> list[KnowledgeUnit]`                         | Return every unit in the store. |
+| `insert` | `(unit: KnowledgeUnit) -> None`                     | Insert a unit. Raise `DuplicateUnitError` on an existing ID; raise `ValueError` if domains are empty after normalization. |
+| `update` | `(unit: KnowledgeUnit) -> None`                     | Replace an existing unit. Raise `KeyError` when the ID is absent; raise `ValueError` if domains are empty. |
+| `delete` | `(unit_id: str) -> None`                            | Remove by ID. Raise `KeyError` when absent. |
+| `query`  | `(params: QueryParams) -> StoreQueryResult`         | Return units matching the query, ranked most-relevant first. |
+| `stats`  | `(*, recent_limit: int = 5) -> StoreStats`          | Return aggregated store statistics. |
+| `close`  | `() -> None`                                        | Release resources. Must be safe to call more than once. |
+
+#### Built-in implementations
+
+- **`SqliteStore`** — the default. Opens a SQLite file with FTS5 full-text search, WAL journaling, and domain-tag indexing.
+- **`InMemoryStore`** — map-backed, no persistence. Useful for tests and as a worked example for custom stores (domain-tag matching only, no full-text).
+
+```python
+from cq import Client, InMemoryStore
+
+client = Client(store=InMemoryStore())
+```
+
+#### Bring your own
+
+Implement the `cq.Store` protocol and inject it via `store=`. Reuse the shared ranker `cq.rank_candidates` from your `query` implementation so ranking stays consistent across backends. Verify the implementation against the conformance suite in `tests/conformance.py`:
+
+```python
+from tests.conformance import run_store_conformance
+
+run_store_conformance(lambda: MyCustomStore())
+```
 
 ## Knowledge tiers
 


### PR DESCRIPTION
## Summary

- **SDK READMEs (Python and Go):** replaced the informal "Custom storage" section with a structured store protocol/interface reference — env var table now includes `CQ_LOCAL_DATABASE_URL` and `XDG_DATA_HOME` in precedence order, a method table documents all eight SPI methods with signatures and error semantics, built-in implementations (SQLite, InMemoryStore) are described, and conformance suite usage is shown with code examples.
- **Architecture doc:** removed all `hooks.json` references from diagrams and prose — the plugin ships an empty hooks object (`"hooks": {}`), and the skill-driven core protocol handles pre-error querying.

## Test plan

- [ ] Verify markdown renders correctly on GitHub (tables, code blocks, links)
- [ ] Confirm no remaining stale hooks references in `docs/architecture.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Updated architecture documentation with revised plugin anatomy and command-based workflow for status and reflect operations
* Enhanced Go SDK configuration and Store interface documentation, including default paths and implementation guidelines
* Expanded Python SDK configuration and local store integration documentation with explicit Store protocol definitions and precedence rules

<!-- end of auto-generated comment: release notes by coderabbit.ai -->