### PR TITLE
feat(cli): add Codex host to cq install

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -116,6 +116,38 @@ make uninstall-pi PROJECT=/path/to/your/project
 
 To verify, run `/cq-status` in a Pi session (note: `/cq-status`, not `/cq:status`, and there is no MCP approval prompt — cq runs as a CLI). The agent runs `cq status --format json` and renders the summary.
 
+### Copilot (VSCode)
+
+Copilot is installed via the Go CLI binary (not the Python Make targets):
+
+```bash
+cq install --target copilot
+```
+
+This writes the shared skill, the MCP server entry to VSCode's user-level `mcp.json`, and a global instruction file to `~/.copilot/instructions/cq.md`.
+
+To uninstall:
+
+```bash
+cq install --target copilot --uninstall
+```
+
+### Codex (OpenAI)
+
+Codex is installed via the Go CLI binary (not the Python Make targets):
+
+```bash
+cq install --target codex
+```
+
+This writes the shared skill, the `[mcp_servers.cq]` entry to `~/.codex/config.toml`, and a cq block in `~/.codex/AGENTS.md`.
+
+To uninstall:
+
+```bash
+cq install --target codex --uninstall
+```
+
 ### Go SDK
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -44,12 +44,15 @@ cd cq
 
 Run `make setup-plugin` before running the relevant `Makefile` target:
 
-| Agent    | Install                 |
-|----------|-------------------------|
-| OpenCode | `make install-opencode` |
-| Cursor   | `make install-cursor`   |
-| Windsurf | `make install-windsurf` |
-| Pi       | `make install-pi`       |
+| Agent    | Install                           |
+|----------|-----------------------------------|
+| Claude   | `make install-claude`             |
+| Codex    | `cq install --target codex`      |
+| Copilot  | `cq install --target copilot`    |
+| Cursor   | `make install-cursor`             |
+| OpenCode | `make install-opencode`           |
+| Pi       | `make install-pi`                 |
+| Windsurf | `make install-windsurf`           |
 
 For Windows, project-specific installs, and uninstall instructions, see [DEVELOPMENT.md](DEVELOPMENT.md).
 

--- a/cli/NOTICE
+++ b/cli/NOTICE
@@ -4,6 +4,34 @@ Copyright 2026 Mozilla AI
 This product includes the following third-party software.
 
 ================================================================================
