### PR TITLE
feat: add extensions slot to KnowledgeUnit schema

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -37,4 +37,4 @@ require (
 
 // Monorepo: the SDK is consumed locally. Re-pin to a published version
 // when the SDK is released alongside the CLI.
-//replace github.com/mozilla-ai/cq/sdk/go => ../sdk/go
+replace github.com/mozilla-ai/cq/sdk/go => ../sdk/go

--- a/cli/mcpserver/propose.go
+++ b/cli/mcpserver/propose.go
@@ -75,9 +75,11 @@ func (s *Server) HandlePropose(ctx context.Context, req mcp.CallToolRequest) (*m
 
 	var extensions map[string]any
 	if raw, ok := req.GetArguments()["extensions"]; ok {
-		if m, ok := raw.(map[string]any); ok {
-			extensions = m
+		m, ok := raw.(map[string]any)
+		if !ok {
+			return mcp.NewToolResultError("extensions must be an object"), nil
 		}
+		extensions = m
 	}
 
 	if err := cq.ValidateExtensionKeys(extensions); err != nil {

--- a/cli/mcpserver/propose.go
+++ b/cli/mcpserver/propose.go
@@ -41,6 +41,13 @@ func ProposeTool() mcp.Tool {
 			mcp.WithStringItems(),
 		),
 		mcp.WithString("pattern", mcp.Description("Pattern name.")),
+		mcp.WithObject(
+			"extensions",
+			mcp.Description(
+				"Implementation-specific fields. Keys MUST use namespace:key format (e.g., myimpl:severity).",
+			),
+			func(schema map[string]any) { schema["additionalProperties"] = true },
+		),
 	)
 }
 
@@ -66,6 +73,17 @@ func (s *Server) HandlePropose(ctx context.Context, req mcp.CallToolRequest) (*m
 		return mcp.NewToolResultError("domains must contain at least one tag"), nil
 	}
 
+	var extensions map[string]any
+	if raw, ok := req.GetArguments()["extensions"]; ok {
+		if m, ok := raw.(map[string]any); ok {
+			extensions = m
+		}
+	}
+
+	if err := cq.ValidateExtensionKeys(extensions); err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
 	params := cq.ProposeParams{
 		Summary:    summary,
 		Detail:     detail,
@@ -74,6 +92,7 @@ func (s *Server) HandlePropose(ctx context.Context, req mcp.CallToolRequest) (*m
 		Languages:  req.GetStringSlice("languages", nil),
 		Frameworks: req.GetStringSlice("frameworks", nil),
 		Pattern:    req.GetString("pattern", ""),
+		Extensions: extensions,
 	}
 
 	result, err := s.client.Propose(ctx, params)

--- a/cli/mcpserver/propose_test.go
+++ b/cli/mcpserver/propose_test.go
@@ -234,6 +234,27 @@ func TestHandlePropose(t *testing.T) {
 		require.Contains(t, result.Content[0].(mcp.TextContent).Text, "namespace:key")
 	})
 
+	t.Run("rejects non-object extensions argument", func(t *testing.T) {
+		t.Parallel()
+
+		s := New(&mockClient{}, "test")
+		result, err := s.HandlePropose(context.Background(), mcp.CallToolRequest{
+			Params: mcp.CallToolParams{
+				Name: "propose",
+				Arguments: map[string]any{
+					"summary":    "s",
+					"detail":     "d",
+					"action":     "a",
+					"domains":    []any{"api"},
+					"extensions": []any{"not", "an", "object"},
+				},
+			},
+		})
+		require.NoError(t, err)
+		require.True(t, result.IsError)
+		require.Contains(t, result.Content[0].(mcp.TextContent).Text, "extensions must be an object")
+	})
+
 	t.Run("empty domains slice yields distinct message", func(t *testing.T) {
 		t.Parallel()
 

--- a/cli/mcpserver/propose_test.go
+++ b/cli/mcpserver/propose_test.go
@@ -51,6 +51,36 @@ func TestHandlePropose(t *testing.T) {
 		require.Equal(t, "ku_0123456789abcdef0123456789abcdef", ku.ID)
 	})
 
+	t.Run("passes extensions through to propose params", func(t *testing.T) {
+		t.Parallel()
+
+		var got cq.ProposeParams
+		s := New(&mockClient{
+			proposeFn: func(_ context.Context, params cq.ProposeParams) (cq.KnowledgeUnit, error) {
+				got = params
+				return cq.KnowledgeUnit{ID: "ku_0123456789abcdef0123456789abcdef"}, nil
+			},
+		}, "test")
+
+		result, err := s.HandlePropose(context.Background(), mcp.CallToolRequest{
+			Params: mcp.CallToolParams{
+				Name: "propose",
+				Arguments: map[string]any{
+					"summary": "s",
+					"detail":  "d",
+					"action":  "a",
+					"domains": []any{"api"},
+					"extensions": map[string]any{
+						"cq:severity": "high",
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+		require.False(t, result.IsError)
+		require.Equal(t, map[string]any{"cq:severity": "high"}, got.Extensions)
+	})
+
 	t.Run("errors when required fields are missing", func(t *testing.T) {
 		t.Parallel()
 
@@ -179,6 +209,29 @@ func TestHandlePropose(t *testing.T) {
 		require.Contains(t, text, "warning: stored locally after remote failure")
 		require.Contains(t, text, "remote API rejected request (401): Invalid API key")
 		require.Contains(t, text, "ku_fedcba9876543210fedcba9876543210")
+	})
+
+	t.Run("rejects invalid extension keys with tool error", func(t *testing.T) {
+		t.Parallel()
+
+		s := New(&mockClient{}, "test")
+		result, err := s.HandlePropose(context.Background(), mcp.CallToolRequest{
+			Params: mcp.CallToolParams{
+				Name: "propose",
+				Arguments: map[string]any{
+					"summary": "s",
+					"detail":  "d",
+					"action":  "a",
+					"domains": []any{"api"},
+					"extensions": map[string]any{
+						"bad-key": "value",
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+		require.True(t, result.IsError)
+		require.Contains(t, result.Content[0].(mcp.TextContent).Text, "namespace:key")
 	})
 
 	t.Run("empty domains slice yields distinct message", func(t *testing.T) {

--- a/schema/fixtures/extensions-unit.json
+++ b/schema/fixtures/extensions-unit.json
@@ -1,0 +1,28 @@
+{
+  "id": "ku_00000000000000000000000000000004",
+  "version": 1,
+  "domains": ["api", "error-handling"],
+  "insight": {
+    "summary": "Rate limiter returns 429 with Retry-After header",
+    "detail": "The Retry-After value is in seconds, not milliseconds.",
+    "action": "Parse Retry-After as integer seconds and sleep accordingly."
+  },
+  "context": {
+    "languages": ["go"],
+    "frameworks": [],
+    "pattern": "api-integration"
+  },
+  "evidence": {
+    "confidence": 0.8,
+    "confirmations": 4,
+    "first_observed": "2026-01-10T08:00:00Z",
+    "last_confirmed": "2026-04-15T16:30:00Z"
+  },
+  "tier": "private",
+  "created_by": "agent:cq-review",
+  "extensions": {
+    "cq:severity": "high",
+    "cq:category": "rate-limiting"
+  },
+  "flags": []
+}

--- a/schema/knowledge_unit.json
+++ b/schema/knowledge_unit.json
@@ -36,6 +36,7 @@
       "pattern": "^ku_[0-9a-f]{32}$",
       "description": "ID of the replacing knowledge unit, if any."
     },
+    "extensions": { "$ref": "#/$defs/Extensions" },
     "flags": {
       "type": "array",
       "items": { "$ref": "#/$defs/Flag" },
@@ -44,6 +45,15 @@
   },
   "additionalProperties": false,
   "$defs": {
+    "Extensions": {
+      "type": "object",
+      "description": "Implementation-specific fields. Not portable across implementations; consumers MUST ignore unknown keys and MUST NOT rely on their presence. Keys MUST use namespace:key format with a lowercase implementation slug.",
+      "patternProperties": {
+        "^[a-z0-9][a-z0-9_-]*:\\S+$": true
+      },
+      "additionalProperties": false,
+      "maxProperties": 20
+    },
     "Tier": {
       "type": "string",
       "enum": ["local", "private", "public"],

--- a/schema/propose.json
+++ b/schema/propose.json
@@ -14,6 +14,7 @@
     },
     "insight": { "$ref": "knowledge_unit.json#/$defs/Insight" },
     "context": { "$ref": "knowledge_unit.json#/$defs/Context" },
+    "extensions": { "$ref": "knowledge_unit.json#/$defs/Extensions" },
     "created_by": {
       "type": "string",
       "description": "Identifier of the agent or user proposing this unit."

--- a/schema/python/tests/test_cq_schema.py
+++ b/schema/python/tests/test_cq_schema.py
@@ -105,6 +105,18 @@ def test_extensions_reject_unnamespaced_keys(bad_key: str) -> None:
         jsonschema.validate(instance=instance, schema=schema)
 
 
+def test_extensions_reject_more_than_twenty_keys() -> None:
+    schema = cq_schema.load_schema("knowledge_unit")
+    instance = {
+        "id": "ku_00000000000000000000000000000099",
+        "domains": ["test"],
+        "insight": {"summary": "s", "detail": "d", "action": "a"},
+        "extensions": {f"ns:key{i}": i for i in range(21)},
+    }
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=instance, schema=schema)
+
+
 def test_extensions_accept_namespaced_keys() -> None:
     schema = cq_schema.load_schema("knowledge_unit")
     instance = {

--- a/schema/python/tests/test_cq_schema.py
+++ b/schema/python/tests/test_cq_schema.py
@@ -69,6 +69,52 @@ def test_scoring_values_validates_against_scoring_schema() -> None:
 def test_knowledge_unit_fixtures_validate() -> None:
     schema = cq_schema.load_schema("knowledge_unit")
     fixtures_dir = Path(__file__).resolve().parent.parent.parent / "fixtures"
-    for fixture_name in ("valid-unit.json", "minimal-unit.json", "flagged-unit.json", "duplicate-flag.json"):
+    for fixture_name in (
+        "valid-unit.json",
+        "minimal-unit.json",
+        "flagged-unit.json",
+        "duplicate-flag.json",
+        "extensions-unit.json",
+    ):
         instance = json.loads((fixtures_dir / fixture_name).read_text(encoding="utf-8"))
         jsonschema.validate(instance=instance, schema=schema)
+
+
+@pytest.mark.parametrize(
+    "bad_key",
+    [
+        "no-namespace",
+        ":missing-slug",
+        "MixedCase:key",
+        "",
+        "impl: space-value",
+        "impl:has space",
+        "impl:\ttab-value",
+        "impl: ",
+    ],
+)
+def test_extensions_reject_unnamespaced_keys(bad_key: str) -> None:
+    schema = cq_schema.load_schema("knowledge_unit")
+    instance = {
+        "id": "ku_00000000000000000000000000000099",
+        "domains": ["test"],
+        "insight": {"summary": "s", "detail": "d", "action": "a"},
+        "extensions": {bad_key: "value"},
+    }
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=instance, schema=schema)
+
+
+def test_extensions_accept_namespaced_keys() -> None:
+    schema = cq_schema.load_schema("knowledge_unit")
+    instance = {
+        "id": "ku_00000000000000000000000000000099",
+        "domains": ["test"],
+        "insight": {"summary": "s", "detail": "d", "action": "a"},
+        "extensions": {
+            "impl:key": "string-value",
+            "my-impl:nested": {"a": 1},
+            "x0:flag": True,
+        },
+    }
+    jsonschema.validate(instance=instance, schema=schema)

--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -287,6 +287,10 @@ func (c *Client) Propose(ctx context.Context, params ProposeParams) (KnowledgeUn
 		return KnowledgeUnit{}, err
 	}
 
+	if err := ValidateExtensionKeys(params.Extensions); err != nil {
+		return KnowledgeUnit{}, err
+	}
+
 	ku := KnowledgeUnit{
 		ID:      GenerateID(),
 		Version: defaultKnowledgeUnitVersion,
@@ -305,8 +309,9 @@ func (c *Client) Propose(ctx context.Context, params ProposeParams) (KnowledgeUn
 			Confidence:    defaultEvidenceConfidence,
 			Confirmations: defaultEvidenceConfirmations,
 		},
-		Tier:      Local,
-		CreatedBy: params.CreatedBy,
+		Tier:       Local,
+		CreatedBy:  params.CreatedBy,
+		Extensions: params.Extensions,
 	}
 
 	var remoteErr error

--- a/sdk/go/client_test.go
+++ b/sdk/go/client_test.go
@@ -162,6 +162,54 @@ func TestPropose(t *testing.T) {
 	require.InDelta(t, 0.5, ku.Evidence.Confidence, 0.001)
 }
 
+func TestProposeWithExtensions(t *testing.T) {
+	c := newTestClient(t)
+	ctx := context.Background()
+
+	ext := map[string]any{
+		"cq:severity": "high",
+		"cq:category": "rate-limiting",
+	}
+	ku, err := c.Propose(ctx, ProposeParams{
+		Summary: "Rate limit", Detail: "429.", Action: "Retry.",
+		Domains: []string{"api"}, Extensions: ext,
+	})
+	require.NoError(t, err)
+	require.Equal(t, ext, ku.Extensions)
+
+	qr, err := c.Query(ctx, QueryParams{Domains: []string{"api"}})
+	require.NoError(t, err)
+	require.Len(t, qr.Units, 1)
+	require.Equal(t, "high", qr.Units[0].Extensions["cq:severity"])
+	require.Equal(t, "rate-limiting", qr.Units[0].Extensions["cq:category"])
+}
+
+func TestProposeRejectsInvalidExtensionKeys(t *testing.T) {
+	c := newTestClient(t)
+
+	_, err := c.Propose(context.Background(), ProposeParams{
+		Summary: "S", Detail: "D.", Action: "A.", Domains: []string{"test"},
+		Extensions: map[string]any{"bad-key": "value"},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "namespace:key")
+}
+
+func TestProposeWithoutExtensionsOmitsField(t *testing.T) {
+	c := newTestClient(t)
+	ctx := context.Background()
+
+	ku, err := c.Propose(ctx, ProposeParams{
+		Summary: "No ext", Detail: "D.", Action: "A.", Domains: []string{"test"},
+	})
+	require.NoError(t, err)
+	require.Nil(t, ku.Extensions)
+
+	data, err := json.Marshal(ku)
+	require.NoError(t, err)
+	require.NotContains(t, string(data), "extensions")
+}
+
 func TestConfirm(t *testing.T) {
 	c := newTestClient(t)
 	ctx := context.Background()

--- a/sdk/go/extensions.go
+++ b/sdk/go/extensions.go
@@ -1,0 +1,19 @@
+package cq
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// extensionKeyPattern matches the required namespace:key format for extension keys.
+var extensionKeyPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9_-]*:\S+$`)
+
+// ValidateExtensionKeys checks that every key in extensions uses namespace:key format.
+func ValidateExtensionKeys(extensions map[string]any) error {
+	for k := range extensions {
+		if !extensionKeyPattern.MatchString(k) {
+			return fmt.Errorf("extension key %s must match namespace:key format (e.g. myimpl:field)", k)
+		}
+	}
+	return nil
+}

--- a/sdk/go/extensions_test.go
+++ b/sdk/go/extensions_test.go
@@ -1,0 +1,180 @@
+package cq
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateExtensionKeys(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		key     string
+		wantErr bool
+	}{
+		{
+			name:    "simple namespaced key",
+			key:     "impl:key",
+			wantErr: false,
+		},
+		{
+			name:    "cq namespace",
+			key:     "cq:severity",
+			wantErr: false,
+		},
+		{
+			name:    "hyphenated namespace",
+			key:     "my-impl:nested-key",
+			wantErr: false,
+		},
+		{
+			name:    "digit in namespace",
+			key:     "x0:flag",
+			wantErr: false,
+		},
+		{
+			name:    "minimal single chars",
+			key:     "a:b",
+			wantErr: false,
+		},
+		{
+			name:    "underscore in namespace",
+			key:     "abc_def:ghi",
+			wantErr: false,
+		},
+		{
+			name:    "digits after first char",
+			key:     "tool123:config",
+			wantErr: false,
+		},
+		{
+			name:    "dashes in value",
+			key:     "impl:key-with-dashes",
+			wantErr: false,
+		},
+		{
+			name:    "underscores in value",
+			key:     "impl:key_with_underscores",
+			wantErr: false,
+		},
+		{
+			name:    "dots in value",
+			key:     "impl:key.with.dots",
+			wantErr: false,
+		},
+		{
+			name:    "slashes in value",
+			key:     "impl:key/with/slashes",
+			wantErr: false,
+		},
+		{
+			name:    "numeric value",
+			key:     "impl:123",
+			wantErr: false,
+		},
+		{
+			name:    "uppercase in value",
+			key:     "ns:UPPER-value",
+			wantErr: false,
+		},
+		{
+			name:    "missing colon",
+			key:     "no-namespace",
+			wantErr: true,
+		},
+		{
+			name:    "empty namespace",
+			key:     ":missing-slug",
+			wantErr: true,
+		},
+		{
+			name:    "uppercase namespace",
+			key:     "MixedCase:key",
+			wantErr: true,
+		},
+		{
+			name:    "empty string",
+			key:     "",
+			wantErr: true,
+		},
+		{
+			name:    "all uppercase namespace",
+			key:     "UPPER:key",
+			wantErr: true,
+		},
+		{
+			name:    "namespace starts with dash",
+			key:     "-starts-with-dash:key",
+			wantErr: true,
+		},
+		{
+			name:    "namespace starts with underscore",
+			key:     "_starts-with-underscore:key",
+			wantErr: true,
+		},
+		{
+			name:    "empty value after colon",
+			key:     "impl:",
+			wantErr: true,
+		},
+		{
+			name:    "leading space in namespace",
+			key:     " space:key",
+			wantErr: true,
+		},
+		{
+			name:    "leading space in value",
+			key:     "impl: space-value",
+			wantErr: true,
+		},
+		{
+			name:    "embedded space in value",
+			key:     "impl:has space",
+			wantErr: true,
+		},
+		{
+			name:    "tab in value",
+			key:     "impl:\ttab-value",
+			wantErr: true,
+		},
+		{
+			name:    "newline in value",
+			key:     "impl:new\nline",
+			wantErr: true,
+		},
+		{
+			name:    "space-only value",
+			key:     "impl: ",
+			wantErr: true,
+		},
+		{
+			name:    "space in namespace",
+			key:     "a b:key",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateExtensionKeys(map[string]any{tc.key: "v"})
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateExtensionKeysNilMapIsValid(t *testing.T) {
+	t.Parallel()
+	require.NoError(t, ValidateExtensionKeys(nil))
+}
+
+func TestValidateExtensionKeysEmptyMapIsValid(t *testing.T) {
+	t.Parallel()
+	require.NoError(t, ValidateExtensionKeys(map[string]any{}))
+}

--- a/sdk/go/remote.go
+++ b/sdk/go/remote.go
@@ -180,6 +180,9 @@ func (r *remoteClient) propose(ctx context.Context, ku KnowledgeUnit) (Knowledge
 		},
 		"created_by": ku.CreatedBy,
 	}
+	if len(ku.Extensions) > 0 {
+		body["extensions"] = ku.Extensions
+	}
 
 	proposeURL, err := r.url(ctx, "/knowledge")
 	if err != nil {

--- a/sdk/go/types.go
+++ b/sdk/go/types.go
@@ -46,16 +46,17 @@ type Insight struct {
 
 // KnowledgeUnit is a single piece of agent knowledge.
 type KnowledgeUnit struct {
-	ID           string   `json:"id"`
-	Version      int32    `json:"version"`
-	Domains      []string `json:"domains"`
-	Insight      Insight  `json:"insight"`
-	Context      Context  `json:"context"`
-	Evidence     Evidence `json:"evidence"`
-	Tier         Tier     `json:"tier"`
-	CreatedBy    string   `json:"created_by"`
-	SupersededBy string   `json:"superseded_by,omitempty"`
-	Flags        []Flag   `json:"flags"`
+	ID           string         `json:"id"`
+	Version      int32          `json:"version"`
+	Domains      []string       `json:"domains"`
+	Insight      Insight        `json:"insight"`
+	Context      Context        `json:"context"`
+	Evidence     Evidence       `json:"evidence"`
+	Tier         Tier           `json:"tier"`
+	CreatedBy    string         `json:"created_by"`
+	SupersededBy string         `json:"superseded_by,omitempty"`
+	Extensions   map[string]any `json:"extensions,omitempty"`
+	Flags        []Flag         `json:"flags"`
 }
 
 // ProposeParams describes a new knowledge unit to create.
@@ -64,10 +65,11 @@ type ProposeParams struct {
 	Detail     string
 	Action     string
 	Domains    []string
-	Languages  []string // Optional.
-	Frameworks []string // Optional.
-	Pattern    string   // Optional.
-	CreatedBy  string   // Optional.
+	Languages  []string       // Optional.
+	Frameworks []string       // Optional.
+	Pattern    string         // Optional.
+	CreatedBy  string         // Optional.
+	Extensions map[string]any // Optional.
 }
 
 // QueryParams configures a knowledge unit search.

--- a/sdk/python/src/cq/models.py
+++ b/sdk/python/src/cq/models.py
@@ -4,6 +4,7 @@ import re
 import uuid
 from datetime import UTC, datetime
 from enum import StrEnum
+from typing import Any
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
@@ -11,6 +12,7 @@ from ._util import _as_list
 
 _KU_ID_PREFIX = "ku_"
 _KU_ID_PATTERN = re.compile(r"^ku_[0-9a-f]{32}$")
+_EXTENSION_KEY_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_-]*:\S+$")
 
 
 class Tier(StrEnum):
@@ -102,6 +104,7 @@ class KnowledgeUnit(BaseModel):
     tier: Tier = Tier.LOCAL
     created_by: str = ""
     superseded_by: str | None = None
+    extensions: dict[str, Any] | None = None
     flags: list[Flag] = Field(default_factory=list)
 
     @field_validator("id")
@@ -120,6 +123,17 @@ class KnowledgeUnit(BaseModel):
             raise ValueError(f"superseded_by must match {_KU_ID_PATTERN.pattern}, got: {v!r}")
         return v
 
+    @field_validator("extensions")
+    @classmethod
+    def _validate_extension_keys(cls, v: dict[str, Any] | None) -> dict[str, Any] | None:
+        """Enforce namespace:key format on extension keys."""
+        if v is None:
+            return v
+        bad = [k for k in v if not _EXTENSION_KEY_PATTERN.match(k)]
+        if bad:
+            raise ValueError(f"extension keys must match namespace:key format, got: {bad}")
+        return v
+
 
 def _generate_ku_id() -> str:
     """Generate a prefixed UUID for knowledge unit identification."""
@@ -131,6 +145,7 @@ def create_knowledge_unit(
     domains: list[str],
     insight: Insight,
     context: Context | None = None,
+    extensions: dict[str, Any] | None = None,
     tier: Tier = Tier.LOCAL,
     created_by: str = "",
 ) -> KnowledgeUnit:
@@ -141,6 +156,7 @@ def create_knowledge_unit(
         domains=domains,
         insight=insight,
         context=context or Context(),
+        extensions=extensions,
         tier=tier,
         created_by=created_by,
     )

--- a/sdk/python/tests/test_models.py
+++ b/sdk/python/tests/test_models.py
@@ -239,6 +239,55 @@ class TestFlagModel:
         assert FlagReason.DUPLICATE == "duplicate"
 
 
+class TestExtensionKeyValidation:
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "impl:key",
+            "cq:severity",
+            "my-impl:nested-key",
+            "a:b",
+            "abc_def:ghi",
+            "tool123:config",
+            "impl:key.with.dots",
+            "ns:UPPER-value",
+        ],
+    )
+    def test_accepts_valid_extension_keys(self, key):
+        unit = _make_unit(extensions={key: "v"})
+        assert key in unit.extensions
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "no-namespace",
+            ":missing-slug",
+            "MixedCase:key",
+            "",
+            "UPPER:key",
+            "-starts-with-dash:key",
+            "_starts-with-underscore:key",
+            "impl:",
+            " space:key",
+            "impl: space-value",
+            "impl:has space",
+            "impl:\ttab-value",
+            "impl: ",
+        ],
+    )
+    def test_rejects_invalid_extension_keys(self, key):
+        with pytest.raises(ValidationError):
+            _make_unit(extensions={key: "v"})
+
+    def test_accepts_none_extensions(self):
+        unit = _make_unit()
+        assert unit.extensions is None
+
+    def test_accepts_empty_extensions(self):
+        unit = _make_unit(extensions={})
+        assert unit.extensions == {}
+
+
 class TestTierEnum:
     def test_tier_values(self):
         assert Tier.LOCAL == "local"

--- a/sdk/python/tests/test_schema_oracle.py
+++ b/sdk/python/tests/test_schema_oracle.py
@@ -63,6 +63,18 @@ def test_full_knowledge_unit_validates_against_canonical_schema() -> None:
     jsonschema.validate(instance=payload, schema=schema)
 
 
+def test_knowledge_unit_with_extensions_validates_against_canonical_schema() -> None:
+    unit = create_knowledge_unit(
+        domains=["api"],
+        insight=Insight(summary="s", detail="d", action="a"),
+    )
+    unit = unit.model_copy(update={"extensions": {"impl:severity": "high", "impl:tags": ["a", "b"]}})
+    schema = cq_schema.load_schema("knowledge_unit")
+    payload = json.loads(unit.model_dump_json(exclude_none=True))
+    jsonschema.validate(instance=payload, schema=schema)
+    assert payload["extensions"] == {"impl:severity": "high", "impl:tags": ["a", "b"]}
+
+
 def test_minimal_knowledge_unit_validates_against_canonical_schema() -> None:
     unit = create_knowledge_unit(
         domains=["databases"],

--- a/server/backend/src/cq_server/api/routes/knowledge.py
+++ b/server/backend/src/cq_server/api/routes/knowledge.py
@@ -5,7 +5,7 @@ from typing import Annotated
 from cq.models import KnowledgeUnit
 from fastapi import APIRouter, Query, status
 
-from ...exceptions import InvalidDomainError, KnowledgeUnitNotFoundError, ServiceError
+from ...exceptions import InvalidDomainError, KnowledgeUnitNotFoundError, ServiceError, ValidationError
 from ...models.knowledge import FlagRequest, KnowledgeUnitList, ProposeRequest, StatsResponse
 from ..deps import APIKeyAuthDep, KnowledgeServiceDep
 
@@ -17,6 +17,7 @@ def knowledge_exception_mappings() -> dict[type[ServiceError], int]:
     return {
         InvalidDomainError: status.HTTP_422_UNPROCESSABLE_CONTENT,
         KnowledgeUnitNotFoundError: status.HTTP_404_NOT_FOUND,
+        ValidationError: status.HTTP_422_UNPROCESSABLE_CONTENT,
     }
 
 
@@ -60,6 +61,7 @@ async def propose_unit(
         domains=request.domains,
         insight=request.insight,
         context=request.context,
+        extensions=request.extensions,
         created_by=username,
     )
 

--- a/server/backend/src/cq_server/models/knowledge.py
+++ b/server/backend/src/cq_server/models/knowledge.py
@@ -1,5 +1,7 @@
 """Pydantic schemas for /knowledge routes."""
 
+from typing import Any
+
 from cq.models import Context, FlagReason, Insight, KnowledgeUnit
 from pydantic import BaseModel, Field
 
@@ -26,6 +28,7 @@ class ProposeRequest(BaseModel):
     domains: list[str] = Field(min_length=1)
     insight: Insight
     context: Context = Field(default_factory=Context)
+    extensions: dict[str, Any] | None = None
     created_by: str = ""
 
 

--- a/server/backend/src/cq_server/services/knowledge.py
+++ b/server/backend/src/cq_server/services/knowledge.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from cq.models import Context, FlagReason, Insight, KnowledgeUnit, Tier, create_knowledge_unit
 from cq.scoring import apply_confirmation, apply_flag
+from pydantic import ValidationError as PydanticValidationError
 
-from ..exceptions import InvalidDomainError, KnowledgeUnitNotFoundError
+from ..exceptions import InvalidDomainError, KnowledgeUnitNotFoundError, ValidationError
 from ..models.knowledge import StatsResponse
 from ..repositories import KnowledgeRepository, normalize_domains
 
@@ -49,6 +52,7 @@ class KnowledgeService:
         domains: list[str],
         insight: Insight,
         context: Context,
+        extensions: dict[str, Any] | None = None,
         created_by: str,
     ) -> KnowledgeUnit:
         """Create + persist a new knowledge unit owned by ``created_by``.
@@ -62,13 +66,17 @@ class KnowledgeService:
         normalized = normalize_domains(domains)
         if not normalized:
             raise InvalidDomainError()
-        unit = create_knowledge_unit(
-            domains=normalized,
-            insight=insight,
-            context=context,
-            tier=Tier.PRIVATE,
-            created_by=created_by,
-        )
+        try:
+            unit = create_knowledge_unit(
+                domains=normalized,
+                insight=insight,
+                context=context,
+                extensions=extensions,
+                tier=Tier.PRIVATE,
+                created_by=created_by,
+            )
+        except PydanticValidationError as exc:
+            raise ValidationError(str(exc)) from exc
         await self._knowledge.insert(unit)
         return unit
 

--- a/server/backend/tests/test_app.py
+++ b/server/backend/tests/test_app.py
@@ -131,6 +131,17 @@ class TestPropose:
         assert resp.status_code == 201
         assert resp.json()["domains"] == ["api", "databases"]
 
+    def test_propose_with_extensions(self, client: TestClient) -> None:
+        payload = _propose_payload(extensions={"impl:severity": "high"})
+        resp = client.post("/api/v1/knowledge", json=payload)
+        assert resp.status_code == 201
+        assert resp.json()["extensions"] == {"impl:severity": "high"}
+
+    def test_propose_rejects_unnamespaced_extension_keys(self, client: TestClient) -> None:
+        payload = _propose_payload(extensions={"bad-key": "value"})
+        resp = client.post("/api/v1/knowledge", json=payload)
+        assert resp.status_code == 422
+
 
 class TestQuery:
     def _insert_unit(self, client: TestClient, **overrides: Any) -> dict[str, Any]:

--- a/server/backend/tests/test_schema_oracle.py
+++ b/server/backend/tests/test_schema_oracle.py
@@ -39,6 +39,18 @@ def test_full_knowledge_unit_validates_against_canonical_schema() -> None:
     jsonschema.validate(instance=payload, schema=schema)
 
 
+def test_knowledge_unit_with_extensions_validates_against_canonical_schema() -> None:
+    unit = create_knowledge_unit(
+        domains=["api"],
+        insight=Insight(summary="s", detail="d", action="a"),
+        extensions={"impl:severity": "high"},
+    )
+    schema = cq_schema.load_schema("knowledge_unit")
+    payload = json.loads(unit.model_dump_json(exclude_none=True))
+    jsonschema.validate(instance=payload, schema=schema)
+    assert payload["extensions"] == {"impl:severity": "high"}
+
+
 def test_minimal_knowledge_unit_validates_against_canonical_schema() -> None:
     unit = create_knowledge_unit(
         domains=["databases"],


### PR DESCRIPTION
## Summary

- Add an optional `extensions` field to `KnowledgeUnit` as the single escape hatch from `additionalProperties: false`, allowing implementation-specific fields with namespaced keys (`namespace:key` format)
- Enforce key format (`^[a-z0-9][a-z0-9_-]*:\S+$`) in all SDK layers (Go, Python, CLI handler) so consumers without the server get the same guarantees
- Server relies on SDK validation rather than duplicating it; service layer catches SDK `ValidationError` and maps to 422

## Test plan

- [x] Table-driven extension key validation tests in Go SDK (valid keys, invalid keys including whitespace edge cases)
- [x] Parameterized extension key validation tests in Python SDK
- [x] Schema-as-oracle tests validate serialized models against canonical JSON Schema
- [x] CLI MCP handler test for bad key rejection
- [x] Server integration tests for propose with/without extensions and bad key rejection
- [x] Schema-level tests for fixture validation and bad key rejection via `patternProperties`
- [x] `make lint` and `make test` pass (server `ty` requires local SDK install during development)

Closes #411

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional `extensions` support on knowledge units, validated using `namespace:key` keys
  * Extensions can now be provided when proposing knowledge units via the server API, CLI, and SDKs

* **Bug Fixes**
  * Improved request handling to validate `extensions` and return clear `422` errors for invalid formats

* **Tests**
  * Expanded coverage across Go, Python, and backend API tests, including schema-oracle checks

* **Chores**
  * Updated CLI module resolution to use the local SDK copy during builds
<!-- end of auto-generated comment: release notes by coderabbit.ai -->