### PR TITLE
docs: inject version badge into component pages built from release tags

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -59,6 +59,9 @@ unfixable = [
     "D",
     "N999",
 ]
+"**/test_*.py" = [
+    "D",
+]
 
 [lint.pydocstyle]
 convention = "google"

--- a/scripts/prepare_gitbook_site.py
+++ b/scripts/prepare_gitbook_site.py
@@ -217,8 +217,12 @@ def substitute_placeholders(path: Path, repo_tree_url: str) -> None:
 def _inject_version_badge(content: str, version: str) -> str:
     """Insert a version indicator after the first top-level heading."""
     lines = content.split("\n")
+    in_fence = False
     for i, line in enumerate(lines):
-        if line.startswith("# "):
+        if line.startswith("```"):
+            in_fence = not in_fence
+            continue
+        if not in_fence and line.startswith("# "):
             j = i + 1
             while j < len(lines) and not lines[j].strip():
                 j += 1
@@ -244,9 +248,12 @@ def copy_component_files(*, from_tags: bool) -> None:
             for repo_rel, dest in entries:
                 try:
                     content = git_show(tag, repo_rel)
-                except subprocess.CalledProcessError:
-                    print(f"    warning: {repo_rel} not found at {tag}, skipping")
-                    continue
+                except subprocess.CalledProcessError as exc:
+                    stderr = exc.stderr or ""
+                    if "does not exist" in stderr or "exists on disk, but not in" in stderr:
+                        print(f"    warning: {repo_rel} not found at {tag}, skipping")
+                        continue
+                    raise
                 content = _inject_version_badge(content, version)
                 dest.parent.mkdir(parents=True, exist_ok=True)
                 dest.write_text(content, encoding="utf-8")

--- a/scripts/prepare_gitbook_site.py
+++ b/scripts/prepare_gitbook_site.py
@@ -214,6 +214,19 @@ def substitute_placeholders(path: Path, repo_tree_url: str) -> None:
         path.write_text(text.replace(REPO_TREE_URL_MARKER, repo_tree_url), encoding="utf-8")
 
 
