### PR TITLE
feat(cli): add Copilot host to cq install

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -168,6 +168,7 @@ func runInstallCmd(cmd *cobra.Command, f *installFlags) error {
 			return fmt.Errorf("host %s does not support project installs", h.Name())
 		}
 		ctx := install.Context{
+			Home:       home,
 			Target:     h.GlobalTarget(home),
 			SkillsDir:  install.SharedSkillsDir(home),
 			BinaryPath: binary,

--- a/cli/install_test.go
+++ b/cli/install_test.go
@@ -21,15 +21,47 @@ func runInstall(t *testing.T, args ...string) (string, error) {
 	return out.String(), err
 }
 
+// setTestHome sets both HOME (Unix) and USERPROFILE (Windows) so
+// os.UserHomeDir() resolves to the temp dir on all platforms.
+func setTestHome(t *testing.T, home string) {
+	t.Helper()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+}
+
 func TestInstallRequiresAHost(t *testing.T) {
 	_, err := runInstall(t)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "select at least one --target")
 }
 
+func TestInstallCopilotEndToEnd(t *testing.T) {
+	home := t.TempDir()
+	setTestHome(t, home)
+	bin := filepath.Join(t.TempDir(), "cq")
+	t.Setenv("CQ_INSTALL_BINARY", bin)
+
+	out, err := runInstall(t, "--target", "copilot")
+	require.NoError(t, err)
+	require.Contains(t, out, "[copilot]")
+
+	require.FileExists(t, filepath.Join(home, ".agents", "skills", "cq", "SKILL.md"))
+	require.FileExists(t, filepath.Join(home, ".copilot", "instructions", "cq.md"))
+
+	// Re-run is idempotent.
+	_, err = runInstall(t, "--target", "copilot")
+	require.NoError(t, err)
+
+	// Uninstall reverses instruction but keeps shared skill.
+	_, err = runInstall(t, "--target", "copilot", "--uninstall")
+	require.NoError(t, err)
+	require.NoFileExists(t, filepath.Join(home, ".copilot", "instructions", "cq.md"))
+	require.FileExists(t, filepath.Join(home, ".agents", "skills", "cq", "SKILL.md"))
+}
+
 func TestInstallClaudeDryRun(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setTestHome(t, home)
 	bin := filepath.Join(t.TempDir(), "cq")
 	t.Setenv("CQ_INSTALL_BINARY", bin)
 
@@ -41,7 +73,7 @@ func TestInstallClaudeDryRun(t *testing.T) {
 
 func TestInstallCursorEndToEnd(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setTestHome(t, home)
 	bin := filepath.Join(t.TempDir(), "cq")
 	t.Setenv("CQ_INSTALL_BINARY", bin)
 
@@ -63,7 +95,7 @@ func TestInstallCursorEndToEnd(t *testing.T) {
 
 func TestInstallPiEndToEnd(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setTestHome(t, home)
 	bin := filepath.Join(t.TempDir(), "cq")
 	t.Setenv("CQ_INSTALL_BINARY", bin)
 
@@ -96,7 +128,7 @@ func TestInstallPiEndToEnd(t *testing.T) {
 
 func TestInstallOpencodeEndToEnd(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setTestHome(t, home)
 	t.Setenv("OPENCODE_CONFIG_DIR", "")
 	bin := filepath.Join(t.TempDir(), "cq")
 	t.Setenv("CQ_INSTALL_BINARY", bin)
@@ -142,7 +174,7 @@ func TestInstallOpencodeEndToEnd(t *testing.T) {
 
 func TestInstallWindsurfEndToEnd(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setTestHome(t, home)
 	bin := filepath.Join(t.TempDir(), "cq")
 	t.Setenv("CQ_INSTALL_BINARY", bin)
 

--- a/cli/internal/install/copilot.go
+++ b/cli/internal/install/copilot.go
@@ -1,0 +1,110 @@
+package install
+
+import (
+	"path/filepath"
+
+	"github.com/mozilla-ai/cq/sdk/go/prompts"
+)
+
+const (
+	// copilotInstruction is the global instruction file content telling Copilot
+	// to load the cq skill before starting work.
+	copilotInstruction = "Before starting any implementation task, load the `cq` skill and follow its Core Protocol.\n"
+
+	// copilotInstructionFile is the cq instruction file written into the
+	// global Copilot instructions directory.
+	copilotInstructionFile = "cq.md"
+
+	// copilotInstructionsDir is the user-level directory Copilot reads for
+	// global custom instructions.
+	copilotInstructionsDir = ".copilot/instructions"
+
+	// copilotMCPFile is the MCP configuration file VSCode reads.
+	copilotMCPFile = "mcp.json"
+)
+
+// copilotHost installs cq into GitHub Copilot in VSCode: the shared skill,
+// the MCP server entry, and a global instruction file.
+//
+// Copilot reads MCP config from <vscode-user-dir>/mcp.json with a top-level
+// "servers" key (not "mcpServers").
+// Skills are read from ~/.agents/skills/ (the shared commons).
+// Global instructions are read from ~/.copilot/instructions/.
+//
+// NOTE: targets the default VSCode profile only.
+// Users with custom profiles or VSCode Insiders need to configure manually.
+type copilotHost struct{}
+
+// GlobalTarget returns the VSCode user config directory under home.
+func (copilotHost) GlobalTarget(home string) string {
+	return copilotTarget(home)
+}
+
+// Install writes the shared skill, the cq MCP server entry, and the global
+// instruction file.
+func (copilotHost) Install(ctx Context) ([]Change, error) {
+	skill, err := writeManagedFiles(ctx.SkillsDir, map[string]string{
+		filepath.Join("cq", "SKILL.md"): prompts.Skill(),
+	}, ctx.DryRun)
+	if err != nil {
+		return nil, err
+	}
+
+	mcp, err := upsertJSONEntry(
+		filepath.Join(ctx.Target, copilotMCPFile),
+		[]string{"servers", "cq"},
+		map[string]any{
+			"type":    "stdio",
+			"command": ctx.BinaryPath,
+			"args":    []any{"mcp"},
+		},
+		ctx.DryRun,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	instruction, err := writeIfMissing(
+		filepath.Join(ctx.Home, copilotInstructionsDir, copilotInstructionFile),
+		copilotInstruction,
+		ctx.DryRun,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return []Change{skill, mcp, instruction}, nil
+}
+
+// Name returns the host identifier.
+func (copilotHost) Name() Target { return TargetCopilot }
+
+// SupportsProject reports that Copilot is global-only in this phase.
+func (copilotHost) SupportsProject() bool { return false }
+
+// Uninstall removes the cq MCP entry and the instruction file (when
+// unmodified).
+//
+// NOTE: the skill lives in the shared commons (~/.agents/skills), which other
+// hosts may also use, so it is intentionally left in place.
+func (copilotHost) Uninstall(ctx Context) ([]Change, error) {
+	mcp, err := removeJSONEntry(
+		filepath.Join(ctx.Target, copilotMCPFile),
+		[]string{"servers", "cq"},
+		ctx.DryRun,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	instruction, err := removeOwnedFile(
+		filepath.Join(ctx.Home, copilotInstructionsDir, copilotInstructionFile),
+		sha256Hex(copilotInstruction),
+		ctx.DryRun,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return []Change{mcp, instruction}, nil
+}

--- a/cli/internal/install/copilot_test.go
+++ b/cli/internal/install/copilot_test.go
@@ -1,0 +1,107 @@
+package install
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mozilla-ai/cq/sdk/go/prompts"
+)
+
+func copilotCtx(t *testing.T) Context {
+	t.Helper()
+	root := t.TempDir()
+	return Context{
+		Home:       root,
+		Target:     copilotTarget(root),
+		SkillsDir:  SharedSkillsDir(root),
+		BinaryPath: filepath.Join(root, "bin", "cq"),
+	}
+}
+
+func TestCopilotInstallWritesAllAssets(t *testing.T) {
+	ctx := copilotCtx(t)
+	changes, err := copilotHost{}.Install(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, changes)
+
+	// Shared skill.
+	skill, err := os.ReadFile(filepath.Join(ctx.SkillsDir, "cq", "SKILL.md"))
+	require.NoError(t, err)
+	require.Equal(t, prompts.Skill(), string(skill))
+
+	// MCP entry uses servers key, type:stdio, and array args.
+	config := readJSON(t, filepath.Join(ctx.Target, "mcp.json"))
+	servers := config["servers"].(map[string]any)
+	cq := servers["cq"].(map[string]any)
+	require.Equal(t, "stdio", cq["type"])
+	require.Equal(t, ctx.BinaryPath, cq["command"])
+	require.Equal(t, []any{"mcp"}, cq["args"])
+
+	// Global instruction file matches the managed content exactly.
+	instruction, err := os.ReadFile(filepath.Join(ctx.Home, ".copilot", "instructions", "cq.md"))
+	require.NoError(t, err)
+	require.Equal(t, copilotInstruction, string(instruction))
+}
+
+func TestCopilotInstallIsIdempotent(t *testing.T) {
+	ctx := copilotCtx(t)
+	_, err := copilotHost{}.Install(ctx)
+	require.NoError(t, err)
+	changes, err := copilotHost{}.Install(ctx)
+	require.NoError(t, err)
+	for _, c := range changes {
+		require.NotEqual(t, ActionCreated, c.Action)
+	}
+}
+
+func TestCopilotUninstallReversesButKeepsSharedSkill(t *testing.T) {
+	ctx := copilotCtx(t)
+	_, err := copilotHost{}.Install(ctx)
+	require.NoError(t, err)
+	_, err = copilotHost{}.Uninstall(ctx)
+	require.NoError(t, err)
+
+	// MCP entry gone.
+	config := readJSON(t, filepath.Join(ctx.Target, "mcp.json"))
+	require.NotContains(t, config, "servers")
+	// Instruction file gone.
+	require.NoFileExists(t, filepath.Join(ctx.Home, ".copilot", "instructions", "cq.md"))
+	// Shared skill REMAINS (it is the cross-host commons).
+	require.FileExists(t, filepath.Join(ctx.SkillsDir, "cq", "SKILL.md"))
+}
+
+func TestCopilotUninstallLeavesUserModifiedInstruction(t *testing.T) {
+	ctx := copilotCtx(t)
+	_, err := copilotHost{}.Install(ctx)
+	require.NoError(t, err)
+	instructionPath := filepath.Join(ctx.Home, ".copilot", "instructions", "cq.md")
+	require.NoError(t, os.WriteFile(instructionPath, []byte("user edited\n"), 0o644))
+
+	_, err = copilotHost{}.Uninstall(ctx)
+	require.NoError(t, err)
+	require.FileExists(t, instructionPath)
+}
+
+func TestCopilotRegisteredAndProject(t *testing.T) {
+	h, ok := hosts[TargetCopilot]
+	require.True(t, ok)
+	require.Equal(t, TargetCopilot, h.Name())
+	require.False(t, h.SupportsProject())
+}
+
+func TestCopilotTargetPath(t *testing.T) {
+	home := "/home/dev"
+	got := copilotTarget(home)
+	switch runtime.GOOS {
+	case "darwin":
+		require.Equal(t, filepath.Join(home, "Library", "Application Support", "Code", "User"), got)
+	case "windows":
+		require.Equal(t, filepath.Join(home, "AppData", "Roaming", "Code", "User"), got)
+	default:
+		require.Equal(t, filepath.Join(home, ".config", "Code", "User"), got)
+	}
+}

--- a/cli/internal/install/paths.go
+++ b/cli/internal/install/paths.go
@@ -3,6 +3,7 @@ package install
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 )
 
 // opencodeConfigDirEnv overrides the default OpenCode config directory.
@@ -17,6 +18,27 @@ const opencodeConfigDirEnv = "OPENCODE_CONFIG_DIR"
 // written once per scope rather than copied per host.
 func SharedSkillsDir(root string) string {
 	return filepath.Join(root, ".agents", "skills")
+}
+
+// copilotTarget returns the VSCode user configuration directory.
+//
+// VSCode stores user-level config under a platform-specific directory:
+//   - macOS:   ~/Library/Application Support/Code/User
+//   - Linux:   ~/.config/Code/User
+//   - Windows: ~/AppData/Roaming/Code/User
+//
+// NOTE: targets the default VSCode profile only.
+// Custom profiles store config in a profiles/<id>/ subdirectory; VSCode
+// Insiders uses "Code - Insiders" instead of "Code".
+func copilotTarget(home string) string {
+	switch runtime.GOOS {
+	case "darwin":
+		return filepath.Join(home, "Library", "Application Support", "Code", "User")
+	case "windows":
+		return filepath.Join(home, "AppData", "Roaming", "Code", "User")
+	default:
+		return filepath.Join(home, ".config", "Code", "User")
+	}
 }
 
 // cursorTarget returns the Cursor configuration directory under home.

--- a/cli/internal/install/registry.go
+++ b/cli/internal/install/registry.go
@@ -10,6 +10,9 @@ const (
 	// TargetClaude is Claude Code via the plugin marketplace.
 	TargetClaude Target = "claude"
 
+	// TargetCopilot is GitHub Copilot in VSCode.
+	TargetCopilot Target = "copilot"
+
 	// TargetCursor is the Cursor editor.
 	TargetCursor Target = "cursor"
 
@@ -29,6 +32,7 @@ const (
 // an entry extends ValidTarget, AllowedTargets, and SelectHosts.
 var hosts = map[Target]Host{
 	TargetClaude:   claudeHost{},
+	TargetCopilot:  copilotHost{},
 	TargetCursor:   cursorHost{},
 	TargetOpenCode: opencodeHost{},
 	TargetPi:       piHost{},

--- a/cli/internal/install/types.go
+++ b/cli/internal/install/types.go
@@ -48,25 +48,27 @@ type CLIVerb struct {
 
 // Context carries the resolved per-host paths for one install or uninstall.
 type Context struct {
-	// Target is the host's configuration directory.
-	Target string
-
-	// SkillsDir is the shared skills commons the skill is written into.
-	SkillsDir string
-
 	// BinaryPath is the absolute cq binary path written into host config.
 	BinaryPath string
-
-	// DryRun reports the planned changes without writing.
-	DryRun bool
 
 	// CLIVerbs lists the cq CLI verbs and their argument templates.
 	//
 	// Populated by the install command from the cobra command definitions;
 	// consumed by hosts that embed CLI instructions (e.g. Pi) instead of MCP
 	// config.
-	// Nil for MCP-capable hosts.
 	CLIVerbs []CLIVerb
+
+	// DryRun reports the planned changes without writing.
+	DryRun bool
+
+	// Home is the user's home directory.
+	Home string
+
+	// SkillsDir is the shared skills commons the skill is written into.
+	SkillsDir string
+
+	// Target is the host's configuration directory.
+	Target string
 }
 
 // Host installs and removes cq for one agent host.


### PR DESCRIPTION
## Summary

- Add Copilot host adapter to `cq install --target copilot`, writing three assets:
  - Shared skill to `~/.agents/skills/cq/SKILL.md` (VSCode reads this at user level)
  - MCP entry to user-level `mcp.json` (`servers.cq` with `type: stdio`)
  - Global instruction file to `~/.copilot/instructions/cq.md`
- VSCode reads skills from `~/.agents/skills/` and instructions from `~/.copilot/instructions/` globally, so all three assets work across workspaces without `--project`.
- The instruction file uses `writeIfMissing`/`removeOwnedFile` (hash-guarded) so user edits are never overwritten or deleted.
- Add `Home` field to `Context` so adapters can write to paths outside their `Target` directory.

### Known limitations

- Targets the default VSCode profile only; custom profiles store config in a `profiles/<id>/` subdirectory.
- Does not support VSCode Insiders (uses `Code` directory, not `Code - Insiders`).

## Test plan

- [x] Unit tests for install (skill, MCP entry with servers/stdio, instruction file), idempotency, uninstall reversal (shared skill survives, user-modified instruction preserved), registry, path resolution
- [x] E2E test covering install → idempotent re-run → uninstall round-trip
- [x] `make lint` and `make test` pass from repo root
- [x] Pragma validators: go-effective, go-proverbs, security, state-machine, error-handling — all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Copilot as a supported installation target, enabling users to install and uninstall Copilot integration using the install command, with correct support for macOS, Windows, and Linux.
  * Copilot setup now creates the required Copilot instruction and MCP configuration, while preserving the shared skill across uninstall.
* **Tests**
  * Added unit and end-to-end coverage for Copilot install/uninstall, including idempotency and safe handling of user-modified instructions.
  * Updated tests to use consistent home-directory handling across platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->