+github.com/BurntSushi/toml v1.6.0
+License: MIT
+================================================================================
+
+The MIT License (MIT)
+
+Copyright (c) 2013 TOML authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+================================================================================
 github.com/dustin/go-humanize v1.0.1
 License: MIT
 ================================================================================

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -3,6 +3,7 @@ module github.com/mozilla-ai/cq/cli
 go 1.26.1
 
 require (
+	github.com/BurntSushi/toml v1.6.0
 	github.com/mark3labs/mcp-go v0.46.0
 	github.com/mozilla-ai/cq/sdk/go v0.11.0
 	github.com/spf13/cobra v1.10.2

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
+github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/danieljoos/wincred v1.2.3 h1:v7dZC2x32Ut3nEfRH+vhoZGvN72+dQ/snVXo/vMFLdQ=
 github.com/danieljoos/wincred v1.2.3/go.mod h1:6qqX0WNrS4RzPZ1tnroDzq9kY3fu1KwE7MRLQK4X0bs=

--- a/cli/install_test.go
+++ b/cli/install_test.go
@@ -35,6 +35,40 @@ func TestInstallRequiresAHost(t *testing.T) {
 	require.Contains(t, err.Error(), "select at least one --target")
 }
 
+func TestInstallCodexEndToEnd(t *testing.T) {
+	home := t.TempDir()
+	setTestHome(t, home)
+	bin := filepath.Join(t.TempDir(), "cq")
+	t.Setenv("CQ_INSTALL_BINARY", bin)
+
+	out, err := runInstall(t, "--target", "codex")
+	require.NoError(t, err)
+	require.Contains(t, out, "[codex]")
+
+	require.FileExists(t, filepath.Join(home, ".agents", "skills", "cq", "SKILL.md"))
+	require.FileExists(t, filepath.Join(home, ".codex", "config.toml"))
+	require.FileExists(t, filepath.Join(home, ".codex", "AGENTS.md"))
+
+	// Config contains the MCP server entry.
+	config, err := os.ReadFile(filepath.Join(home, ".codex", "config.toml"))
+	require.NoError(t, err)
+	require.Contains(t, string(config), "[mcp_servers.cq]")
+	require.Contains(t, string(config), bin)
+
+	// Re-run is idempotent.
+	_, err = runInstall(t, "--target", "codex")
+	require.NoError(t, err)
+
+	// Uninstall reverses MCP and AGENTS.md but keeps shared skill.
+	_, err = runInstall(t, "--target", "codex", "--uninstall")
+	require.NoError(t, err)
+	configAfter, err := os.ReadFile(filepath.Join(home, ".codex", "config.toml"))
+	require.NoError(t, err)
+	require.NotContains(t, string(configAfter), "mcp_servers")
+	require.NoFileExists(t, filepath.Join(home, ".codex", "AGENTS.md"))
+	require.FileExists(t, filepath.Join(home, ".agents", "skills", "cq", "SKILL.md"))
+}
+
 func TestInstallCopilotEndToEnd(t *testing.T) {
 	home := t.TempDir()
 	setTestHome(t, home)

--- a/cli/internal/install/codex.go
+++ b/cli/internal/install/codex.go
@@ -1,0 +1,100 @@
+package install
+
+import (
+	"path/filepath"
+
+	"github.com/mozilla-ai/cq/sdk/go/prompts"
+)
+
+const (
+	// codexAgentsFile is the always-loaded instruction file for Codex.
+	codexAgentsFile = "AGENTS.md"
+
+	// codexConfigFile is the TOML configuration file Codex reads.
+	codexConfigFile = "config.toml"
+
+	// codexMCPSection is the dotted TOML key path for the cq MCP server entry.
+	codexMCPSection = "mcp_servers.cq"
+)
+
+// codexAgentsBlock is the delimited block written into AGENTS.md.
+var codexAgentsBlock = cqBlock.start + "\n## CQ\n\nBefore starting any implementation task, load the `cq` skill and follow its Core Protocol.\n" + cqBlock.end
+
+// codexHost installs cq into the OpenAI Codex CLI: the shared skill, the MCP
+// server entry in config.toml, and an AGENTS.md instruction block.
+//
+// Codex reads config from ~/.codex/config.toml (TOML format) and instructions
+// from ~/.codex/AGENTS.md.
+type codexHost struct{}
+
+// GlobalTarget returns the Codex config directory under home.
+func (codexHost) GlobalTarget(home string) string {
+	return codexTarget(home)
+}
+
+// Install writes the shared skill, the MCP entry, and the AGENTS.md block.
+func (codexHost) Install(ctx Context) ([]Change, error) {
+	skill, err := writeManagedFiles(ctx.SkillsDir, map[string]string{
+		filepath.Join("cq", "SKILL.md"): prompts.Skill(),
+	}, ctx.DryRun)
+	if err != nil {
+		return nil, err
+	}
+
+	mcp, err := upsertTOMLSection(
+		filepath.Join(ctx.Target, codexConfigFile),
+		codexMCPSection,
+		map[string]any{
+			"command": ctx.BinaryPath,
+			"args":    []any{"mcp"},
+		},
+		ctx.DryRun,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	agents, err := upsertMarkdownBlock(
+		filepath.Join(ctx.Target, codexAgentsFile),
+		cqBlock,
+		codexAgentsBlock,
+		ctx.DryRun,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return []Change{skill, mcp, agents}, nil
+}
+
+// Name returns the host identifier.
+func (codexHost) Name() Target { return TargetCodex }
+
+// SupportsProject reports that Codex is global-only in this phase.
+func (codexHost) SupportsProject() bool { return false }
+
+// Uninstall removes the MCP entry and the AGENTS.md block.
+//
+// NOTE: the skill lives in the shared commons (~/.agents/skills), which other
+// hosts may also use, so it is intentionally left in place.
+func (codexHost) Uninstall(ctx Context) ([]Change, error) {
+	mcp, err := removeTOMLSection(
+		filepath.Join(ctx.Target, codexConfigFile),
+		codexMCPSection,
+		ctx.DryRun,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	agents, err := removeMarkdownBlock(
+		filepath.Join(ctx.Target, codexAgentsFile),
+		cqBlock,
+		ctx.DryRun,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return []Change{mcp, agents}, nil
+}

--- a/cli/internal/install/codex_test.go
+++ b/cli/internal/install/codex_test.go
@@ -1,0 +1,86 @@
+package install
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mozilla-ai/cq/sdk/go/prompts"
+)
+
+func codexCtx(t *testing.T) Context {
+	t.Helper()
+	root := t.TempDir()
+	return Context{
+		BinaryPath: filepath.Join(root, "bin", "cq"),
+		Home:       root,
+		SkillsDir:  SharedSkillsDir(root),
+		Target:     filepath.Join(root, ".codex"),
+	}
+}
+
+func TestCodexInstallWritesAllAssets(t *testing.T) {
+	ctx := codexCtx(t)
+	changes, err := codexHost{}.Install(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, changes)
+
+	// Shared skill.
+	skill, err := os.ReadFile(filepath.Join(ctx.SkillsDir, "cq", "SKILL.md"))
+	require.NoError(t, err)
+	require.Equal(t, prompts.Skill(), string(skill))
+
+	// MCP entry in TOML config.
+	config, err := os.ReadFile(filepath.Join(ctx.Target, "config.toml"))
+	require.NoError(t, err)
+	require.Contains(t, string(config), "[mcp_servers.cq]")
+	require.Contains(t, string(config), ctx.BinaryPath)
+
+	// AGENTS.md block.
+	agents, err := os.ReadFile(filepath.Join(ctx.Target, "AGENTS.md"))
+	require.NoError(t, err)
+	require.Contains(t, string(agents), cqBlock.start)
+	require.Contains(t, string(agents), cqBlock.end)
+	require.Contains(t, string(agents), "Core Protocol")
+}
+
+func TestCodexInstallIsIdempotent(t *testing.T) {
+	ctx := codexCtx(t)
+	_, err := codexHost{}.Install(ctx)
+	require.NoError(t, err)
+	changes, err := codexHost{}.Install(ctx)
+	require.NoError(t, err)
+	for _, c := range changes {
+		require.NotEqual(t, ActionCreated, c.Action)
+	}
+}
+
+func TestCodexUninstallReversesButKeepsSharedSkill(t *testing.T) {
+	ctx := codexCtx(t)
+	_, err := codexHost{}.Install(ctx)
+	require.NoError(t, err)
+	_, err = codexHost{}.Uninstall(ctx)
+	require.NoError(t, err)
+
+	// MCP entry gone.
+	config, err := os.ReadFile(filepath.Join(ctx.Target, "config.toml"))
+	require.NoError(t, err)
+	require.NotContains(t, string(config), "mcp_servers")
+	// AGENTS.md gone (file deleted when only our block).
+	require.NoFileExists(t, filepath.Join(ctx.Target, "AGENTS.md"))
+	// Shared skill REMAINS.
+	require.FileExists(t, filepath.Join(ctx.SkillsDir, "cq", "SKILL.md"))
+}
+
+func TestCodexRegisteredAndProject(t *testing.T) {
+	h, ok := hosts[TargetCodex]
+	require.True(t, ok)
+	require.Equal(t, TargetCodex, h.Name())
+	require.False(t, h.SupportsProject())
+}
+
+func TestCodexTargetPath(t *testing.T) {
+	require.Equal(t, filepath.Join("/home/dev", ".codex"), codexTarget("/home/dev"))
+}

--- a/cli/internal/install/paths.go
+++ b/cli/internal/install/paths.go
@@ -20,6 +20,11 @@ func SharedSkillsDir(root string) string {
 	return filepath.Join(root, ".agents", "skills")
 }
 
+// codexTarget returns the Codex configuration directory under home.
+func codexTarget(home string) string {
+	return filepath.Join(home, ".codex")
+}
+
 // copilotTarget returns the VSCode user configuration directory.
 //
 // VSCode stores user-level config under a platform-specific directory:

--- a/cli/internal/install/registry.go
+++ b/cli/internal/install/registry.go
@@ -10,6 +10,9 @@ const (
 	// TargetClaude is Claude Code via the plugin marketplace.
 	TargetClaude Target = "claude"
 
+	// TargetCodex is the OpenAI Codex CLI.
+	TargetCodex Target = "codex"
+
 	// TargetCopilot is GitHub Copilot in VSCode.
 	TargetCopilot Target = "copilot"
 
@@ -32,6 +35,7 @@ const (
 // an entry extends ValidTarget, AllowedTargets, and SelectHosts.
 var hosts = map[Target]Host{
 	TargetClaude:   claudeHost{},
+	TargetCodex:    codexHost{},
 	TargetCopilot:  copilotHost{},
 	TargetCursor:   cursorHost{},
 	TargetOpenCode: opencodeHost{},

--- a/cli/internal/install/toml.go
+++ b/cli/internal/install/toml.go
@@ -1,0 +1,181 @@
+package install
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+)
+
+// upsertTOMLSection sets the values at a dotted key path in a TOML file,
+// creating intermediate tables as needed and preserving sibling keys.
+//
+// Returns CREATED when the section was absent, UPDATED when a value changed,
+// UNCHANGED when the section already matched.
+// Returns an error when an intermediate or leaf key exists as a non-table value
+// (the installer must not silently overwrite user-authored config).
+func upsertTOMLSection(file string, section string, desired map[string]any, dryRun bool) (Change, error) {
+	if err := validateTOMLSection(section); err != nil {
+		return Change{}, err
+	}
+
+	root, err := loadTOML(file)
+	if err != nil {
+		return Change{}, err
+	}
+
+	keys := strings.Split(section, ".")
+	parent := root
+	for _, key := range keys[:len(keys)-1] {
+		raw, present := parent[key]
+		if !present {
+			child := map[string]any{}
+			parent[key] = child
+			parent = child
+			continue
+		}
+		child, ok := raw.(map[string]any)
+		if !ok {
+			return Change{}, fmt.Errorf("config key %q is not a table", key)
+		}
+		parent = child
+	}
+
+	leaf := keys[len(keys)-1]
+	raw, present := parent[leaf]
+	if present {
+		existing, ok := raw.(map[string]any)
+		if !ok {
+			return Change{}, fmt.Errorf("config key %q is not a table", leaf)
+		}
+		if reflect.DeepEqual(existing, desired) {
+			return Change{Action: ActionUnchanged, Path: file}, nil
+		}
+	}
+
+	parent[leaf] = desired
+	if dryRun {
+		return Change{Action: upsertAction(present), Path: file}, nil
+	}
+	if err := writeTOML(file, root); err != nil {
+		return Change{}, err
+	}
+	return Change{Action: upsertAction(present), Path: file}, nil
+}
+
+// removeTOMLSection deletes the entry at a dotted key path in a TOML file,
+// pruning empty parent tables.
+//
+// Returns UNCHANGED when the file or section is absent.
+func removeTOMLSection(file string, section string, dryRun bool) (Change, error) {
+	if err := validateTOMLSection(section); err != nil {
+		return Change{}, err
+	}
+
+	data, err := os.ReadFile(file)
+	if os.IsNotExist(err) {
+		return Change{Action: ActionUnchanged, Path: file}, nil
+	}
+	if err != nil {
+		return Change{}, fmt.Errorf("reading config file: %w", err)
+	}
+
+	root := map[string]any{}
+	if err := toml.Unmarshal(data, &root); err != nil {
+		return Change{}, fmt.Errorf("parsing config file: %w", err)
+	}
+
+	keys := strings.Split(section, ".")
+	tables := make([]map[string]any, 0, len(keys))
+	cursor := root
+	for _, key := range keys[:len(keys)-1] {
+		child, ok := cursor[key].(map[string]any)
+		if !ok {
+			return Change{Action: ActionUnchanged, Path: file}, nil
+		}
+		tables = append(tables, cursor)
+		cursor = child
+	}
+
+	leaf := keys[len(keys)-1]
+	if _, ok := cursor[leaf]; !ok {
+		return Change{Action: ActionUnchanged, Path: file}, nil
+	}
+
+	delete(cursor, leaf)
+
+	for i := len(tables) - 1; i >= 0; i-- {
+		key := keys[i]
+		if child, ok := tables[i][key].(map[string]any); ok && len(child) == 0 {
+			delete(tables[i], key)
+		} else {
+			break
+		}
+	}
+
+	if dryRun {
+		return Change{Action: ActionRemoved, Path: file}, nil
+	}
+	if err := writeTOML(file, root); err != nil {
+		return Change{}, err
+	}
+	return Change{Action: ActionRemoved, Path: file}, nil
+}
+
+// loadTOML reads and parses a TOML file, returning an empty map when absent.
+func loadTOML(file string) (map[string]any, error) {
+	data, err := os.ReadFile(file)
+	if os.IsNotExist(err) {
+		return map[string]any{}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading config file: %w", err)
+	}
+	root := map[string]any{}
+	if err := toml.Unmarshal(data, &root); err != nil {
+		return nil, fmt.Errorf("parsing config file: %w", err)
+	}
+	return root, nil
+}
+
+// upsertAction returns UPDATED when the key was present, CREATED when absent.
+func upsertAction(present bool) Action {
+	if present {
+		return ActionUpdated
+	}
+	return ActionCreated
+}
+
+// validateTOMLSection rejects empty or blank-segment section paths.
+func validateTOMLSection(section string) error {
+	if strings.TrimSpace(section) == "" {
+		return fmt.Errorf("config section path must not be empty")
+	}
+	for _, seg := range strings.Split(section, ".") {
+		if strings.TrimSpace(seg) == "" {
+			return fmt.Errorf("config section path contains an empty segment: %q", section)
+		}
+	}
+	return nil
+}
+
+// writeTOML encodes root to file as TOML, creating parent directories as
+// needed.
+func writeTOML(file string, root map[string]any) error {
+	var buf bytes.Buffer
+	enc := toml.NewEncoder(&buf)
+	if err := enc.Encode(root); err != nil {
+		return fmt.Errorf("encoding config file: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(file), 0o755); err != nil {
+		return fmt.Errorf("creating config directory: %w", err)
+	}
+	if err := os.WriteFile(file, buf.Bytes(), 0o644); err != nil {
+		return fmt.Errorf("writing config file: %w", err)
+	}
+	return nil
+}

--- a/cli/internal/install/toml_test.go
+++ b/cli/internal/install/toml_test.go
@@ -1,0 +1,148 @@
+package install
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpsertTOMLSectionCreatesFile(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "config.toml")
+	c, err := upsertTOMLSection(p, "mcp_servers.cq", map[string]any{
+		"command": "/bin/cq",
+		"args":    []any{"mcp"},
+	}, false)
+	require.NoError(t, err)
+	require.Equal(t, ActionCreated, c.Action)
+
+	got, err := os.ReadFile(p)
+	require.NoError(t, err)
+	require.Contains(t, string(got), "[mcp_servers.cq]")
+	require.Contains(t, string(got), `command = "/bin/cq"`)
+	require.Contains(t, string(got), `"mcp"`)
+}
+
+func TestUpsertTOMLSectionIsIdempotent(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "config.toml")
+	entry := map[string]any{"command": "/bin/cq", "args": []any{"mcp"}}
+	_, err := upsertTOMLSection(p, "mcp_servers.cq", entry, false)
+	require.NoError(t, err)
+	c, err := upsertTOMLSection(p, "mcp_servers.cq", entry, false)
+	require.NoError(t, err)
+	require.Equal(t, ActionUnchanged, c.Action)
+}
+
+func TestUpsertTOMLSectionPreservesSiblings(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(t, os.WriteFile(p, []byte("[mcp_servers.other]\ncommand = \"other\"\n"), 0o644))
+	c, err := upsertTOMLSection(p, "mcp_servers.cq", map[string]any{
+		"command": "/bin/cq",
+		"args":    []any{"mcp"},
+	}, false)
+	require.NoError(t, err)
+	require.Equal(t, ActionCreated, c.Action)
+
+	got, err := os.ReadFile(p)
+	require.NoError(t, err)
+	require.Contains(t, string(got), "[mcp_servers.other]")
+	require.Contains(t, string(got), "[mcp_servers.cq]")
+}
+
+func TestUpsertTOMLSectionUpdatesChanged(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(t, os.WriteFile(p, []byte("[mcp_servers.cq]\ncommand = \"/old/cq\"\n"), 0o644))
+	c, err := upsertTOMLSection(p, "mcp_servers.cq", map[string]any{
+		"command": "/new/cq",
+		"args":    []any{"mcp"},
+	}, false)
+	require.NoError(t, err)
+	require.Equal(t, ActionUpdated, c.Action)
+
+	got, err := os.ReadFile(p)
+	require.NoError(t, err)
+	require.Contains(t, string(got), `command = "/new/cq"`)
+}
+
+func TestUpsertTOMLSectionDryRunWritesNothing(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "config.toml")
+	c, err := upsertTOMLSection(p, "mcp_servers.cq", map[string]any{
+		"command": "/bin/cq",
+	}, true)
+	require.NoError(t, err)
+	require.Equal(t, ActionCreated, c.Action)
+	_, statErr := os.Stat(p)
+	require.True(t, os.IsNotExist(statErr))
+}
+
+func TestRemoveTOMLSectionDeletesEntry(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(t, os.WriteFile(p, []byte("[mcp_servers.cq]\ncommand = \"/bin/cq\"\n"), 0o644))
+	c, err := removeTOMLSection(p, "mcp_servers.cq", false)
+	require.NoError(t, err)
+	require.Equal(t, ActionRemoved, c.Action)
+
+	got, err := os.ReadFile(p)
+	require.NoError(t, err)
+	require.NotContains(t, string(got), "mcp_servers")
+}
+
+func TestRemoveTOMLSectionPreservesSiblings(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(t, os.WriteFile(p, []byte(
+		"[mcp_servers.other]\ncommand = \"other\"\n\n[mcp_servers.cq]\ncommand = \"/bin/cq\"\n"), 0o644))
+	c, err := removeTOMLSection(p, "mcp_servers.cq", false)
+	require.NoError(t, err)
+	require.Equal(t, ActionRemoved, c.Action)
+
+	got, err := os.ReadFile(p)
+	require.NoError(t, err)
+	require.Contains(t, string(got), "[mcp_servers.other]")
+	require.NotContains(t, string(got), "[mcp_servers.cq]")
+}
+
+func TestRemoveTOMLSectionAbsentFileIsUnchanged(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "config.toml")
+	c, err := removeTOMLSection(p, "mcp_servers.cq", false)
+	require.NoError(t, err)
+	require.Equal(t, ActionUnchanged, c.Action)
+}
+
+func TestRemoveTOMLSectionAbsentKeyIsUnchanged(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(t, os.WriteFile(p, []byte("[other]\nkey = \"val\"\n"), 0o644))
+	c, err := removeTOMLSection(p, "mcp_servers.cq", false)
+	require.NoError(t, err)
+	require.Equal(t, ActionUnchanged, c.Action)
+}
+
+func TestUpsertTOMLSectionRejectsNonTableIntermediate(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(t, os.WriteFile(p, []byte("mcp_servers = \"not a table\"\n"), 0o644))
+	_, err := upsertTOMLSection(p, "mcp_servers.cq", map[string]any{"command": "/bin/cq"}, false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not a table")
+}
+
+func TestUpsertTOMLSectionRejectsNonTableLeaf(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(t, os.WriteFile(p, []byte("[mcp_servers]\ncq = \"not a table\"\n"), 0o644))
+	_, err := upsertTOMLSection(p, "mcp_servers.cq", map[string]any{"command": "/bin/cq"}, false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not a table")
+}
+
+func TestUpsertTOMLSectionRejectsBlankSegment(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "config.toml")
+	_, err := upsertTOMLSection(p, "a..b", map[string]any{"key": "val"}, false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "empty segment")
+}
+
+func TestRemoveTOMLSectionRejectsBlankSegment(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "config.toml")
+	_, err := removeTOMLSection(p, "", false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "must not be empty")
+}

--- a/plugins/cq/README.md
+++ b/plugins/cq/README.md
@@ -12,7 +12,7 @@ Requires: the [cq CLI](../cli/README.md).
 cq install --target claude
 ```
 
-Supported targets: `claude`, `cursor`, `opencode`, `pi`, `windsurf`. Install into multiple agents at once by repeating `--target`:
+Supported targets: `claude`, `codex`, `copilot`, `cursor`, `opencode`, `pi`, `windsurf`. Install into multiple agents at once by repeating `--target`:
 
 ```bash
 cq install --target claude --target cursor


### PR DESCRIPTION
## Summary

- Add Codex host adapter to `cq install --target codex`, writing the shared skill, a `[mcp_servers.cq]` TOML section in `~/.codex/config.toml`, and a delimited cq block in `~/.codex/AGENTS.md`.
- Introduce TOML section upsert/remove primitives (`toml.go`) using `github.com/BurntSushi/toml` for parsing and encoding.
- Uninstall reverses the MCP entry and AGENTS.md block but leaves the shared skill in the cross-host commons.

## Test plan

- [x] Unit tests for TOML primitives (create, idempotent, sibling preservation, update, dry-run, remove, absent file/key)
- [x] Unit tests for Codex adapter (all assets, idempotency, uninstall reversal, shared skill survives, registry, path)
- [x] E2E test covering install → idempotent re-run → uninstall round-trip
- [x] `make lint` and `make test` pass from repo root (including regenerated NOTICE for new dependency)
- [x] Pragma validators: go-effective, go-proverbs, security, state-machine, error-handling — all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Codex as a new installation target, including agent setup and MCP server configuration.
* **Bug Fixes**
  * Codex uninstall now removes Codex-specific entries while preserving the shared `cq` skill.
* **Tests**
  * Added end-to-end and unit tests covering install/uninstall, idempotency, TOML updates, and uninstall cleanup.
* **Documentation**
  * Updated third-party licence/attribution notices (including an additional MIT block).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->