+def _inject_version_badge(content: str, version: str) -> str:
+    """Insert a version indicator after the first top-level heading."""
+    lines = content.split("\n")
+    for i, line in enumerate(lines):
+        if line.startswith("# "):
+            j = i + 1
+            while j < len(lines) and not lines[j].strip():
+                j += 1
+            lines[j:j] = [f"*Version: {version}*", ""]
+            break
+    return "\n".join(lines)
+
+
 def copy_component_files(*, from_tags: bool) -> None:
     """Copy component documentation to the site directory.
 
@@ -226,9 +239,11 @@ def copy_component_files(*, from_tags: bool) -> None:
             tag = latest_tag(prefix)
             if tag is None:
                 raise SystemExit(f"Error: no release tag found for {component} ({prefix}*)")
+            version = tag[len(prefix) :]
             print(f"  {component}: {tag}")
             for repo_rel, dest in entries:
                 content = git_show(tag, repo_rel)
+                content = _inject_version_badge(content, version)
                 dest.parent.mkdir(parents=True, exist_ok=True)
                 dest.write_text(content, encoding="utf-8")
         else:

--- a/scripts/prepare_gitbook_site.py
+++ b/scripts/prepare_gitbook_site.py
@@ -239,7 +239,7 @@ def copy_component_files(*, from_tags: bool) -> None:
             tag = latest_tag(prefix)
             if tag is None:
                 raise SystemExit(f"Error: no release tag found for {component} ({prefix}*)")
-            version = tag[len(prefix) :]
+            version = tag[len(component) + 1 :]
             print(f"  {component}: {tag}")
             for repo_rel, dest in entries:
                 try:

--- a/scripts/prepare_gitbook_site.py
+++ b/scripts/prepare_gitbook_site.py
@@ -242,14 +242,22 @@ def copy_component_files(*, from_tags: bool) -> None:
             version = tag[len(prefix) :]
             print(f"  {component}: {tag}")
             for repo_rel, dest in entries:
-                content = git_show(tag, repo_rel)
+                try:
+                    content = git_show(tag, repo_rel)
+                except subprocess.CalledProcessError:
+                    print(f"    warning: {repo_rel} not found at {tag}, skipping")
+                    continue
                 content = _inject_version_badge(content, version)
                 dest.parent.mkdir(parents=True, exist_ok=True)
                 dest.write_text(content, encoding="utf-8")
         else:
             for repo_rel, dest in entries:
+                src = REPO_ROOT / repo_rel
+                if not src.exists():
+                    print(f"    warning: {repo_rel} not found in working tree, skipping")
+                    continue
                 dest.parent.mkdir(parents=True, exist_ok=True)
-                shutil.copy2(REPO_ROOT / repo_rel, dest)
+                shutil.copy2(src, dest)
 
 
 def parse_args() -> argparse.Namespace:

--- a/scripts/test_prepare_gitbook_site.py
+++ b/scripts/test_prepare_gitbook_site.py
@@ -1,0 +1,38 @@
+"""Tests for prepare_gitbook_site helpers."""
+
+from __future__ import annotations
+
+from prepare_gitbook_site import _inject_version_badge
+
+
+class TestInjectVersionBadge:
+    def test_inserts_after_heading_with_blank_line(self) -> None:
+        content = "# Title\n\nBody text"
+        result = _inject_version_badge(content, "1.2.3")
+        assert result == "# Title\n\n*Version: 1.2.3*\n\nBody text"
+
+    def test_inserts_after_heading_without_blank_line(self) -> None:
+        content = "# Title\nBody text"
+        result = _inject_version_badge(content, "1.2.3")
+        assert result == "# Title\n*Version: 1.2.3*\n\nBody text"
+
+    def test_no_heading_returns_unchanged(self) -> None:
+        content = "No heading here"
+        result = _inject_version_badge(content, "1.0.0")
+        assert result == content
+
+    def test_only_first_heading_is_modified(self) -> None:
+        content = "# First\n\nText\n\n# Second\n\nMore text"
+        result = _inject_version_badge(content, "2.0.0")
+        assert result.count("*Version:") == 1
+        assert result.startswith("# First\n\n*Version: 2.0.0*\n\nText")
+
+    def test_heading_only_content(self) -> None:
+        content = "# Title"
+        result = _inject_version_badge(content, "0.1.0")
+        assert result == "# Title\n*Version: 0.1.0*\n"
+
+    def test_h2_not_treated_as_top_level(self) -> None:
+        content = "## Subtitle\n\nBody"
+        result = _inject_version_badge(content, "1.0.0")
+        assert result == content

--- a/scripts/test_prepare_gitbook_site.py
+++ b/scripts/test_prepare_gitbook_site.py
@@ -36,3 +36,9 @@ class TestInjectVersionBadge:
         content = "## Subtitle\n\nBody"
         result = _inject_version_badge(content, "1.0.0")
         assert result == content
+
+    def test_heading_inside_code_fence_is_skipped(self) -> None:
+        content = "```\n# Not a heading\n```\n\n# Real heading\n\nBody"
+        result = _inject_version_badge(content, "1.0.0")
+        assert "*Version: 1.0.0*" in result
+        assert result.index("*Version: 1.0.0*") > result.index("# Real heading")


### PR DESCRIPTION
## Summary
- Add `_inject_version_badge` helper that inserts a `*Version: X.Y.Z*`
  line after the first `# ` heading in each component markdown file
- Apply the badge in `copy_component_files` when `--from-tags` is used;
  no-op in working-tree mode
- Skip missing component files with a warning instead of crashing the
  build (e.g. plugin README not yet present at the latest plugin tag)
- Add unit tests for `_inject_version_badge`

Closes #437

## Test plan
- [ ] Run `python scripts/prepare_gitbook_site.py --from-tags` and verify
  version lines appear in `site/cli/README.md`, `site/sdk/*/README.md`,
  `site/server/README.md`
- [ ] Run without `--from-tags` and confirm no version lines are injected
- [ ] Verify missing files produce a warning, not a crash
- [ ] `cd scripts && uvx pytest test_prepare_gitbook_site.py -v`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Component documentation pages now include version information badges, automatically injected when building the site from release tags to make it easier to verify the correct release version.
  * Documentation extraction now safely skips component files that are missing at a given release tag, while issuing a warning.
* **Tests**
  * Added coverage to ensure version badges are inserted correctly after the first top-level heading and never for non-top-level headings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->