### PR TITLE
schema: reconcile stats.json with StoreStats and guard against drift

### DIFF
--- a/schema/stats.json
+++ b/schema/stats.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://mozilla-ai.github.io/cq/schema/stats.json",
   "title": "StoreStats",
-  "description": "Aggregated knowledge-store statistics. Models the canonical StoreStats shape shared by the SDK clients and the server StatsResponse.",
+  "description": "Aggregated knowledge-store statistics. Models the canonical StoreStats shape produced by SDK clients; the server StatsResponse is a required subset (recent and warnings are SDK-only).",
   "type": "object",
   "required": [
     "total_count",

--- a/schema/stats.json
+++ b/schema/stats.json
@@ -1,10 +1,15 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://mozilla-ai.github.io/cq/schema/stats.json",
-  "title": "StatsResponse",
-  "description": "Store-level statistics.",
+  "title": "StoreStats",
+  "description": "Aggregated knowledge-store statistics. Models the canonical StoreStats shape shared by the SDK clients and the server StatsResponse.",
   "type": "object",
-  "required": ["total_count", "domain_counts"],
+  "required": [
+    "total_count",
+    "domain_counts",
+    "tier_counts",
+    "confidence_distribution"
+  ],
   "properties": {
     "total_count": {
       "type": "integer",
@@ -16,15 +21,25 @@
       "additionalProperties": { "type": "integer", "minimum": 0 },
       "description": "Count of knowledge units per domain."
     },
-    "recent": {
-      "type": "array",
-      "items": { "$ref": "knowledge_unit.json" },
-      "description": "Recently added or confirmed knowledge units."
+    "tier_counts": {
+      "type": "object",
+      "additionalProperties": { "type": "integer", "minimum": 0 },
+      "description": "Count of knowledge units per tier (local, private, public)."
     },
     "confidence_distribution": {
       "type": "object",
       "additionalProperties": { "type": "integer", "minimum": 0 },
       "description": "Count of knowledge units per confidence bucket."
+    },
+    "recent": {
+      "type": "array",
+      "items": { "$ref": "knowledge_unit.json" },
+      "description": "Recently added or confirmed knowledge units."
+    },
+    "warnings": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Non-fatal issues encountered while aggregating stats."
     }
   },
   "additionalProperties": false

--- a/sdk/go/types_test.go
+++ b/sdk/go/types_test.go
@@ -2,6 +2,8 @@ package cq
 
 import (
 	"encoding/json"
+	"errors"
+	"os"
 	"testing"
 	"time"
 
@@ -126,6 +128,50 @@ func TestKnowledgeUnitJSONSchemaFieldCoverage(t *testing.T) {
 
 	for field := range props {
 		require.Contains(t, kuMap, field, "Go KnowledgeUnit missing JSON Schema field %q", field)
+	}
+}
+
+func TestStoreStatsJSONSchemaFieldCoverage(t *testing.T) {
+	t.Parallel()
+
+	raw, err := os.ReadFile("../../schema/stats.json")
+	require.NoError(t, err)
+
+	var schema map[string]any
+	require.NoError(t, json.Unmarshal(raw, &schema))
+
+	props, ok := schema["properties"].(map[string]any)
+	require.True(t, ok)
+
+	now := time.Now().UTC()
+	stats := StoreStats{
+		TotalCount:             42,
+		DomainCounts:           map[string]int{"api": 20},
+		TierCounts:             map[Tier]int{Local: 30, Private: 10, Public: 2},
+		ConfidenceDistribution: map[string]int{"low": 5},
+		Recent: []KnowledgeUnit{{
+			ID:      "ku_0123456789abcdef0123456789abcdef",
+			Domains: []string{"test"},
+			Evidence: Evidence{
+				Confidence:    0.5,
+				FirstObserved: &now,
+			},
+		}},
+		Warnings: Warnings{errors.New("remote stats unavailable")},
+	}
+
+	data, err := json.Marshal(stats)
+	require.NoError(t, err)
+
+	var statsMap map[string]any
+	require.NoError(t, json.Unmarshal(data, &statsMap))
+
+	for field := range props {
+		require.Contains(t, statsMap, field, "Go StoreStats missing JSON Schema field %q", field)
+	}
+
+	for field := range statsMap {
+		require.Contains(t, props, field, "Go StoreStats has field %q not in stats.json", field)
 	}
 }
 

--- a/sdk/go/types_test.go
+++ b/sdk/go/types_test.go
@@ -148,7 +148,7 @@ func TestStoreStatsJSONSchemaFieldCoverage(t *testing.T) {
 		TotalCount:             42,
 		DomainCounts:           map[string]int{"api": 20},
 		TierCounts:             map[Tier]int{Local: 30, Private: 10, Public: 2},
-		ConfidenceDistribution: map[string]int{"low": 5},
+		ConfidenceDistribution: map[string]int{"0.0-0.3": 5, "0.3-0.5": 10, "0.5-0.7": 15, "0.7-1.0": 12},
 		Recent: []KnowledgeUnit{{
 			ID:      "ku_0123456789abcdef0123456789abcdef",
 			Domains: []string{"test"},

--- a/sdk/python/tests/test_schema_oracle.py
+++ b/sdk/python/tests/test_schema_oracle.py
@@ -108,7 +108,7 @@ def test_full_store_stats_validates_against_canonical_schema() -> None:
         total_count=42,
         domain_counts={"api": 20, "ci": 12, "testing": 10},
         recent=[unit],
-        confidence_distribution={"low": 5, "medium": 25, "high": 12},
+        confidence_distribution={"0.0-0.3": 5, "0.3-0.5": 10, "0.5-0.7": 15, "0.7-1.0": 12},
         tier_counts={Tier.LOCAL: 30, Tier.PRIVATE: 10, Tier.PUBLIC: 2},
         warnings=["remote stats unavailable"],
     )
@@ -134,3 +134,5 @@ def test_store_stats_field_coverage() -> None:
     model_fields = set(StoreStats.model_fields)
     missing = model_fields - schema_props
     assert not missing, f"StoreStats fields missing from stats.json: {missing}"
+    extra = schema_props - model_fields
+    assert not extra, f"stats.json properties not present in StoreStats: {extra}"

--- a/sdk/python/tests/test_schema_oracle.py
+++ b/sdk/python/tests/test_schema_oracle.py
@@ -14,6 +14,8 @@ from datetime import UTC, datetime
 import cq_schema
 import jsonschema
 import pytest
+from referencing import Registry, Resource
+from referencing.jsonschema import DRAFT202012
 
 from cq.models import (
     Context,
@@ -25,6 +27,7 @@ from cq.models import (
     Tier,
     create_knowledge_unit,
 )
+from cq.store import StoreStats
 
 
 def _make_full_unit() -> KnowledgeUnit:
@@ -82,3 +85,52 @@ def test_tiers_match_canonical_enum(tier: Tier) -> None:
     schema = cq_schema.load_schema("knowledge_unit")
     tier_def = schema["$defs"]["Tier"]
     assert tier.value in tier_def["enum"]
+
+
+def _stats_validator() -> jsonschema.Draft202012Validator:
+    """Build a validator for stats.json with the knowledge_unit $ref resolvable."""
+    stats_schema = cq_schema.load_schema("stats")
+    ku_schema = cq_schema.load_schema("knowledge_unit")
+    registry = Registry().with_resources(
+        [
+            (
+                "https://mozilla-ai.github.io/cq/schema/knowledge_unit.json",
+                Resource.from_contents(ku_schema, default_specification=DRAFT202012),
+            ),
+        ]
+    )
+    return jsonschema.Draft202012Validator(stats_schema, registry=registry)
+
+
+def test_full_store_stats_validates_against_canonical_schema() -> None:
+    unit = _make_full_unit()
+    stats = StoreStats(
+        total_count=42,
+        domain_counts={"api": 20, "ci": 12, "testing": 10},
+        recent=[unit],
+        confidence_distribution={"low": 5, "medium": 25, "high": 12},
+        tier_counts={Tier.LOCAL: 30, Tier.PRIVATE: 10, Tier.PUBLIC: 2},
+        warnings=["remote stats unavailable"],
+    )
+    payload = json.loads(stats.model_dump_json(exclude_none=True))
+    _stats_validator().validate(payload)
+
+
+def test_minimal_store_stats_validates_against_canonical_schema() -> None:
+    stats = StoreStats(
+        total_count=0,
+        domain_counts={},
+        confidence_distribution={},
+        tier_counts={},
+    )
+    payload = json.loads(stats.model_dump_json(exclude_none=True))
+    _stats_validator().validate(payload)
+
+
+def test_store_stats_field_coverage() -> None:
+    """Every StoreStats field must appear in the canonical stats schema."""
+    schema = cq_schema.load_schema("stats")
+    schema_props = set(schema["properties"])
+    model_fields = set(StoreStats.model_fields)
+    missing = model_fields - schema_props
+    assert not missing, f"StoreStats fields missing from stats.json: {missing}"


### PR DESCRIPTION
## Summary

- Add `tier_counts` and `warnings` to `stats.json` properties; promote `tier_counts` and `confidence_distribution` to `required`. This aligns the schema with the canonical `StoreStats` shape shared by both SDKs and the server `StatsResponse`.
- Add schema oracle tests to the Go and Python SDKs that validate `StoreStats` field coverage against `stats.json`, catching future drift in the same PR where it is introduced.

Fixes #410.

## Detail

`stats.json` had drifted from the types it describes: `tier_counts` (added in #404) was missing entirely, `confidence_distribution` (added in #409) was optional despite always being emitted, and `warnings` was absent. With `additionalProperties: false` (per #406), a strict validator would reject a real response.

The contract tests read the canonical `stats.json` from within the repo (Go via filesystem path, Python via editable `cq-schema` path dep) so drift is caught locally rather than after a publish cycle.

Server-side oracle tests are deferred until the next `cq-schema` package publish, since the server resolves `cq-schema` from PyPI.

## Test plan

- [x] `make lint` passes
- [x] `make test-schema` passes
- [x] `make test-sdk-python` passes (425 tests)
- [x] `make test-sdk-go` passes (with local replace for schema module)
- [x] Schema validation fixtures pass (`make -C schema validate`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stats responses now include `tier_counts` and `confidence_distribution` fields for enhanced analytics.
  * Added `warnings` field to stats data to surface relevant alerts.

* **Tests**
  * Implemented validation tests to ensure stats data consistency across SDKs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->