### PR TITLE
docs: publish plugin documentation on the docs site

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -52,6 +52,13 @@ cq flag <unit_id> --reason duplicate --duplicate-of <other_id>
 cq status
 cq status --format json
 
+# Install the plugin into a coding agent.
+cq install --target claude
+cq install --target claude --target cursor
+cq install --target claude --project .
+cq install --target claude --dry-run
+cq install --target claude --uninstall
+
 # Print the agent protocol prompt (for frameworks without the cq plugin).
 cq prompt
 
@@ -67,6 +74,7 @@ The CLI works out of the box in local-only mode with no configuration.
 |--------------------|------------------------------------|--------------------------------|
 | `CQ_ADDR`          | Remote cq API address              | None (local-only)              |
 | `CQ_API_KEY`       | API key (data-plane, long-lived)   | None                           |
+| `CQ_LOCAL_DATABASE_URL` | Local store connection URL (e.g. `sqlite:///abs/path/local.db`) | None (falls back to `CQ_LOCAL_DB_PATH`) |
 | `CQ_LOCAL_DB_PATH` | Local SQLite path                  | `~/.local/share/cq/local.db`   |
 | `CQ_CONFIG_DIR`    | Credential and config directory    | `${XDG_CONFIG_HOME:-~/.config}/cq` |
 | `CQ_TIMEOUT`       | CLI operation timeout              | 30s                            |
@@ -131,7 +139,7 @@ Knowledge units live in one of three tiers:
 
 - **local** — on-disk SQLite, never leaves your machine.
 - **private** — stored on the remote at `CQ_ADDR`, visible to every client that can reach the same remote (e.g. teammates pointing at the same server).
