### PR TITLE
feat(ui): add dark mode support for server dashboard

### DIFF
--- a/server/frontend/src/App.tsx
+++ b/server/frontend/src/App.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react"
 import { BrowserRouter, Navigate, Route, Routes } from "react-router"
 import { AuthProvider, useAuth } from "./auth"
 import { Layout } from "./components/Layout"
@@ -33,11 +34,25 @@ function AppRoutes() {
   )
 }
 
+function ThemeInitializer({ children }: { children: React.ReactNode }) {
+  useEffect(() => {
+    const stored = localStorage.getItem("cq-dark-mode")
+    const dark =
+      stored !== null
+        ? stored === "true"
+        : window.matchMedia("(prefers-color-scheme: dark)").matches
+    document.documentElement.classList.toggle("dark", dark)
+  }, [])
+  return <>{children}</>
+}
+
 export default function App() {
   return (
     <BrowserRouter>
       <AuthProvider>
-        <AppRoutes />
+        <ThemeInitializer>
+          <AppRoutes />
+        </ThemeInitializer>
       </AuthProvider>
     </BrowserRouter>
   )

--- a/server/frontend/src/App.tsx
+++ b/server/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react"
+import { useLayoutEffect } from "react"
 import { BrowserRouter, Navigate, Route, Routes } from "react-router"
 import { AuthProvider, useAuth } from "./auth"
 import { Layout } from "./components/Layout"
@@ -35,13 +35,20 @@ function AppRoutes() {
 }
 
 function ThemeInitializer({ children }: { children: React.ReactNode }) {
-  useEffect(() => {
-    const stored = localStorage.getItem("cq-dark-mode")
-    const dark =
-      stored !== null
-        ? stored === "true"
-        : window.matchMedia("(prefers-color-scheme: dark)").matches
-    document.documentElement.classList.toggle("dark", dark)
+  useLayoutEffect(() => {
+    try {
+      const stored = localStorage.getItem("cq-dark-mode")
+      const dark =
+        stored !== null
+          ? stored === "true"
+          : window.matchMedia("(prefers-color-scheme: dark)").matches
+      document.documentElement.classList.toggle("dark", dark)
+    } catch {
+      // localStorage blocked (privacy mode, embedded context)
+      if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
+        document.documentElement.classList.add("dark")
+      }
+    }
   }, [])
   return <>{children}</>
 }

--- a/server/frontend/src/components/ConfidenceBadge.tsx
+++ b/server/frontend/src/components/ConfidenceBadge.tsx
@@ -1,8 +1,10 @@
 export function ConfidenceBadge({ confidence }: { confidence: number }) {
   return (
-    <span className="text-sm text-gray-500">
+    <span className="text-sm text-gray-500 dark:text-slate-400">
       Confidence:{" "}
-      <strong className="text-gray-800">{confidence.toFixed(2)}</strong>
+      <strong className="text-gray-800 dark:text-slate-200">
+        {confidence.toFixed(2)}
+      </strong>
     </span>
   )
 }

--- a/server/frontend/src/components/DomainTags.tsx
+++ b/server/frontend/src/components/DomainTags.tsx
@@ -1,10 +1,12 @@
 import type { Selection } from "../types"
 
 const TAG_STYLES: Record<string, string> = {
-  neutral: "bg-indigo-100 text-indigo-700",
-  approve: "bg-green-100 text-green-700",
-  reject: "bg-red-100 text-red-700",
-  skip: "bg-slate-100 text-slate-700",
+  neutral:
+    "bg-indigo-100 dark:bg-indigo-500/20 text-indigo-700 dark:text-indigo-300",
+  approve:
+    "bg-green-100 dark:bg-green-500/20 text-green-700 dark:text-green-300",
+  reject: "bg-red-100 dark:bg-red-500/20 text-red-700 dark:text-red-300",
+  skip: "bg-slate-100 dark:bg-slate-700 text-slate-700 dark:text-slate-300",
 }
 
 interface Props {

--- a/server/frontend/src/components/DragIndicators.tsx
+++ b/server/frontend/src/components/DragIndicators.tsx
@@ -38,7 +38,7 @@ export function DragIndicators({ drag }: Props) {
         >
           {INDICATORS.approve.symbol}
         </div>
-        <span className="text-xs font-semibold text-green-600">
+        <span className="text-xs font-semibold text-green-600 dark:text-green-400">
           {INDICATORS.approve.label}
         </span>
       </div>
@@ -56,7 +56,7 @@ export function DragIndicators({ drag }: Props) {
         >
           {INDICATORS.reject.symbol}
         </div>
-        <span className="text-xs font-semibold text-red-600">
+        <span className="text-xs font-semibold text-red-600 dark:text-red-400">
           {INDICATORS.reject.label}
         </span>
       </div>
@@ -74,7 +74,7 @@ export function DragIndicators({ drag }: Props) {
         >
           {INDICATORS.skip.symbol}
         </div>
-        <span className="text-xs font-semibold text-slate-600">
+        <span className="text-xs font-semibold text-slate-600 dark:text-slate-400">
           {INDICATORS.skip.label}
         </span>
       </div>
@@ -92,7 +92,7 @@ export function DragIndicators({ drag }: Props) {
         >
           {INDICATORS.skip.symbol}
         </div>
-        <span className="text-xs font-semibold text-slate-600">
+        <span className="text-xs font-semibold text-slate-600 dark:text-slate-400">
           {INDICATORS.skip.label}
         </span>
       </div>

--- a/server/frontend/src/components/FilteredListModal.tsx
+++ b/server/frontend/src/components/FilteredListModal.tsx
@@ -78,7 +78,7 @@ export function FilteredListModal({ filter, onClose, onSelectUnit }: Props) {
         tabIndex={-1}
         aria-hidden="true"
         onClick={onClose}
-        className="absolute inset-0 bg-black/40 cursor-default"
+        className="absolute inset-0 bg-black/40 dark:bg-black/60 cursor-default"
       />
       <div
         ref={dialogRef}
@@ -86,19 +86,19 @@ export function FilteredListModal({ filter, onClose, onSelectUnit }: Props) {
         aria-modal="true"
         aria-labelledby={MODAL_TITLE_ID}
         tabIndex={-1}
-        className="relative bg-white rounded-lg shadow-xl w-full max-w-2xl mx-4 max-h-[90vh] flex flex-col outline-none"
+        className="relative bg-white dark:bg-slate-900 rounded-lg shadow-xl w-full max-w-2xl mx-4 max-h-[90vh] flex flex-col outline-none"
       >
-        <div className="flex items-center justify-between p-4 border-b border-gray-200">
+        <div className="flex items-center justify-between p-4 border-b border-gray-200 dark:border-slate-800">
           <h2
             id={MODAL_TITLE_ID}
-            className="text-lg font-semibold text-gray-900"
+            className="text-lg font-semibold text-gray-900 dark:text-slate-100"
           >
             {filter.title}
           </h2>
           <button
             type="button"
             onClick={onClose}
-            className="text-gray-400 hover:text-gray-600 text-xl leading-none"
+            className="text-gray-400 hover:text-gray-600 dark:text-slate-400 dark:hover:text-slate-200 text-xl leading-none"
             aria-label="Close"
           >
             &times;
@@ -107,7 +107,9 @@ export function FilteredListModal({ filter, onClose, onSelectUnit }: Props) {
 
         <div className="flex-1 overflow-y-auto p-4">
           {error && (
-            <p className="text-red-600 text-sm text-center py-4">{error}</p>
+            <p className="text-red-600 dark:text-red-400 text-sm text-center py-4">
+              {error}
+            </p>
           )}
 
           {!items && !error && (
@@ -115,14 +117,14 @@ export function FilteredListModal({ filter, onClose, onSelectUnit }: Props) {
               {[1, 2, 3].map((i) => (
                 <div
                   key={i}
-                  className="h-16 animate-pulse bg-gray-100 rounded-lg"
+                  className="h-16 animate-pulse bg-gray-100 dark:bg-slate-800 rounded-lg"
                 />
               ))}
             </div>
           )}
 
           {items && items.length === 0 && (
-            <p className="text-gray-400 text-sm text-center py-8">
+            <p className="text-gray-400 dark:text-slate-500 text-sm text-center py-8">
               No knowledge units found.
             </p>
           )}
@@ -133,18 +135,18 @@ export function FilteredListModal({ filter, onClose, onSelectUnit }: Props) {
                 <button
                   type="button"
                   key={item.knowledge_unit.id}
-                  className="w-full text-left p-3 rounded-lg border border-gray-200 hover:border-indigo-300 hover:bg-indigo-50/50 transition-colors"
+                  className="w-full text-left p-3 rounded-lg border border-gray-200 dark:border-slate-800 hover:border-indigo-300 dark:hover:border-indigo-600 hover:bg-indigo-50/50 dark:hover:bg-indigo-950/30 transition-colors"
                   onClick={() => onSelectUnit(item.knowledge_unit.id)}
                 >
                   <div className="flex items-center gap-2 mb-1">
                     <StatusBadge status={item.status} />
-                    <span className="text-sm font-medium text-gray-900 truncate">
+                    <span className="text-sm font-medium text-gray-900 dark:text-slate-100 truncate">
                       {item.knowledge_unit.insight.summary}
                     </span>
                   </div>
                   <div className="flex items-center gap-3">
                     <DomainTags domains={item.knowledge_unit.domains} />
-                    <span className="text-xs text-gray-400 ml-auto shrink-0">
+                    <span className="text-xs text-gray-400 dark:text-slate-500 ml-auto shrink-0">
                       {confidenceLabel(item.knowledge_unit.evidence.confidence)}
                     </span>
                   </div>

--- a/server/frontend/src/components/KnowledgeUnitModal.tsx
+++ b/server/frontend/src/components/KnowledgeUnitModal.tsx
@@ -11,10 +11,10 @@ interface Props {
 }
 
 function confidenceColor(c: number): string {
-  if (c < 0.3) return "text-red-600"
-  if (c < 0.5) return "text-amber-600"
-  if (c < 0.7) return "text-yellow-500"
-  return "text-green-600"
+  if (c < 0.3) return "text-red-600 dark:text-red-400"
+  if (c < 0.5) return "text-amber-600 dark:text-amber-400"
+  if (c < 0.7) return "text-yellow-500 dark:text-yellow-400"
+  return "text-green-600 dark:text-green-400"
 }
 
 const MODAL_TITLE_ID = "ku-modal-title"
@@ -71,15 +71,15 @@ export function KnowledgeUnitModal({ unitId, onClose }: Props) {
         aria-modal="true"
         aria-labelledby={item ? MODAL_TITLE_ID : undefined}
         tabIndex={-1}
-        className="relative bg-white rounded-lg shadow-xl w-full max-w-lg mx-4 max-h-[90vh] overflow-y-auto outline-none"
+        className="relative bg-white dark:bg-slate-900 rounded-lg shadow-xl w-full max-w-lg mx-4 max-h-[90vh] overflow-y-auto outline-none"
       >
         {error && (
           <div className="p-6 text-center">
-            <p className="text-red-600 text-sm">{error}</p>
+            <p className="text-red-600 dark:text-red-400 text-sm">{error}</p>
             <button
               type="button"
               onClick={onClose}
-              className="mt-3 text-sm text-gray-500 hover:text-gray-700"
+              className="mt-3 text-sm text-gray-500 hover:text-gray-700 dark:text-slate-400 dark:hover:text-slate-200"
             >
               Close
             </button>
@@ -88,9 +88,9 @@ export function KnowledgeUnitModal({ unitId, onClose }: Props) {
 
         {!item && !error && (
           <div className="p-6 space-y-3">
-            <div className="h-4 w-32 animate-pulse bg-gray-200 rounded" />
-            <div className="h-6 w-48 animate-pulse bg-gray-200 rounded" />
-            <div className="h-16 w-full animate-pulse bg-gray-200 rounded" />
+            <div className="h-4 w-32 animate-pulse bg-gray-200 dark:bg-slate-700 rounded" />
+            <div className="h-6 w-48 animate-pulse bg-gray-200 dark:bg-slate-700 rounded" />
+            <div className="h-16 w-full animate-pulse bg-gray-200 dark:bg-slate-700 rounded" />
           </div>
         )}
 
@@ -99,14 +99,14 @@ export function KnowledgeUnitModal({ unitId, onClose }: Props) {
             <div className="flex items-start justify-between gap-3">
               <h2
                 id={MODAL_TITLE_ID}
-                className="text-lg font-semibold text-gray-900"
+                className="text-lg font-semibold text-gray-900 dark:text-slate-100"
               >
                 {item.knowledge_unit.insight.summary}
               </h2>
               <button
                 type="button"
                 onClick={onClose}
-                className="text-gray-400 hover:text-gray-600 text-xl leading-none shrink-0"
+                className="text-gray-400 hover:text-gray-600 dark:text-slate-400 dark:hover:text-slate-200 text-xl leading-none shrink-0"
                 aria-label="Close"
               >
                 &times;
@@ -116,12 +116,12 @@ export function KnowledgeUnitModal({ unitId, onClose }: Props) {
             <div className="flex items-center gap-2">
               <StatusBadge status={item.status} />
               {item.reviewed_by && (
-                <span className="text-xs text-gray-500">
+                <span className="text-xs text-gray-500 dark:text-slate-400">
                   by {item.reviewed_by}
                 </span>
               )}
               {item.reviewed_at && (
-                <span className="text-xs text-gray-400">
+                <span className="text-xs text-gray-400 dark:text-slate-500">
                   {timeAgo(item.reviewed_at)}
                 </span>
               )}
@@ -129,22 +129,22 @@ export function KnowledgeUnitModal({ unitId, onClose }: Props) {
 
             <DomainTags domains={item.knowledge_unit.domains} />
 
-            <p className="text-gray-600 leading-relaxed">
+            <p className="text-gray-600 dark:text-slate-300 leading-relaxed">
               {item.knowledge_unit.insight.detail}
             </p>
 
-            <div className="border-l-3 rounded-r-lg px-4 py-3 bg-indigo-50 border-indigo-500">
-              <span className="text-xs font-semibold uppercase tracking-wide text-indigo-500">
+            <div className="border-l-3 rounded-r-lg px-4 py-3 bg-indigo-50 dark:bg-indigo-950/40 border-indigo-500">
+              <span className="text-xs font-semibold uppercase tracking-wide text-indigo-500 dark:text-indigo-400">
                 Action
               </span>
-              <p className="text-gray-800 text-sm mt-1">
+              <p className="text-gray-800 dark:text-slate-200 text-sm mt-1">
                 {item.knowledge_unit.insight.action}
               </p>
             </div>
 
             <div className="grid grid-cols-2 gap-3 text-sm">
-              <div className="bg-gray-50 rounded-lg p-3">
-                <span className="text-xs text-gray-500 uppercase">
+              <div className="bg-gray-50 dark:bg-slate-800 rounded-lg p-3">
+                <span className="text-xs text-gray-500 dark:text-slate-400 uppercase">
                   Confidence
                 </span>
                 <p
@@ -153,11 +153,11 @@ export function KnowledgeUnitModal({ unitId, onClose }: Props) {
                   {item.knowledge_unit.evidence.confidence.toFixed(2)}
                 </p>
               </div>
-              <div className="bg-gray-50 rounded-lg p-3">
-                <span className="text-xs text-gray-500 uppercase">
+              <div className="bg-gray-50 dark:bg-slate-800 rounded-lg p-3">
+                <span className="text-xs text-gray-500 dark:text-slate-400 uppercase">
                   Confirmations
                 </span>
-                <p className="font-semibold text-gray-800">
+                <p className="font-semibold text-gray-800 dark:text-slate-200">
                   {item.knowledge_unit.evidence.confirmations}
                 </p>
               </div>
@@ -165,7 +165,7 @@ export function KnowledgeUnitModal({ unitId, onClose }: Props) {
 
             {(item.knowledge_unit.context.languages.length > 0 ||
               item.knowledge_unit.context.frameworks.length > 0) && (
-              <div className="text-sm text-gray-500">
+              <div className="text-sm text-gray-500 dark:text-slate-400">
                 {item.knowledge_unit.context.languages.length > 0 && (
                   <span>
                     Languages:{" "}
@@ -185,7 +185,7 @@ export function KnowledgeUnitModal({ unitId, onClose }: Props) {
               </div>
             )}
 
-            <div className="flex items-center justify-between text-xs text-gray-400 pt-2 border-t border-gray-100">
+            <div className="flex items-center justify-between text-xs text-gray-400 dark:text-slate-500 pt-2 border-t border-gray-100 dark:border-slate-800">
               <span className="font-mono">{item.knowledge_unit.id}</span>
               {item.knowledge_unit.evidence.first_observed && (
                 <span>

--- a/server/frontend/src/components/KnowledgeUnitModal.tsx
+++ b/server/frontend/src/components/KnowledgeUnitModal.tsx
@@ -1,20 +1,13 @@
 import { useEffect, useRef, useState } from "react"
 import { ApiError, api } from "../api"
 import type { ReviewItem } from "../types"
-import { timeAgo } from "../utils"
+import { confidenceColor, timeAgo } from "../utils"
 import { DomainTags } from "./DomainTags"
 import { StatusBadge } from "./StatusBadge"
 
 interface Props {
   unitId: string
   onClose: () => void
-}
-
-function confidenceColor(c: number): string {
-  if (c < 0.3) return "text-red-600 dark:text-red-400"
-  if (c < 0.5) return "text-amber-600 dark:text-amber-400"
-  if (c < 0.7) return "text-yellow-500 dark:text-yellow-400"
-  return "text-green-600 dark:text-green-400"
 }
 
 const MODAL_TITLE_ID = "ku-modal-title"

--- a/server/frontend/src/components/Layout.tsx
+++ b/server/frontend/src/components/Layout.tsx
@@ -70,7 +70,11 @@ export function Layout() {
                   setDark(prev => {
                     const next = !prev;
                     document.documentElement.classList.toggle("dark", next);
-                    localStorage.setItem("cq-dark-mode", String(next));
+                    try {
+                      localStorage.setItem("cq-dark-mode", String(next));
+                    } catch {
+                      // localStorage blocked (privacy mode, embedded context)
+                    }
                     return next;
                   });
                 }}

--- a/server/frontend/src/components/Layout.tsx
+++ b/server/frontend/src/components/Layout.tsx
@@ -8,8 +8,12 @@ export function Layout() {
   const location = useLocation()
   const [pendingCount, setPendingCount] = useState(0)
   const [dark, setDark] = useState(() => {
-    const stored = localStorage.getItem("cq-dark-mode")
-    if (stored !== null) return stored === "true"
+    try {
+      const stored = localStorage.getItem("cq-dark-mode")
+      if (stored !== null) return stored === "true"
+    } catch {
+      // localStorage blocked — fall through to system preference
+    }
     return window.matchMedia("(prefers-color-scheme: dark)").matches
   })
   const onDashboard = location.pathname === "/dashboard"
@@ -70,12 +74,12 @@ export function Layout() {
               {username}
             </span>
             <div className="flex items-center gap-1.5">
-              <span className="text-xs select-none">{dark ? "🌙" : "☀️"}</span>
+              <span className="text-xs select-none" aria-hidden="true">{dark ? "🌙" : "☀️"}</span>
               <button
                 type="button"
                 role="switch"
                 aria-checked={dark}
-                onClick={() => setDark(!dark)}
+                onClick={() => setDark(prev => !prev)}
                 className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-slate-900 ${
                   dark
                     ? "bg-indigo-600"

--- a/server/frontend/src/components/Layout.tsx
+++ b/server/frontend/src/components/Layout.tsx
@@ -1,7 +1,47 @@
-import { useEffect, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { Link, Outlet, useLocation } from "react-router"
 import { api } from "../api"
 import { useAuth } from "../auth"
+
+function SunIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      className="h-5 w-5"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M12 3v2.25m6.364.386-1.591 1.591M21 12h-2.25m-.386 6.364-1.591-1.591M12 18.75V21m-4.773-4.227-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z"
+      />
+    </svg>
+  )
+}
+
+function MoonIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      className="h-5 w-5"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M21.752 15.002A9.72 9.72 0 0 1 18 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 0 0 3 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 0 0 9.002-5.998Z"
+      />
+    </svg>
+  )
+}
 
 export function Layout() {
   const { username, logout } = useAuth()
@@ -10,6 +50,8 @@ export function Layout() {
   const [dark, setDark] = useState(() =>
     document.documentElement.classList.contains("dark"),
   )
+  const [menuOpen, setMenuOpen] = useState(false)
+  const menuRef = useRef<HTMLDivElement>(null)
   const onDashboard = location.pathname === "/dashboard"
 
   useEffect(() => {
@@ -24,6 +66,37 @@ export function Layout() {
     const interval = setInterval(fetchCount, 15_000)
     return () => clearInterval(interval)
   }, [onDashboard])
+
+  useEffect(() => {
+    if (!menuOpen) return
+    function handlePointerDown(e: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setMenuOpen(false)
+      }
+    }
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") setMenuOpen(false)
+    }
+    document.addEventListener("mousedown", handlePointerDown)
+    document.addEventListener("keydown", handleKeyDown)
+    return () => {
+      document.removeEventListener("mousedown", handlePointerDown)
+      document.removeEventListener("keydown", handleKeyDown)
+    }
+  }, [menuOpen])
+
+  function toggleTheme() {
+    setDark((prev) => {
+      const next = !prev
+      document.documentElement.classList.toggle("dark", next)
+      try {
+        localStorage.setItem("cq-dark-mode", String(next))
+      } catch {
+        // localStorage blocked (privacy mode, embedded context)
+      }
+      return next
+    })
+  }
 
   function navLink(path: string, label: string) {
     const active = location.pathname === path
@@ -58,49 +131,59 @@ export function Layout() {
             {navLink("/dashboard", "Dashboard")}
             {navLink("/settings/api-keys", "API Keys")}
           </div>
-          <div className="flex items-center gap-3">
-            <span className="hidden md:inline text-sm text-gray-500 dark:text-slate-400">
-              {username}
-            </span>
-            <div className="flex items-center gap-1.5">
-              <span className="text-xs select-none" aria-hidden="true">{dark ? "🌙" : "☀️"}</span>
-              <button
-                type="button"
-                role="switch"
-                aria-checked={dark}
-                onClick={() => {
-                  setDark(prev => {
-                    const next = !prev;
-                    document.documentElement.classList.toggle("dark", next);
-                    try {
-                      localStorage.setItem("cq-dark-mode", String(next));
-                    } catch {
-                      // localStorage blocked (privacy mode, embedded context)
-                    }
-                    return next;
-                  });
-                }}
-                className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-slate-900 ${
-                  dark
-                    ? "bg-indigo-600"
-                    : "bg-gray-300"
-                }`}
-              >
-                <span className="sr-only">Toggle dark mode</span>
-                <span
-                  className={`inline-flex items-center justify-center h-3.5 w-3.5 rounded-full bg-white shadow-sm transition-transform duration-200 ${
-                    dark ? "translate-x-[18px]" : "translate-x-[3px]"
-                  }`}
-                />
-              </button>
-            </div>
+          <div className="flex items-center gap-2">
             <button
               type="button"
-              onClick={logout}
-              className="text-sm text-gray-400 hover:text-gray-700 dark:text-slate-400 dark:hover:text-slate-200"
+              onClick={toggleTheme}
+              aria-label={dark ? "Switch to light mode" : "Switch to dark mode"}
+              title={dark ? "Switch to light mode" : "Switch to dark mode"}
+              className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-gray-500 hover:bg-gray-100 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-200 dark:focus-visible:ring-offset-slate-900"
             >
-              Logout
+              {dark ? <MoonIcon /> : <SunIcon />}
             </button>
+            <div className="relative" ref={menuRef}>
+              <button
+                type="button"
+                onClick={() => setMenuOpen((open) => !open)}
+                aria-haspopup="menu"
+                aria-expanded={menuOpen}
+                className="inline-flex items-center gap-1.5 rounded-lg border border-gray-200 px-2.5 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800 dark:focus-visible:ring-offset-slate-900"
+              >
+                <span className="max-w-[10rem] truncate">{username}</span>
+                <svg
+                  aria-hidden="true"
+                  className={`h-4 w-4 text-gray-400 dark:text-slate-500 transition-transform ${
+                    menuOpen ? "rotate-180" : ""
+                  }`}
+                  viewBox="0 0 20 20"
+                  fill="currentColor"
+                >
+                  <path
+                    fillRule="evenodd"
+                    d="M5.23 7.21a.75.75 0 011.06.02L10 11.06l3.71-3.83a.75.75 0 111.08 1.04l-4.25 4.39a.75.75 0 01-1.08 0L5.21 8.27a.75.75 0 01.02-1.06z"
+                    clipRule="evenodd"
+                  />
+                </svg>
+              </button>
+              {menuOpen && (
+                <div
+                  role="menu"
+                  className="absolute right-0 mt-1 w-max min-w-full rounded-lg border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 py-1 shadow-lg z-10"
+                >
+                  <button
+                    type="button"
+                    role="menuitem"
+                    onClick={() => {
+                      setMenuOpen(false)
+                      logout()
+                    }}
+                    className="block w-full px-3 py-1.5 text-center text-sm text-gray-700 hover:bg-gray-100 dark:text-slate-200 dark:hover:bg-slate-800"
+                  >
+                    Logout
+                  </button>
+                </div>
+              )}
+            </div>
           </div>
         </div>
       </nav>

--- a/server/frontend/src/components/Layout.tsx
+++ b/server/frontend/src/components/Layout.tsx
@@ -74,13 +74,27 @@ export function Layout() {
             <span className="hidden md:inline text-sm text-gray-500 dark:text-slate-400">
               {username}
             </span>
-            <button
-              type="button"
-              onClick={() => setDark(!dark)}
-              className="text-sm text-gray-400 hover:text-gray-700 dark:text-slate-400 dark:hover:text-slate-200"
-            >
-              {dark ? "☀️" : "🌙"}
-            </button>
+            <div className="flex items-center gap-1.5">
+              <span className="text-xs select-none">{dark ? "🌙" : "☀️"}</span>
+              <button
+                type="button"
+                role="switch"
+                aria-checked={dark}
+                onClick={() => setDark(!dark)}
+                className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-slate-900 ${
+                  dark
+                    ? "bg-indigo-600"
+                    : "bg-gray-300"
+                }`}
+              >
+                <span className="sr-only">Toggle dark mode</span>
+                <span
+                  className={`inline-flex items-center justify-center h-3.5 w-3.5 rounded-full bg-white shadow-sm transition-transform duration-200 ${
+                    dark ? "translate-x-[18px]" : "translate-x-[3px]"
+                  }`}
+                />
+              </button>
+            </div>
             <button
               type="button"
               onClick={logout}

--- a/server/frontend/src/components/Layout.tsx
+++ b/server/frontend/src/components/Layout.tsx
@@ -7,7 +7,22 @@ export function Layout() {
   const { username, logout } = useAuth()
   const location = useLocation()
   const [pendingCount, setPendingCount] = useState(0)
+  const [dark, setDark] = useState(false)
   const onDashboard = location.pathname === "/dashboard"
+
+  useEffect(() => {
+    const stored = localStorage.getItem("cq-dark-mode")
+    if (stored !== null) {
+      setDark(stored === "true")
+    } else {
+      setDark(window.matchMedia("(prefers-color-scheme: dark)").matches)
+    }
+  }, [])
+
+  useEffect(() => {
+    document.documentElement.classList.toggle("dark", dark)
+    localStorage.setItem("cq-dark-mode", String(dark))
+  }, [dark])
 
   useEffect(() => {
     if (onDashboard) return
@@ -29,13 +44,13 @@ export function Layout() {
         to={path}
         className={`px-3 py-1 text-sm font-medium whitespace-nowrap ${
           active
-            ? "border-b-2 border-indigo-500 font-semibold text-gray-900"
-            : "text-gray-500 hover:text-gray-900"
+            ? "border-b-2 border-indigo-500 font-semibold text-gray-900 dark:text-slate-100"
+            : "text-gray-500 hover:text-gray-900 dark:text-slate-400 dark:hover:text-slate-200"
         }`}
       >
         {label}
         {path === "/review" && pendingCount > 0 && (
-          <span className="ml-1.5 inline-flex items-center justify-center rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700">
+          <span className="ml-1.5 inline-flex items-center justify-center rounded-full bg-amber-100 dark:bg-amber-500/20 px-2 py-0.5 text-xs font-medium text-amber-700 dark:text-amber-300">
             {pendingCount}
           </span>
         )}
@@ -44,23 +59,32 @@ export function Layout() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 overflow-x-hidden">
-      <nav className="bg-white border-b border-gray-200">
+    <div className="min-h-screen bg-gray-50 dark:bg-slate-950 overflow-x-hidden">
+      <nav className="bg-white dark:bg-slate-900 border-b border-gray-200 dark:border-slate-800">
         <div className="max-w-2xl mx-auto px-4 py-3 flex items-center justify-between">
           <div className="flex items-center gap-3 md:gap-6">
-            <span className="text-lg font-bold text-indigo-600">cq</span>
+            <span className="text-lg font-bold text-indigo-600 dark:text-indigo-400">
+              cq
+            </span>
             {navLink("/review", "Review")}
             {navLink("/dashboard", "Dashboard")}
             {navLink("/settings/api-keys", "API Keys")}
           </div>
           <div className="flex items-center gap-3">
-            <span className="hidden md:inline text-sm text-gray-500">
+            <span className="hidden md:inline text-sm text-gray-500 dark:text-slate-400">
               {username}
             </span>
             <button
               type="button"
+              onClick={() => setDark(!dark)}
+              className="text-sm text-gray-400 hover:text-gray-700 dark:text-slate-400 dark:hover:text-slate-200"
+            >
+              {dark ? "☀️" : "🌙"}
+            </button>
+            <button
+              type="button"
               onClick={logout}
-              className="text-sm text-gray-400 hover:text-gray-700"
+              className="text-sm text-gray-400 hover:text-gray-700 dark:text-slate-400 dark:hover:text-slate-200"
             >
               Logout
             </button>

--- a/server/frontend/src/components/Layout.tsx
+++ b/server/frontend/src/components/Layout.tsx
@@ -7,7 +7,9 @@ export function Layout() {
   const { username, logout } = useAuth()
   const location = useLocation()
   const [pendingCount, setPendingCount] = useState(0)
-  const [dark, setDark] = useState(false)
+  const [dark, setDark] = useState(() =>
+    document.documentElement.classList.contains("dark"),
+  )
   const onDashboard = location.pathname === "/dashboard"
 
   useEffect(() => {

--- a/server/frontend/src/components/Layout.tsx
+++ b/server/frontend/src/components/Layout.tsx
@@ -7,21 +7,8 @@ export function Layout() {
   const { username, logout } = useAuth()
   const location = useLocation()
   const [pendingCount, setPendingCount] = useState(0)
-  const [dark, setDark] = useState(() => {
-    try {
-      const stored = localStorage.getItem("cq-dark-mode")
-      if (stored !== null) return stored === "true"
-    } catch {
-      // localStorage blocked — fall through to system preference
-    }
-    return window.matchMedia("(prefers-color-scheme: dark)").matches
-  })
+  const [dark, setDark] = useState(false)
   const onDashboard = location.pathname === "/dashboard"
-
-  useEffect(() => {
-    document.documentElement.classList.toggle("dark", dark)
-    localStorage.setItem("cq-dark-mode", String(dark))
-  }, [dark])
 
   useEffect(() => {
     if (onDashboard) return
@@ -79,7 +66,14 @@ export function Layout() {
                 type="button"
                 role="switch"
                 aria-checked={dark}
-                onClick={() => setDark(prev => !prev)}
+                onClick={() => {
+                  setDark(prev => {
+                    const next = !prev;
+                    document.documentElement.classList.toggle("dark", next);
+                    localStorage.setItem("cq-dark-mode", String(next));
+                    return next;
+                  });
+                }}
                 className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-slate-900 ${
                   dark
                     ? "bg-indigo-600"

--- a/server/frontend/src/components/Layout.tsx
+++ b/server/frontend/src/components/Layout.tsx
@@ -7,17 +7,12 @@ export function Layout() {
   const { username, logout } = useAuth()
   const location = useLocation()
   const [pendingCount, setPendingCount] = useState(0)
-  const [dark, setDark] = useState(false)
-  const onDashboard = location.pathname === "/dashboard"
-
-  useEffect(() => {
+  const [dark, setDark] = useState(() => {
     const stored = localStorage.getItem("cq-dark-mode")
-    if (stored !== null) {
-      setDark(stored === "true")
-    } else {
-      setDark(window.matchMedia("(prefers-color-scheme: dark)").matches)
-    }
-  }, [])
+    if (stored !== null) return stored === "true"
+    return window.matchMedia("(prefers-color-scheme: dark)").matches
+  })
+  const onDashboard = location.pathname === "/dashboard"
 
   useEffect(() => {
     document.documentElement.classList.toggle("dark", dark)

--- a/server/frontend/src/components/ReviewActions.tsx
+++ b/server/frontend/src/components/ReviewActions.tsx
@@ -28,10 +28,10 @@ export function ReviewActions({
           disabled={disabled}
           className={`px-8 py-2.5 rounded-lg font-semibold text-sm transition-all duration-200 disabled:opacity-50 ${
             selection === "reject"
-              ? "bg-red-600 text-white ring-3 ring-red-200"
+              ? "bg-red-600 text-white ring-3 ring-red-200 dark:ring-red-700"
               : selection
-                ? "bg-red-100 text-red-600 opacity-40"
-                : "bg-red-100 text-red-600"
+                ? "bg-red-100 dark:bg-red-950/40 text-red-600 dark:text-red-400 opacity-40"
+                : "bg-red-100 dark:bg-red-950/40 text-red-600 dark:text-red-400"
           }`}
         >
           {selection === "reject" ? "Confirm Reject" : "\u2190 Reject"}
@@ -48,10 +48,10 @@ export function ReviewActions({
           disabled={disabled}
           className={`px-6 py-2.5 rounded-lg font-semibold text-sm transition-all duration-200 disabled:opacity-50 ${
             selection === "skip"
-              ? "bg-slate-600 text-white ring-3 ring-slate-200"
+              ? "bg-slate-600 text-white ring-3 ring-slate-200 dark:ring-slate-700"
               : selection
-                ? "bg-slate-100 text-slate-600 opacity-40"
-                : "bg-slate-100 text-slate-600"
+                ? "bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-300 opacity-40"
+                : "bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-300"
           }`}
         >
           {selection === "skip" ? "Confirm Skip" : "\u2191\u2193 Skip"}
@@ -68,10 +68,10 @@ export function ReviewActions({
           disabled={disabled}
           className={`px-8 py-2.5 rounded-lg font-semibold text-sm transition-all duration-200 disabled:opacity-50 ${
             selection === "approve"
-              ? "bg-green-600 text-white ring-3 ring-green-200"
+              ? "bg-green-600 text-white ring-3 ring-green-200 dark:ring-green-700"
               : selection
-                ? "bg-green-100 text-green-600 opacity-40"
-                : "bg-green-100 text-green-600"
+                ? "bg-green-100 dark:bg-green-950/40 text-green-600 dark:text-green-400 opacity-40"
+                : "bg-green-100 dark:bg-green-950/40 text-green-600 dark:text-green-400"
           }`}
         >
           {selection === "approve" ? "Confirm Approve" : "Approve \u2192"}
@@ -79,7 +79,9 @@ export function ReviewActions({
       </div>
       <p
         className={`text-center text-xs ${
-          selection ? "text-gray-500 font-medium" : "text-gray-400"
+          selection
+            ? "text-gray-500 dark:text-slate-400 font-medium"
+            : "text-gray-400 dark:text-slate-500"
         }`}
       >
         {selection

--- a/server/frontend/src/components/ReviewCard.tsx
+++ b/server/frontend/src/components/ReviewCard.tsx
@@ -17,24 +17,28 @@ interface Props {
 }
 
 const CARD_STYLES: Record<string, string> = {
-  neutral: "border-gray-200 bg-white",
-  approve: "border-green-300 bg-green-50",
-  reject: "border-red-300 bg-red-50",
-  skip: "border-slate-400 bg-slate-50",
+  neutral: "border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900",
+  approve:
+    "border-green-300 dark:border-green-700 bg-green-50 dark:bg-green-950/40",
+  reject: "border-red-300 dark:border-red-700 bg-red-50 dark:bg-red-950/40",
+  skip: "border-slate-400 dark:border-slate-600 bg-slate-50 dark:bg-slate-800",
 }
 
 const ACTION_BOX_STYLES: Record<string, string> = {
-  neutral: "bg-indigo-50 border-indigo-500 text-indigo-500",
-  approve: "bg-green-50 border-green-500 text-green-600",
-  reject: "bg-red-50 border-red-500 text-red-600",
-  skip: "bg-slate-50 border-slate-400 text-slate-500",
+  neutral:
+    "bg-indigo-50 dark:bg-indigo-950/40 border-indigo-500 text-indigo-500",
+  approve:
+    "bg-green-50 dark:bg-green-950/40 border-green-500 text-green-600 dark:text-green-400",
+  reject:
+    "bg-red-50 dark:bg-red-950/40 border-red-500 text-red-600 dark:text-red-400",
+  skip: "bg-slate-50 dark:bg-slate-800 border-slate-400 text-slate-500 dark:text-slate-300",
 }
 
 function confidenceColor(c: number): string {
-  if (c < 0.3) return "text-red-600"
-  if (c < 0.5) return "text-amber-600"
-  if (c < 0.7) return "text-yellow-500"
-  return "text-green-600"
+  if (c < 0.3) return "text-red-600 dark:text-red-400"
+  if (c < 0.5) return "text-amber-600 dark:text-amber-400"
+  if (c < 0.7) return "text-yellow-500 dark:text-yellow-400"
+  return "text-green-600 dark:text-green-400"
 }
 
 export const ReviewCard = forwardRef<HTMLDivElement, Props>(function ReviewCard(
@@ -68,17 +72,17 @@ export const ReviewCard = forwardRef<HTMLDivElement, Props>(function ReviewCard(
       <div className="flex items-center justify-between mb-3">
         <DomainTags domains={unit.domains} variant={activeState} />
         {unit.evidence.first_observed && (
-          <span className="text-xs text-gray-400">
+          <span className="text-xs text-gray-400 dark:text-slate-500">
             {timeAgo(unit.evidence.first_observed)}
           </span>
         )}
       </div>
 
-      <h2 className="text-lg font-semibold text-gray-900 mb-2">
+      <h2 className="text-lg font-semibold text-gray-900 dark:text-slate-100 mb-2">
         {unit.insight.summary}
       </h2>
 
-      <p className="text-gray-600 mb-3 leading-relaxed">
+      <p className="text-gray-600 dark:text-slate-300 mb-3 leading-relaxed">
         {unit.insight.detail}
       </p>
 
@@ -88,10 +92,12 @@ export const ReviewCard = forwardRef<HTMLDivElement, Props>(function ReviewCard(
         <span className="text-xs font-semibold uppercase tracking-wide">
           Action
         </span>
-        <p className="text-gray-800 text-sm mt-1">{unit.insight.action}</p>
+        <p className="text-gray-800 dark:text-slate-200 text-sm mt-1">
+          {unit.insight.action}
+        </p>
       </div>
 
-      <div className="flex gap-4 text-sm text-gray-500">
+      <div className="flex gap-4 text-sm text-gray-500 dark:text-slate-400">
         <span>
           Confidence:{" "}
           <strong className={confidenceColor(unit.evidence.confidence)}>
@@ -100,7 +106,7 @@ export const ReviewCard = forwardRef<HTMLDivElement, Props>(function ReviewCard(
         </span>
         <span>
           Confirmations:{" "}
-          <strong className="text-gray-800">
+          <strong className="text-gray-800 dark:text-slate-200">
             {unit.evidence.confirmations}
           </strong>
         </span>

--- a/server/frontend/src/components/ReviewCard.tsx
+++ b/server/frontend/src/components/ReviewCard.tsx
@@ -26,7 +26,7 @@ const CARD_STYLES: Record<string, string> = {
 
 const ACTION_BOX_STYLES: Record<string, string> = {
   neutral:
-    "bg-indigo-50 dark:bg-indigo-950/40 border-indigo-500 text-indigo-500",
+    "bg-indigo-50 dark:bg-indigo-950/40 border-indigo-500 text-indigo-500 dark:text-indigo-400",
   approve:
     "bg-green-50 dark:bg-green-950/40 border-green-500 text-green-600 dark:text-green-400",
   reject:

--- a/server/frontend/src/components/ReviewCard.tsx
+++ b/server/frontend/src/components/ReviewCard.tsx
@@ -6,7 +6,7 @@ import {
   SNAP_BACK_MS,
 } from "../hooks/useCardDrag"
 import type { KnowledgeUnit, Selection } from "../types"
-import { timeAgo } from "../utils"
+import { confidenceColor, timeAgo } from "../utils"
 import { DomainTags } from "./DomainTags"
 
 interface Props {
@@ -32,13 +32,6 @@ const ACTION_BOX_STYLES: Record<string, string> = {
   reject:
     "bg-red-50 dark:bg-red-950/40 border-red-500 text-red-600 dark:text-red-400",
   skip: "bg-slate-50 dark:bg-slate-800 border-slate-400 text-slate-500 dark:text-slate-300",
-}
-
-function confidenceColor(c: number): string {
-  if (c < 0.3) return "text-red-600 dark:text-red-400"
-  if (c < 0.5) return "text-amber-600 dark:text-amber-400"
-  if (c < 0.7) return "text-yellow-500 dark:text-yellow-400"
-  return "text-green-600 dark:text-green-400"
 }
 
 export const ReviewCard = forwardRef<HTMLDivElement, Props>(function ReviewCard(

--- a/server/frontend/src/components/StatusBadge.tsx
+++ b/server/frontend/src/components/StatusBadge.tsx
@@ -1,13 +1,15 @@
 const STYLES: Record<string, string> = {
-  proposed: "bg-amber-100 text-amber-800",
-  approved: "bg-green-100 text-green-800",
-  rejected: "bg-red-100 text-red-800",
+  proposed:
+    "bg-amber-100 dark:bg-amber-500/20 text-amber-800 dark:text-amber-300",
+  approved:
+    "bg-green-100 dark:bg-green-500/20 text-green-800 dark:text-green-300",
+  rejected: "bg-red-100 dark:bg-red-500/20 text-red-800 dark:text-red-300",
 }
 
 export function StatusBadge({ status }: { status: string }) {
   return (
     <span
-      className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${STYLES[status] ?? "bg-gray-100 text-gray-800"}`}
+      className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${STYLES[status] ?? "bg-gray-100 dark:bg-slate-700 text-gray-800 dark:text-slate-300"}`}
     >
       {status}
     </span>

--- a/server/frontend/src/hooks/useIsDark.ts
+++ b/server/frontend/src/hooks/useIsDark.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from "react"
+
+export function useIsDark() {
+  const [isDark, setIsDark] = useState(() =>
+    document.documentElement.classList.contains("dark"),
+  )
+  useEffect(() => {
+    const observer = new MutationObserver(() => {
+      setIsDark(document.documentElement.classList.contains("dark"))
+    })
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    })
+    return () => observer.disconnect()
+  }, [])
+  return isDark
+}

--- a/server/frontend/src/index.css
+++ b/server/frontend/src/index.css
@@ -1,2 +1,3 @@
 @import "tailwindcss";
+@custom-variant dark (&:where(.dark, .dark *));
 @custom-variant pointer-fine (@media (pointer: fine));

--- a/server/frontend/src/pages/ApiKeysPage.tsx
+++ b/server/frontend/src/pages/ApiKeysPage.tsx
@@ -24,17 +24,22 @@ function statusLabel(key: ApiKeyPublic): string {
 }
 
 function statusBadgeClasses(key: ApiKeyPublic): string {
-  if (key.revoked_at) return "bg-red-100 text-red-700"
-  if (key.is_expired) return "bg-gray-200 text-gray-600"
-  return "bg-green-100 text-green-700"
+  if (key.revoked_at)
+    return "bg-red-100 dark:bg-red-950/40 text-red-700 dark:text-red-300"
+  if (key.is_expired)
+    return "bg-gray-200 dark:bg-slate-700 text-gray-600 dark:text-slate-400"
+  return "bg-green-100 dark:bg-green-950/40 text-green-700 dark:text-green-300"
 }
 
 function expiryUrgencyClasses(key: ApiKeyPublic): string {
-  if (key.revoked_at || key.is_expired) return "bg-gray-100 text-gray-500"
+  if (key.revoked_at || key.is_expired)
+    return "bg-gray-100 dark:bg-slate-800 text-gray-500 dark:text-slate-400"
   const remaining = secondsUntil(key.expires_at)
-  if (remaining <= DAY_SECONDS) return "bg-red-100 text-red-700"
-  if (remaining <= WEEK_SECONDS) return "bg-amber-100 text-amber-700"
-  return "bg-green-100 text-green-700"
+  if (remaining <= DAY_SECONDS)
+    return "bg-red-100 dark:bg-red-950/40 text-red-700 dark:text-red-300"
+  if (remaining <= WEEK_SECONDS)
+    return "bg-amber-100 dark:bg-amber-500/20 text-amber-700 dark:text-amber-300"
+  return "bg-green-100 dark:bg-green-950/40 text-green-700 dark:text-green-300"
 }
 
 function expiryLabel(key: ApiKeyPublic): string {
@@ -190,22 +195,26 @@ export function ApiKeysPage() {
   return (
     <div className="space-y-8">
       <section>
-        <h1 className="text-2xl font-semibold text-gray-900">API Keys</h1>
-        <p className="mt-2 text-sm text-gray-600">
+        <h1 className="text-2xl font-semibold text-gray-900 dark:text-slate-100">
+          API Keys
+        </h1>
+        <p className="mt-2 text-sm text-gray-600 dark:text-slate-400">
           API keys let agents act on your behalf. Give each key a name and an
           expiry; attach optional labels to group or filter keys later. The full
           key is shown only once at creation.
         </p>
       </section>
 
-      <section className="rounded-lg border border-gray-200 bg-white p-6">
-        <h2 className="text-lg font-medium text-gray-900">Create a new key</h2>
+      <section className="rounded-lg border border-gray-200 dark:border-slate-800 bg-white dark:bg-slate-900 p-6">
+        <h2 className="text-lg font-medium text-gray-900 dark:text-slate-100">
+          Create a new key
+        </h2>
         <form
           onSubmit={handleCreate}
           className="mt-4 grid gap-4 md:grid-cols-2"
         >
           <label className="flex flex-col text-sm">
-            <span className="text-gray-700">Name</span>
+            <span className="text-gray-700 dark:text-slate-300">Name</span>
             <input
               type="text"
               required
@@ -213,11 +222,11 @@ export function ApiKeysPage() {
               value={name}
               onChange={(e) => setName(e.target.value)}
               placeholder="e.g. laptop-mcp"
-              className="mt-1 rounded-md border border-gray-300 px-3 py-2 focus:border-indigo-500 focus:outline-none"
+              className="mt-1 rounded-md border border-gray-300 dark:border-slate-700 bg-white dark:bg-slate-800 text-gray-900 dark:text-slate-100 px-3 py-2 focus:border-indigo-500 focus:outline-none"
             />
           </label>
           <label className="flex flex-col text-sm">
-            <span className="text-gray-700">TTL</span>
+            <span className="text-gray-700 dark:text-slate-300">TTL</span>
             <input
               type="text"
               required
@@ -226,26 +235,28 @@ export function ApiKeysPage() {
               onChange={(e) => setTtl(e.target.value)}
               maxLength={16}
               aria-invalid={ttl.length > 0 && !ttlIsValid}
-              className="mt-1 rounded-md border border-gray-300 px-3 py-2 focus:border-indigo-500 focus:outline-none"
+              className="mt-1 rounded-md border border-gray-300 dark:border-slate-700 bg-white dark:bg-slate-800 text-gray-900 dark:text-slate-100 px-3 py-2 focus:border-indigo-500 focus:outline-none"
             />
             <datalist id="ttl-suggestions">
               {TTL_SUGGESTIONS.map((s) => (
                 <option key={s} value={s} />
               ))}
             </datalist>
-            <span className="mt-1 text-xs text-gray-500">
+            <span className="mt-1 text-xs text-gray-500 dark:text-slate-400">
               e.g. <code>30s</code>, <code>15m</code>, <code>2h</code>,{" "}
               <code>90d</code> (max 365d).
             </span>
           </label>
           <label className="flex flex-col text-sm md:col-span-2">
-            <span className="text-gray-700">Labels (optional)</span>
+            <span className="text-gray-700 dark:text-slate-300">
+              Labels (optional)
+            </span>
             <input
               type="text"
               value={labelsInput}
               onChange={(e) => setLabelsInput(e.target.value)}
               placeholder="comma-separated, e.g. mcp, claude, personal"
-              className="mt-1 rounded-md border border-gray-300 px-3 py-2 focus:border-indigo-500 focus:outline-none"
+              className="mt-1 rounded-md border border-gray-300 dark:border-slate-700 bg-white dark:bg-slate-800 text-gray-900 dark:text-slate-100 px-3 py-2 focus:border-indigo-500 focus:outline-none"
             />
           </label>
           <div className="md:col-span-2">
@@ -264,20 +275,22 @@ export function ApiKeysPage() {
             )}
           </div>
         </form>
-        {error && <p className="mt-3 text-sm text-red-600">{error}</p>}
+        {error && (
+          <p className="mt-3 text-sm text-red-600 dark:text-red-400">{error}</p>
+        )}
       </section>
 
       <section>
         <div className="flex flex-wrap items-center gap-3">
-          <h2 className="shrink-0 text-lg font-medium text-gray-900">
+          <h2 className="shrink-0 text-lg font-medium text-gray-900 dark:text-slate-100">
             Your keys
-            <span className="ml-2 text-sm font-normal text-gray-500">
+            <span className="ml-2 text-sm font-normal text-gray-500 dark:text-slate-400">
               {activeCount} of {MAX_ACTIVE_KEYS} active
             </span>
           </h2>
           <fieldset
             aria-label="Filter keys"
-            className="inline-flex shrink-0 overflow-hidden rounded-lg border border-gray-200 bg-white text-sm"
+            className="inline-flex shrink-0 overflow-hidden rounded-lg border border-gray-200 dark:border-slate-800 bg-white dark:bg-slate-900 text-sm"
           >
             {(
               [
@@ -294,7 +307,7 @@ export function ApiKeysPage() {
                 className={`px-3 py-1.5 ${
                   filter === value
                     ? "bg-indigo-600 text-white"
-                    : "text-gray-700 hover:bg-gray-50"
+                    : "text-gray-700 hover:bg-gray-50 dark:text-slate-300 dark:hover:bg-slate-800"
                 }`}
               >
                 {label}
@@ -307,15 +320,19 @@ export function ApiKeysPage() {
             onChange={(e) => setSearch(e.target.value)}
             placeholder="Search name or label…"
             aria-label="Search keys"
-            className="min-w-40 flex-1 rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-sm focus:border-indigo-500 focus:outline-none"
+            className="min-w-40 flex-1 rounded-lg border border-gray-200 dark:border-slate-800 bg-white dark:bg-slate-900 text-gray-900 dark:text-slate-100 px-3 py-1.5 text-sm focus:border-indigo-500 focus:outline-none"
           />
         </div>
         {loading ? (
-          <p className="mt-4 text-sm text-gray-500">Loading…</p>
+          <p className="mt-4 text-sm text-gray-500 dark:text-slate-400">
+            Loading…
+          </p>
         ) : keys.length === 0 ? (
-          <p className="mt-4 text-sm text-gray-500">No API keys yet.</p>
+          <p className="mt-4 text-sm text-gray-500 dark:text-slate-400">
+            No API keys yet.
+          </p>
         ) : filteredKeys.length === 0 ? (
-          <p className="mt-4 text-sm text-gray-500">
+          <p className="mt-4 text-sm text-gray-500 dark:text-slate-400">
             No keys match the current filter.
           </p>
         ) : (
@@ -325,21 +342,21 @@ export function ApiKeysPage() {
               return (
                 <li
                   key={key.id}
-                  className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm"
+                  className="overflow-hidden rounded-lg border border-gray-200 dark:border-slate-800 bg-white dark:bg-slate-900 shadow-sm"
                 >
                   <button
                     type="button"
                     onClick={() => toggleExpanded(key.id)}
                     aria-expanded={isOpen}
                     aria-controls={`apikey-details-${key.id}`}
-                    className="flex w-full items-center justify-between gap-4 px-5 py-4 text-left hover:bg-gray-50"
+                    className="flex w-full items-center justify-between gap-4 px-5 py-4 text-left hover:bg-gray-50 dark:hover:bg-slate-800"
                   >
                     <div className="min-w-0 flex-1">
                       <div className="flex items-center gap-2">
-                        <h3 className="truncate text-base font-semibold text-gray-900">
+                        <h3 className="truncate text-base font-semibold text-gray-900 dark:text-slate-100">
                           {key.name}
                         </h3>
-                        <code className="rounded bg-gray-100 px-1.5 py-0.5 font-mono text-xs text-gray-600">
+                        <code className="rounded bg-gray-100 dark:bg-slate-800 px-1.5 py-0.5 font-mono text-xs text-gray-600 dark:text-slate-400">
                           {key.prefix}…
                         </code>
                       </div>
@@ -354,7 +371,7 @@ export function ApiKeysPage() {
                           </span>
                           <span
                             role="tooltip"
-                            className="pointer-events-none invisible absolute bottom-full left-1/2 z-20 mb-1 -translate-x-1/2 whitespace-nowrap rounded bg-gray-900 px-2 py-1 text-xs text-white opacity-0 transition-opacity group-hover:visible group-hover:opacity-100"
+                            className="pointer-events-none invisible absolute bottom-full left-1/2 z-20 mb-1 -translate-x-1/2 whitespace-nowrap rounded bg-gray-900 dark:bg-slate-700 px-2 py-1 text-xs text-white opacity-0 transition-opacity group-hover:visible group-hover:opacity-100"
                           >
                             {expiryTooltip(key)}
                           </span>
@@ -371,7 +388,7 @@ export function ApiKeysPage() {
                       </span>
                       <svg
                         aria-hidden="true"
-                        className={`h-4 w-4 text-gray-400 transition-transform ${isOpen ? "rotate-180" : ""}`}
+                        className={`h-4 w-4 text-gray-400 dark:text-slate-500 transition-transform ${isOpen ? "rotate-180" : ""}`}
                         viewBox="0 0 20 20"
                         fill="currentColor"
                       >
@@ -387,18 +404,18 @@ export function ApiKeysPage() {
                   {isOpen && (
                     <div
                       id={`apikey-details-${key.id}`}
-                      className="border-t border-gray-200 bg-gray-50/60 px-5 py-4"
+                      className="border-t border-gray-200 dark:border-slate-800 bg-gray-50/60 dark:bg-slate-900 px-5 py-4"
                     >
                       {key.labels.length > 0 && (
                         <div className="mb-4">
-                          <div className="text-xs uppercase tracking-wide text-gray-400">
+                          <div className="text-xs uppercase tracking-wide text-gray-400 dark:text-slate-500">
                             Labels
                           </div>
                           <div className="mt-1 flex flex-wrap gap-1">
                             {key.labels.map((label) => (
                               <span
                                 key={label}
-                                className="rounded-full bg-indigo-50 px-2 py-0.5 text-xs text-indigo-700"
+                                className="rounded-full bg-indigo-50 dark:bg-indigo-950/40 px-2 py-0.5 text-xs text-indigo-700 dark:text-indigo-300"
                               >
                                 {label}
                               </span>
@@ -408,26 +425,26 @@ export function ApiKeysPage() {
                       )}
                       <dl className="grid grid-cols-2 gap-x-6 gap-y-3 text-sm sm:grid-cols-3">
                         <div>
-                          <dt className="text-xs uppercase tracking-wide text-gray-400">
+                          <dt className="text-xs uppercase tracking-wide text-gray-400 dark:text-slate-500">
                             TTL
                           </dt>
-                          <dd className="mt-0.5 font-mono text-gray-800">
+                          <dd className="mt-0.5 font-mono text-gray-800 dark:text-slate-200">
                             {key.ttl}
                           </dd>
                         </div>
                         <div>
-                          <dt className="text-xs uppercase tracking-wide text-gray-400">
+                          <dt className="text-xs uppercase tracking-wide text-gray-400 dark:text-slate-500">
                             Created
                           </dt>
-                          <dd className="mt-0.5 text-gray-700">
+                          <dd className="mt-0.5 text-gray-700 dark:text-slate-300">
                             {timeAgo(key.created_at)}
                           </dd>
                         </div>
                         <div>
-                          <dt className="text-xs uppercase tracking-wide text-gray-400">
+                          <dt className="text-xs uppercase tracking-wide text-gray-400 dark:text-slate-500">
                             Last used
                           </dt>
-                          <dd className="mt-0.5 text-gray-700">
+                          <dd className="mt-0.5 text-gray-700 dark:text-slate-300">
                             {key.last_used_at
                               ? timeAgo(key.last_used_at)
                               : "never"}
@@ -441,7 +458,7 @@ export function ApiKeysPage() {
                             onClick={() =>
                               setRevokePrompt({ id: key.id, name: key.name })
                             }
-                            className="inline-flex items-center gap-1.5 rounded-lg border border-red-200 bg-white px-3 py-1.5 text-sm font-medium text-red-700 hover:bg-red-50"
+                            className="inline-flex items-center gap-1.5 rounded-lg border border-red-200 dark:border-red-800 bg-white dark:bg-slate-900 px-3 py-1.5 text-sm font-medium text-red-700 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-950/30"
                           >
                             <svg
                               aria-hidden="true"
@@ -475,18 +492,18 @@ export function ApiKeysPage() {
           aria-labelledby="created-key-heading"
           className="fixed inset-0 z-10 flex items-center justify-center bg-black/40 p-4"
         >
-          <div className="w-full max-w-lg rounded-lg bg-white p-6 shadow-xl">
+          <div className="w-full max-w-lg rounded-lg bg-white dark:bg-slate-900 p-6 shadow-xl">
             <h3
               id="created-key-heading"
-              className="text-lg font-semibold text-gray-900"
+              className="text-lg font-semibold text-gray-900 dark:text-slate-100"
             >
               Your new API key
             </h3>
-            <p className="mt-2 text-sm text-gray-600">
+            <p className="mt-2 text-sm text-gray-600 dark:text-slate-400">
               Copy this token now. It will not be shown again.
             </p>
-            <div className="mt-4 flex items-center gap-2 rounded-md bg-gray-100 p-3">
-              <code className="flex-1 break-all text-sm">
+            <div className="mt-4 flex items-center gap-2 rounded-md bg-gray-100 dark:bg-slate-800 p-3">
+              <code className="flex-1 break-all text-sm text-gray-900 dark:text-slate-100">
                 {createdKey.token}
               </code>
               <button
@@ -497,7 +514,7 @@ export function ApiKeysPage() {
                 {copied ? "Copied" : "Copy"}
               </button>
             </div>
-            <label className="mt-4 flex items-center gap-2 text-sm text-gray-700">
+            <label className="mt-4 flex items-center gap-2 text-sm text-gray-700 dark:text-slate-300">
               <input
                 type="checkbox"
                 checked={acknowledged}
@@ -526,14 +543,14 @@ export function ApiKeysPage() {
           aria-labelledby="revoke-key-heading"
           className="fixed inset-0 z-10 flex items-center justify-center bg-black/40 p-4"
         >
-          <div className="w-full max-w-md rounded-lg bg-white p-6 shadow-xl">
+          <div className="w-full max-w-md rounded-lg bg-white dark:bg-slate-900 p-6 shadow-xl">
             <h3
               id="revoke-key-heading"
-              className="text-lg font-semibold text-gray-900"
+              className="text-lg font-semibold text-gray-900 dark:text-slate-100"
             >
               Revoke &ldquo;{revokePrompt.name}&rdquo;?
             </h3>
-            <p className="mt-2 text-sm text-gray-600">
+            <p className="mt-2 text-sm text-gray-600 dark:text-slate-400">
               Clients using this key will start receiving 401 responses
               immediately. This cannot be undone.
             </p>
@@ -542,7 +559,7 @@ export function ApiKeysPage() {
                 type="button"
                 onClick={() => setRevokePrompt(null)}
                 disabled={revoking}
-                className="rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+                className="rounded-lg border border-gray-300 dark:border-slate-700 bg-white dark:bg-slate-800 px-4 py-2 text-sm font-medium text-gray-700 dark:text-slate-300 hover:bg-gray-50 dark:hover:bg-slate-700 disabled:opacity-50"
               >
                 Cancel
               </button>

--- a/server/frontend/src/pages/DashboardPage.tsx
+++ b/server/frontend/src/pages/DashboardPage.tsx
@@ -16,9 +16,9 @@ import {
 } from "../components/FilteredListModal"
 import { KnowledgeUnitModal } from "../components/KnowledgeUnitModal"
 import { StatusBadge } from "../components/StatusBadge"
+import { useIsDark } from "../hooks/useIsDark"
 import type { ReviewStatsResponse } from "../types"
 import { timeAgo } from "../utils"
-import { useIsDark } from "../hooks/useIsDark"
 
 const CONFIDENCE_COLORS: Record<string, string> = {
   "0.0-0.3": "bg-red-200",
@@ -26,7 +26,6 @@ const CONFIDENCE_COLORS: Record<string, string> = {
   "0.6-0.8": "bg-green-200",
   "0.8-1.0": "bg-green-400",
 }
-
 
 export function DashboardPage() {
   const { setPendingCount } = useOutletContext<{
@@ -267,7 +266,9 @@ export function DashboardPage() {
                       fontSize: "12px",
                     }}
                   />
-                  <Legend wrapperStyle={{ fontSize: 11, color: chartColors.legend }} />
+                  <Legend
+                    wrapperStyle={{ fontSize: 11, color: chartColors.legend }}
+                  />
                   <Line
                     type="monotone"
                     dataKey="proposed"

--- a/server/frontend/src/pages/DashboardPage.tsx
+++ b/server/frontend/src/pages/DashboardPage.tsx
@@ -98,7 +98,7 @@ export function DashboardPage() {
         {[1, 2].map((i) => (
           <div
             key={i}
-            className="bg-white dark:bg-slate-900 rounded-lg border border-gray-200 dark:border-slate-800 p-4 h-40 animate-pulse bg-gray-100 dark:bg-slate-800"
+            className="bg-gray-100 dark:bg-slate-800 rounded-lg border border-gray-200 dark:border-slate-800 p-4 h-40 animate-pulse"
           />
         ))}
       </div>

--- a/server/frontend/src/pages/DashboardPage.tsx
+++ b/server/frontend/src/pages/DashboardPage.tsx
@@ -62,17 +62,17 @@ export function DashboardPage() {
           {[1, 2, 3].map((i) => (
             <div
               key={i}
-              className="bg-white rounded-lg border border-gray-200 p-4"
+              className="bg-white dark:bg-slate-900 rounded-lg border border-gray-200 dark:border-slate-800 p-4"
             >
-              <div className="h-4 w-16 animate-pulse bg-gray-200 rounded mb-2" />
-              <div className="h-8 w-12 animate-pulse bg-gray-200 rounded" />
+              <div className="h-4 w-16 animate-pulse bg-gray-200 dark:bg-slate-700 rounded mb-2" />
+              <div className="h-8 w-12 animate-pulse bg-gray-200 dark:bg-slate-700 rounded" />
             </div>
           ))}
         </div>
         {[1, 2].map((i) => (
           <div
             key={i}
-            className="bg-white rounded-lg border border-gray-200 p-4 h-40 animate-pulse bg-gray-100"
+            className="bg-white dark:bg-slate-900 rounded-lg border border-gray-200 dark:border-slate-800 p-4 h-40 animate-pulse bg-gray-100 dark:bg-slate-800"
           />
         ))}
       </div>
@@ -82,8 +82,10 @@ export function DashboardPage() {
   return (
     <div className="space-y-6">
       {error && (
-        <div className="bg-red-50 border border-red-200 rounded-lg p-4 text-center">
-          <p className="text-red-600 text-sm font-medium">{error}</p>
+        <div className="bg-red-50 dark:bg-red-950/50 border border-red-200 dark:border-red-800 rounded-lg p-4 text-center">
+          <p className="text-red-600 dark:text-red-400 text-sm font-medium">
+            {error}
+          </p>
         </div>
       )}
 
@@ -92,36 +94,42 @@ export function DashboardPage() {
           <div className="grid grid-cols-3 gap-4">
             <Link
               to="/review"
-              className="bg-white rounded-lg border border-gray-200 p-4 text-center hover:border-amber-300 transition-colors"
+              className="bg-white dark:bg-slate-900 rounded-lg border border-gray-200 dark:border-slate-800 p-4 text-center hover:border-amber-300 dark:hover:border-amber-600 transition-colors"
             >
               <p className="text-3xl font-bold text-amber-500">
                 {stats.counts.pending}
               </p>
-              <p className="text-xs text-gray-500 uppercase mt-1">Pending</p>
+              <p className="text-xs text-gray-500 dark:text-slate-400 uppercase mt-1">
+                Pending
+              </p>
             </Link>
-            <div className="bg-white rounded-lg border border-gray-200 p-4 text-center">
-              <p className="text-3xl font-bold text-green-600">
+            <div className="bg-white dark:bg-slate-900 rounded-lg border border-gray-200 dark:border-slate-800 p-4 text-center">
+              <p className="text-3xl font-bold text-green-600 dark:text-green-400">
                 {stats.counts.approved}
               </p>
-              <p className="text-xs text-gray-500 uppercase mt-1">Approved</p>
+              <p className="text-xs text-gray-500 dark:text-slate-400 uppercase mt-1">
+                Approved
+              </p>
             </div>
             <button
               type="button"
-              className="bg-white rounded-lg border border-gray-200 p-4 text-center hover:border-red-300 transition-colors w-full"
+              className="bg-white dark:bg-slate-900 rounded-lg border border-gray-200 dark:border-slate-800 p-4 text-center hover:border-red-300 dark:hover:border-red-600 transition-colors w-full"
               onClick={() =>
                 setListFilter({ title: "Rejected", status: "rejected" })
               }
             >
-              <p className="text-3xl font-bold text-red-600">
+              <p className="text-3xl font-bold text-red-600 dark:text-red-400">
                 {stats.counts.rejected}
               </p>
-              <p className="text-xs text-gray-500 uppercase mt-1">Rejected</p>
+              <p className="text-xs text-gray-500 dark:text-slate-400 uppercase mt-1">
+                Rejected
+              </p>
             </button>
           </div>
 
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div className="bg-white rounded-lg border border-gray-200 p-4">
-              <h3 className="text-xs font-semibold text-gray-500 uppercase mb-3">
+            <div className="bg-white dark:bg-slate-900 rounded-lg border border-gray-200 dark:border-slate-800 p-4">
+              <h3 className="text-xs font-semibold text-gray-500 dark:text-slate-400 uppercase mb-3">
                 Domains
               </h3>
               <div className="space-y-3 max-h-48 overflow-y-auto">
@@ -133,7 +141,7 @@ export function DashboardPage() {
                       <button
                         type="button"
                         key={domain}
-                        className="flex items-center gap-3 w-full text-left rounded hover:bg-indigo-50 transition-colors -mx-1 px-1"
+                        className="flex items-center gap-3 w-full text-left rounded hover:bg-indigo-50 dark:hover:bg-indigo-950/40 transition-colors -mx-1 px-1"
                         onClick={() =>
                           setListFilter({
                             title: `Domain: ${domain}`,
@@ -142,16 +150,16 @@ export function DashboardPage() {
                           })
                         }
                       >
-                        <span className="text-sm text-gray-700 w-24 truncate">
+                        <span className="text-sm text-gray-700 dark:text-slate-300 w-24 truncate">
                           {domain}
                         </span>
-                        <div className="flex-1 h-1.5 bg-gray-100 rounded-full overflow-hidden">
+                        <div className="flex-1 h-1.5 bg-gray-100 dark:bg-slate-700 rounded-full overflow-hidden">
                           <div
                             className="h-full bg-indigo-500 rounded-full"
                             style={{ width: `${(count / maxCount) * 100}%` }}
                           />
                         </div>
-                        <span className="text-xs text-gray-400 w-6 text-right">
+                        <span className="text-xs text-gray-400 dark:text-slate-500 w-6 text-right">
                           {count}
                         </span>
                       </button>
@@ -160,8 +168,8 @@ export function DashboardPage() {
               </div>
             </div>
 
-            <div className="bg-white rounded-lg border border-gray-200 p-4">
-              <h3 className="text-xs font-semibold text-gray-500 uppercase mb-3">
+            <div className="bg-white dark:bg-slate-900 rounded-lg border border-gray-200 dark:border-slate-800 p-4">
+              <h3 className="text-xs font-semibold text-gray-500 dark:text-slate-400 uppercase mb-3">
                 Confidence
               </h3>
               {(() => {
@@ -179,7 +187,7 @@ export function DashboardPage() {
                           <button
                             type="button"
                             key={bucket}
-                            className="flex-1 flex flex-col items-center gap-1 rounded hover:bg-gray-50 transition-colors cursor-pointer"
+                            className="flex-1 flex flex-col items-center gap-1 rounded hover:bg-gray-50 dark:hover:bg-slate-800 transition-colors cursor-pointer"
                             disabled={count === 0}
                             onClick={() =>
                               setListFilter({
@@ -190,12 +198,12 @@ export function DashboardPage() {
                               })
                             }
                           >
-                            <span className="text-xs text-gray-500 font-medium">
+                            <span className="text-xs text-gray-500 dark:text-slate-400 font-medium">
                               {count}
                             </span>
                             <div className="w-full h-24 flex items-end">
                               <div
-                                className={`w-full rounded-t ${CONFIDENCE_COLORS[bucket] ?? "bg-gray-200"}`}
+                                className={`w-full rounded-t ${CONFIDENCE_COLORS[bucket] ?? "bg-gray-200 dark:bg-slate-600"}`}
                                 style={{
                                   height:
                                     maxCount > 0
@@ -205,7 +213,7 @@ export function DashboardPage() {
                                 }}
                               />
                             </div>
-                            <span className="text-[10px] text-gray-500 truncate w-full text-center">
+                            <span className="text-[10px] text-gray-500 dark:text-slate-400 truncate w-full text-center">
                               {bucket}
                             </span>
                           </button>
@@ -218,21 +226,37 @@ export function DashboardPage() {
             </div>
           </div>
 
-          <div className="bg-white rounded-lg border border-gray-200 p-4">
-            <h3 className="text-xs font-semibold text-gray-500 uppercase mb-3">
+          <div className="bg-white dark:bg-slate-900 rounded-lg border border-gray-200 dark:border-slate-800 p-4">
+            <h3 className="text-xs font-semibold text-gray-500 dark:text-slate-400 uppercase mb-3">
               Submissions
             </h3>
             {trendData.length === 0 ? (
-              <p className="text-gray-400 text-sm text-center py-8">
+              <p className="text-gray-400 dark:text-slate-500 text-sm text-center py-8">
                 No submission data yet
               </p>
             ) : (
               <ResponsiveContainer width="100%" height={200}>
                 <LineChart data={trendData}>
-                  <XAxis dataKey="date" tick={{ fontSize: 10 }} />
-                  <YAxis tick={{ fontSize: 10 }} allowDecimals={false} />
-                  <Tooltip />
-                  <Legend wrapperStyle={{ fontSize: 11 }} />
+                  <XAxis
+                    dataKey="date"
+                    tick={{ fontSize: 10, fill: "#94a3b8" }}
+                    stroke="#475569"
+                  />
+                  <YAxis
+                    tick={{ fontSize: 10, fill: "#94a3b8" }}
+                    stroke="#475569"
+                    allowDecimals={false}
+                  />
+                  <Tooltip
+                    contentStyle={{
+                      backgroundColor: "#1e293b",
+                      border: "1px solid #334155",
+                      borderRadius: "6px",
+                      color: "#f1f5f9",
+                      fontSize: "12px",
+                    }}
+                  />
+                  <Legend wrapperStyle={{ fontSize: 11, color: "#cbd5e1" }} />
                   <Line
                     type="monotone"
                     dataKey="proposed"
@@ -262,16 +286,18 @@ export function DashboardPage() {
             )}
           </div>
 
-          <div className="bg-white rounded-lg border border-gray-200 p-4">
-            <h3 className="text-xs font-semibold text-gray-500 uppercase mb-3">
+          <div className="bg-white dark:bg-slate-900 rounded-lg border border-gray-200 dark:border-slate-800 p-4">
+            <h3 className="text-xs font-semibold text-gray-500 dark:text-slate-400 uppercase mb-3">
               Recent Activity
             </h3>
             <div className="max-h-60 overflow-y-auto">
               {stats.recent_activity.length === 0 ? (
-                <p className="text-gray-400 text-sm">No activity yet</p>
+                <p className="text-gray-400 dark:text-slate-500 text-sm">
+                  No activity yet
+                </p>
               ) : (
                 <ul>
-                  <li className="grid grid-cols-[5rem_1fr_5rem_4rem] gap-3 border-b border-gray-200 py-1.5 text-[10px] font-semibold text-gray-400 uppercase">
+                  <li className="grid grid-cols-[5rem_1fr_5rem_4rem] gap-3 border-b border-gray-200 dark:border-slate-800 py-1.5 text-[10px] font-semibold text-gray-400 dark:text-slate-500 uppercase">
                     <span>Status</span>
                     <span>Summary</span>
                     <span className="text-right">Reviewer</span>
@@ -282,18 +308,18 @@ export function DashboardPage() {
                       <button
                         type="button"
                         onClick={() => setSelectedUnitId(event.unit_id)}
-                        className="grid grid-cols-[5rem_1fr_5rem_4rem] gap-3 items-center w-full text-left border-b border-gray-50 last:border-0 cursor-pointer hover:bg-gray-50 transition-colors py-2"
+                        className="grid grid-cols-[5rem_1fr_5rem_4rem] gap-3 items-center w-full text-left border-b border-gray-50 dark:border-slate-800/50 last:border-0 cursor-pointer hover:bg-gray-50 dark:hover:bg-slate-800 transition-colors py-2"
                       >
                         <span>
                           <StatusBadge status={event.type} />
                         </span>
-                        <span className="text-sm text-gray-700 truncate min-w-0">
+                        <span className="text-sm text-gray-700 dark:text-slate-300 truncate min-w-0">
                           {event.summary}
                         </span>
-                        <span className="text-xs text-gray-400 whitespace-nowrap text-right">
+                        <span className="text-xs text-gray-400 dark:text-slate-500 whitespace-nowrap text-right">
                           {event.reviewed_by ?? ""}
                         </span>
-                        <span className="text-xs text-gray-400 whitespace-nowrap text-right">
+                        <span className="text-xs text-gray-400 dark:text-slate-500 whitespace-nowrap text-right">
                           {event.timestamp ? timeAgo(event.timestamp) : ""}
                         </span>
                       </button>

--- a/server/frontend/src/pages/DashboardPage.tsx
+++ b/server/frontend/src/pages/DashboardPage.tsx
@@ -26,6 +26,23 @@ const CONFIDENCE_COLORS: Record<string, string> = {
   "0.8-1.0": "bg-green-400",
 }
 
+function useIsDark() {
+  const [isDark, setIsDark] = useState(
+    document.documentElement.classList.contains("dark"),
+  )
+  useEffect(() => {
+    const observer = new MutationObserver(() => {
+      setIsDark(document.documentElement.classList.contains("dark"))
+    })
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    })
+    return () => observer.disconnect()
+  }, [])
+  return isDark
+}
+
 export function DashboardPage() {
   const { setPendingCount } = useOutletContext<{
     setPendingCount: (n: number) => void
@@ -36,6 +53,15 @@ export function DashboardPage() {
   const [listFilter, setListFilter] = useState<ListFilter | null>(null)
   const closeModal = useCallback(() => setSelectedUnitId(null), [])
   const closeListModal = useCallback(() => setListFilter(null), [])
+  const isDark = useIsDark()
+  const chartColors = {
+    axis: isDark ? "#94a3b8" : "#64748b",
+    grid: isDark ? "#475569" : "#cbd5e1",
+    tooltipBg: isDark ? "#1e293b" : "#ffffff",
+    tooltipBorder: isDark ? "#334155" : "#e2e8f0",
+    tooltipText: isDark ? "#f1f5f9" : "#1e293b",
+    legend: isDark ? "#cbd5e1" : "#475569",
+  }
 
   useEffect(() => {
     function fetchStats() {
@@ -239,24 +265,24 @@ export function DashboardPage() {
                 <LineChart data={trendData}>
                   <XAxis
                     dataKey="date"
-                    tick={{ fontSize: 10, fill: "#94a3b8" }}
-                    stroke="#475569"
+                    tick={{ fontSize: 10, fill: chartColors.axis }}
+                    stroke={chartColors.grid}
                   />
                   <YAxis
-                    tick={{ fontSize: 10, fill: "#94a3b8" }}
-                    stroke="#475569"
+                    tick={{ fontSize: 10, fill: chartColors.axis }}
+                    stroke={chartColors.grid}
                     allowDecimals={false}
                   />
                   <Tooltip
                     contentStyle={{
-                      backgroundColor: "#1e293b",
-                      border: "1px solid #334155",
+                      backgroundColor: chartColors.tooltipBg,
+                      border: `1px solid ${chartColors.tooltipBorder}`,
                       borderRadius: "6px",
-                      color: "#f1f5f9",
+                      color: chartColors.tooltipText,
                       fontSize: "12px",
                     }}
                   />
-                  <Legend wrapperStyle={{ fontSize: 11, color: "#cbd5e1" }} />
+                  <Legend wrapperStyle={{ fontSize: 11, color: chartColors.legend }} />
                   <Line
                     type="monotone"
                     dataKey="proposed"

--- a/server/frontend/src/pages/DashboardPage.tsx
+++ b/server/frontend/src/pages/DashboardPage.tsx
@@ -18,6 +18,7 @@ import { KnowledgeUnitModal } from "../components/KnowledgeUnitModal"
 import { StatusBadge } from "../components/StatusBadge"
 import type { ReviewStatsResponse } from "../types"
 import { timeAgo } from "../utils"
+import { useIsDark } from "../hooks/useIsDark"
 
 const CONFIDENCE_COLORS: Record<string, string> = {
   "0.0-0.3": "bg-red-200",
@@ -26,22 +27,6 @@ const CONFIDENCE_COLORS: Record<string, string> = {
   "0.8-1.0": "bg-green-400",
 }
 
-function useIsDark() {
-  const [isDark, setIsDark] = useState(
-    document.documentElement.classList.contains("dark"),
-  )
-  useEffect(() => {
-    const observer = new MutationObserver(() => {
-      setIsDark(document.documentElement.classList.contains("dark"))
-    })
-    observer.observe(document.documentElement, {
-      attributes: true,
-      attributeFilter: ["class"],
-    })
-    return () => observer.disconnect()
-  }, [])
-  return isDark
-}
 
 export function DashboardPage() {
   const { setPendingCount } = useOutletContext<{

--- a/server/frontend/src/pages/LoginPage.tsx
+++ b/server/frontend/src/pages/LoginPage.tsx
@@ -22,34 +22,40 @@ export function LoginPage() {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-slate-950">
       <form
         onSubmit={handleSubmit}
-        className="bg-white p-8 rounded-lg shadow-sm border border-gray-200 w-full max-w-sm"
+        className="bg-white dark:bg-slate-900 p-8 rounded-lg shadow-sm border border-gray-200 dark:border-slate-800 w-full max-w-sm"
       >
-        <h1 className="text-3xl font-bold mb-6 text-center text-indigo-600">
+        <h1 className="text-3xl font-bold mb-6 text-center text-indigo-600 dark:text-indigo-400">
           cq
         </h1>
         {error && (
-          <p className="text-red-600 text-sm mb-4 text-center">{error}</p>
+          <p className="text-red-600 dark:text-red-400 text-sm mb-4 text-center">
+            {error}
+          </p>
         )}
         <label className="block mb-4">
-          <span className="text-sm font-medium text-gray-700">Username</span>
+          <span className="text-sm font-medium text-gray-700 dark:text-slate-300">
+            Username
+          </span>
           <input
             type="text"
             value={username}
             onChange={(e) => setUsername(e.target.value)}
-            className="mt-1 block w-full rounded-lg border border-gray-300 px-3 py-2 focus:border-indigo-500 focus:ring-indigo-500"
+            className="mt-1 block w-full rounded-lg border border-gray-300 dark:border-slate-700 bg-white dark:bg-slate-800 text-gray-900 dark:text-slate-100 px-3 py-2 focus:border-indigo-500 focus:ring-indigo-500"
             required
           />
         </label>
         <label className="block mb-6">
-          <span className="text-sm font-medium text-gray-700">Password</span>
+          <span className="text-sm font-medium text-gray-700 dark:text-slate-300">
+            Password
+          </span>
           <input
             type="password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
-            className="mt-1 block w-full rounded-lg border border-gray-300 px-3 py-2 focus:border-indigo-500 focus:ring-indigo-500"
+            className="mt-1 block w-full rounded-lg border border-gray-300 dark:border-slate-700 bg-white dark:bg-slate-800 text-gray-900 dark:text-slate-100 px-3 py-2 focus:border-indigo-500 focus:ring-indigo-500"
             required
           />
         </label>

--- a/server/frontend/src/pages/ReviewPage.tsx
+++ b/server/frontend/src/pages/ReviewPage.tsx
@@ -162,7 +162,9 @@ export function ReviewPage() {
     const hasSkipped = skippedIds.current.size > 0
     return (
       <div className="max-w-xl mx-auto border-2 border-gray-200 dark:border-slate-700 rounded-lg bg-white dark:bg-slate-900 p-10 text-center mt-8">
-        <div className="text-4xl mb-3">{hasSkipped ? "\u23ed" : "\u2713"}</div>
+        <div className={`text-4xl mb-3 ${hasSkipped ? "text-amber-500 dark:text-amber-400" : "text-green-600 dark:text-green-400"}`}>
+          {hasSkipped ? "\u23ed" : "\u2713"}
+        </div>
         <h2 className="text-lg font-semibold text-gray-900 dark:text-slate-100 mb-1">
           {hasSkipped ? "All remaining skipped" : "All caught up"}
         </h2>

--- a/server/frontend/src/pages/ReviewPage.tsx
+++ b/server/frontend/src/pages/ReviewPage.tsx
@@ -162,7 +162,9 @@ export function ReviewPage() {
     const hasSkipped = skippedIds.current.size > 0
     return (
       <div className="max-w-xl mx-auto border-2 border-gray-200 dark:border-slate-700 rounded-lg bg-white dark:bg-slate-900 p-10 text-center mt-8">
-        <div className={`text-4xl mb-3 ${hasSkipped ? "text-amber-500 dark:text-amber-400" : "text-green-600 dark:text-green-400"}`}>
+        <div
+          className={`text-4xl mb-3 ${hasSkipped ? "text-amber-500 dark:text-amber-400" : "text-green-600 dark:text-green-400"}`}
+        >
           {hasSkipped ? "\u23ed" : "\u2713"}
         </div>
         <h2 className="text-lg font-semibold text-gray-900 dark:text-slate-100 mb-1">

--- a/server/frontend/src/pages/ReviewPage.tsx
+++ b/server/frontend/src/pages/ReviewPage.tsx
@@ -161,26 +161,30 @@ export function ReviewPage() {
     const total = sessionApproved + sessionRejected
     const hasSkipped = skippedIds.current.size > 0
     return (
-      <div className="max-w-xl mx-auto border-2 border-gray-200 rounded-lg bg-white p-10 text-center mt-8">
+      <div className="max-w-xl mx-auto border-2 border-gray-200 dark:border-slate-700 rounded-lg bg-white dark:bg-slate-900 p-10 text-center mt-8">
         <div className="text-4xl mb-3">{hasSkipped ? "\u23ed" : "\u2713"}</div>
-        <h2 className="text-lg font-semibold text-gray-900 mb-1">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-slate-100 mb-1">
           {hasSkipped ? "All remaining skipped" : "All caught up"}
         </h2>
         {hasSkipped && (
-          <p className="text-gray-500">
+          <p className="text-gray-500 dark:text-slate-400">
             {skippedIds.current.size} skipped{" "}
             {skippedIds.current.size === 1 ? "item" : "items"} still pending
           </p>
         )}
         {total > 0 && (
           <>
-            <p className="text-gray-500">You've reviewed {total} KUs today</p>
+            <p className="text-gray-500 dark:text-slate-400">
+              You've reviewed {total} KUs today
+            </p>
             <div className="flex gap-4 justify-center mt-3 text-sm">
-              <span className="text-red-600 font-medium">
+              <span className="text-red-600 dark:text-red-400 font-medium">
                 {sessionRejected} rejected
               </span>
-              <span className="text-gray-300">{"\u00b7"}</span>
-              <span className="text-green-600 font-medium">
+              <span className="text-gray-300 dark:text-slate-600">
+                {"\u00b7"}
+              </span>
+              <span className="text-green-600 dark:text-green-400 font-medium">
                 {sessionApproved} approved
               </span>
             </div>
@@ -193,14 +197,14 @@ export function ReviewPage() {
               skippedIds.current.clear()
               fetchNext()
             }}
-            className="inline-block mt-5 text-sm font-medium text-indigo-500 hover:text-indigo-700"
+            className="inline-block mt-5 text-sm font-medium text-indigo-500 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300"
           >
             Review skipped items
           </button>
         )}
         <Link
           to="/dashboard"
-          className="inline-block mt-5 text-sm font-medium text-indigo-500 ml-4"
+          className="inline-block mt-5 text-sm font-medium text-indigo-500 dark:text-indigo-400 ml-4"
         >
           View dashboard {"\u2192"}
         </Link>
@@ -211,7 +215,7 @@ export function ReviewPage() {
   return (
     <div>
       {conflictMessage && (
-        <p className="text-center text-amber-600 text-sm font-medium mb-3">
+        <p className="text-center text-amber-600 dark:text-amber-400 text-sm font-medium mb-3">
           {conflictMessage}
         </p>
       )}
@@ -234,7 +238,9 @@ export function ReviewPage() {
       />
 
       {error && (
-        <p className="text-center text-red-600 text-sm mt-3">{error}</p>
+        <p className="text-center text-red-600 dark:text-red-400 text-sm mt-3">
+          {error}
+        </p>
       )}
     </div>
   )

--- a/server/frontend/src/utils.ts
+++ b/server/frontend/src/utils.ts
@@ -24,3 +24,10 @@ export function timeUntil(iso: string): string {
 export function secondsUntil(iso: string): number {
   return Math.floor((new Date(iso).getTime() - Date.now()) / 1000)
 }
+
+export function confidenceColor(c: number): string {
+  if (c < 0.3) return "text-red-600 dark:text-red-400"
+  if (c < 0.5) return "text-amber-600 dark:text-amber-400"
+  if (c < 0.7) return "text-yellow-500 dark:text-yellow-400"
+  return "text-green-600 dark:text-green-400"
+}


### PR DESCRIPTION
## Summary

This PR implements comprehensive dark mode support across the cq web dashboard, including theme persistence and system preference detection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added full dark mode support, with instant theme application on load and a header toggle that persists your preference.
* **Style**
  * Updated dark-mode styling across the app: badges, modals, cards, lists, forms, navigation, buttons, and tooltips.
  * Enhanced dashboard visuals for dark mode, including chart theming and progress/bucket indicators.
  * Improved consistency for confidence and status colouring, plus refined text contrast and truncation in dark mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->