### PR TITLE
test: preview hint block version badges

### DIFF
--- a/cli/DEVELOPMENT.md
+++ b/cli/DEVELOPMENT.md
@@ -1,6 +1,8 @@
 # Development
 
-*Version: v0.14.0*
+{% hint style="info" %}
+Version: v0.14.0
+{% endhint %}
 
 ## Requirements
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,6 +1,8 @@
 # cq CLI
 
-*Version: v0.14.0*
+{% hint style="info" %}
+Version: v0.14.0
+{% endhint %}
 
 Command-line interface for [cq](https://github.com/mozilla-ai/cq) — the
 shared agent knowledge commons. Also runs as an

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,6 +1,8 @@
 # cq Plugin
 
-*Version: 0.13.0*
+{% hint style="info" %}
+Version: 0.13.0
+{% endhint %}
 
 Agent plugin for [cq](https://github.com/mozilla-ai/cq) — the shared agent knowledge commons. Bundles the MCP server, the cq protocol skill, and session commands (`/cq:status`, `/cq:reflect`) so your coding agent can query, propose, confirm, and flag knowledge units during normal work.
 

--- a/schema/README.md
+++ b/schema/README.md
@@ -1,6 +1,8 @@
 # Schema Reference
 
-*Version: v0.2.0*
+{% hint style="info" %}
+Version: v0.2.0
+{% endhint %}
 
 Canonical [JSON Schema](https://json-schema.org/draft/2020-12/schema) definitions for the cq wire protocol. Every SDK, server, and plugin implementation validates against these schemas; they are the single source of truth for the shapes that cross process and network boundaries.
 

--- a/sdk/go/DEVELOPMENT.md
+++ b/sdk/go/DEVELOPMENT.md
@@ -1,6 +1,8 @@
 # Development
 
-*Version: v0.12.1*
+{% hint style="info" %}
+Version: v0.12.1
+{% endhint %}
 
 ## Requirements
 

--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -1,6 +1,8 @@
 # cq Go SDK
 
-*Version: v0.12.1*
+{% hint style="info" %}
+Version: v0.12.1
+{% endhint %}
 
 Go SDK for [cq](https://github.com/mozilla-ai/cq) — the shared agent
 knowledge commons. It stores knowledge units locally in SQLite and

--- a/sdk/python/DEVELOPMENT.md
+++ b/sdk/python/DEVELOPMENT.md
@@ -1,6 +1,8 @@
 # Development
 
-*Version: 0.16.0*
+{% hint style="info" %}
+Version: 0.16.0
+{% endhint %}
 
 ## Requirements
 

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -1,6 +1,8 @@
 # cq-sdk
 
-*Version: 0.16.0*
+{% hint style="info" %}
+Version: 0.16.0
+{% endhint %}
 
 Python SDK for [cq](https://github.com/mozilla-ai/cq) — the shared agent knowledge commons.
 

--- a/server/README.md
+++ b/server/README.md
@@ -1,6 +1,8 @@
 # cq-server backend
 
-*Version: v0.8.0*
+{% hint style="info" %}
+Version: v0.8.0
+{% endhint %}
 
 FastAPI service backing the cq remote store.
 


### PR DESCRIPTION
Temporary PR to test GitBook rendering of hint block version badges.

Replaces `*Version: vX.Y.Z*` (italic, consumed by GitBook as page description metadata) with `{% hint style="info" %}` blocks.

**Close after verifying the GitBook preview renders correctly.**