-- **public** — open commons; not yet available.
+- **public** — open commons, available via [cq exchange](https://cq.exchange).
 
 With `CQ_ADDR` set, `cq propose` sends the unit straight to the remote as `private` (falling back to local if the remote is unreachable). With no remote, everything stays local. `cq status` shows the count in each tier.
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -11,6 +11,7 @@
 
 * [CLI](cli/README.md)
   * [CLI Development](cli/DEVELOPMENT.md)
+* [Plugin](plugin/README.md)
 * [Go SDK](sdk/go/README.md)
   * [Go SDK Development](sdk/go/DEVELOPMENT.md)
 * [Python SDK](sdk/python/README.md)

--- a/plugins/cq/README.md
+++ b/plugins/cq/README.md
@@ -1,0 +1,114 @@
+# cq Plugin
+
+Agent plugin for [cq](https://github.com/mozilla-ai/cq) — the shared agent knowledge commons. Bundles the MCP server, the cq protocol skill, and session commands (`/cq:status`, `/cq:reflect`) so your coding agent can query, propose, confirm, and flag knowledge units during normal work.
+
+The plugin works with Claude Code, OpenCode, Cursor, Windsurf, and Pi.
+
+## Installation
+
+Requires: the [cq CLI](../cli/README.md).
+
+```bash
+cq install --target claude
+```
+
+Supported targets: `claude`, `cursor`, `opencode`, `pi`, `windsurf`. Install into multiple agents at once by repeating `--target`:
+
+```bash
+cq install --target claude --target cursor
+```
+
+Use `--project` to scope the install to a single project directory instead of globally:
+
+```bash
+cq install --target claude --project .
+```
+
+Preview what will change without writing anything:
+
+```bash
+cq install --target claude --dry-run
+```
+
+To remove:
+
+```bash
+cq install --target claude --uninstall
+```
+
+Re-running `cq install` is idempotent.
+
+## What the plugin provides
+
+The plugin bundles three things:
+
+1. **MCP server** — exposes the five cq tools (`query`, `propose`, `confirm`, `flag`, `status`) over stdio. The plugin bootstraps the cq CLI binary automatically on first run.
+2. **Skill** (`cq`) — the core protocol that guides the agent to query before acting, propose when it discovers something novel, and confirm or flag existing knowledge.
+3. **Commands** — `/cq:status` and `/cq:reflect`, described below.
+
+## MCP tools
+
+| Tool      | What it does                               |
+|-----------|--------------------------------------------|
+| `query`   | Search the knowledge store before acting   |
+| `propose` | Submit a new knowledge unit                |
+| `confirm` | Endorse an existing KU that proved correct |
+| `flag`    | Mark a KU as wrong or stale                |
+| `status`  | Show store statistics                      |
+
+The agent calls these tools during normal work. You do not need to invoke them directly.
+
+## Commands
+
+### `/cq:status`
+
+Display a summary of the knowledge store: tier counts (local, private, public), recent local additions, confidence distribution, and domain breakdown.
+
+### `/cq:reflect`
+
+Mine the current session for knowledge worth sharing. The agent scans for debugging breakthroughs, undocumented API behavior, and workarounds, then presents candidates for your approval before proposing them to the store.
+
+This is a catch-all for the end of a session; during normal work the skill guides the agent to propose knowledge inline as it discovers it.
+
+## Configuration
+
+The plugin uses the same environment variables as the CLI:
+
+| Variable                | Description                        | Default                        |
+|-------------------------|------------------------------------|--------------------------------|
+| `CQ_ADDR`               | Remote cq API address              | None (local-only)              |
+| `CQ_API_KEY`            | API key (data-plane, long-lived)   | None                           |
+| `CQ_LOCAL_DATABASE_URL` | Local store connection URL (e.g. `sqlite:///abs/path/local.db`) | None (falls back to `CQ_LOCAL_DB_PATH`) |
+| `CQ_LOCAL_DB_PATH`      | Local SQLite path                  | `~/.local/share/cq/local.db`   |
+| `CQ_CONFIG_DIR`         | Credential and config directory    | `${XDG_CONFIG_HOME:-~/.config}/cq` |
+| `CQ_TIMEOUT`            | Operation timeout                  | 30s                            |
+
+Selection precedence: `CQ_LOCAL_DATABASE_URL` > `CQ_LOCAL_DB_PATH` > XDG default.
+
+With no configuration, knowledge stays local on your machine. Set `CQ_ADDR` to connect to a remote store.
+
+## Knowledge tiers
+
+Knowledge units live in one of three tiers:
+
+- **local** — on-disk SQLite, never leaves your machine.
+- **private** — stored on the remote at `CQ_ADDR`, visible to every client that can reach the same remote (e.g. teammates pointing at the same server).
+- **public** — open commons, available via [cq exchange](https://cq.exchange).
+
+With `CQ_ADDR` set, `propose` sends the unit to the remote as `private` (falling back to local if the remote is unreachable). With no remote, everything stays local. `/cq:status` shows the count in each tier.
+
+See the [top-level README](../../README.md) for the full description.
+
+## Development
+
+From the repository root:
+
+```
+make setup-plugin       # uv sync
+make test-plugin        # pytest
+make lint-plugin        # pre-commit (ruff, ty)
+```
+
+## License
+
+[Apache-2.0](../../LICENSE)

--- a/scripts/prepare_gitbook_site.py
+++ b/scripts/prepare_gitbook_site.py
@@ -52,6 +52,9 @@ COMPONENT_FILES: dict[str, list[tuple[str, Path]]] = {
         ("sdk/python/README.md", SITE_DIR / "sdk" / "python" / "README.md"),
         ("sdk/python/DEVELOPMENT.md", SITE_DIR / "sdk" / "python" / "DEVELOPMENT.md"),
     ],
+    "plugin": [
+        ("plugins/cq/README.md", SITE_DIR / "plugin" / "README.md"),
+    ],
     "server": [
         ("server/backend/README.md", SITE_DIR / "server" / "README.md"),
     ],
@@ -59,6 +62,7 @@ COMPONENT_FILES: dict[str, list[tuple[str, Path]]] = {
 
 COMPONENT_TAG_PREFIXES = {
     "cli": "cli/v",
+    "plugin": "plugin/",
     "sdk/go": "sdk/go/v",
     "sdk/python": "sdk/python/",
     "server": "server/v",
@@ -185,9 +189,7 @@ def expand_includes(path: Path) -> None:
             include_path = stripped[len(INCLUDE_PREFIX) : -len(INCLUDE_SUFFIX)].strip()
             source_path = (REPO_ROOT / include_path).resolve()
             if not source_path.is_relative_to(REPO_ROOT):
-                raise ValueError(
-                    f"Include `{include_path}` escapes the repository root"
-                )
+                raise ValueError(f"Include `{include_path}` escapes the repository root")
             if not source_path.is_file():
                 raise FileNotFoundError(
                     f"Missing include `{include_path}` referenced from {path.relative_to(REPO_ROOT)}"
@@ -219,9 +221,7 @@ def copy_component_files(*, from_tags: bool) -> None:
             prefix = COMPONENT_TAG_PREFIXES[component]
             tag = latest_tag(prefix)
             if tag is None:
-                raise SystemExit(
-                    f"Error: no release tag found for {component} ({prefix}*)"
-                )
+                raise SystemExit(f"Error: no release tag found for {component} ({prefix}*)")
             print(f"  {component}: {tag}")
             for repo_rel, dest in entries:
                 content = git_show(tag, repo_rel)
@@ -234,6 +234,7 @@ def copy_component_files(*, from_tags: bool) -> None:
 
 
 def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--from-tags",


### PR DESCRIPTION
## Summary

- Add `plugins/cq/README.md` covering installation via `cq install`, what the plugin provides (MCP server, skill, commands), MCP tools, `/cq:status` and `/cq:reflect`, configuration, and knowledge tiers.
- Register plugin in `COMPONENT_FILES` and `COMPONENT_TAG_PREFIXES` in `prepare_gitbook_site.py`, and add Plugin entry to `docs/SUMMARY.md`.
- Update CLI README with `cq install` usage examples, `CQ_LOCAL_DATABASE_URL` env var, and fix stale public tier description.

Fixes #439

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added new documentation for the `cq` agent plugin, including installation/uninstallation, supported agent targets, configuration environment variables, local vs remote behaviour, and knowledge tier details.
  * Updated CLI and site documentation navigation, including new configuration guidance and revised “public” tier availability wording.
* **Chores**
  * Improved the GitBook site build to include the new plugin documentation section and refined error messaging for clearer build-time failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->