### PR TITLE
fix(docs): use GitBook hint blocks for version badges

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -8,6 +8,7 @@ on:
       - "docs/**"
       - "**/*.md"
       - "scripts/prepare_gitbook_site.py"
+      - "scripts/test_prepare_gitbook_site.py"
       - "scripts/check_docs.py"
       - ".gitbook.yaml"
       - ".gitbook-branch-readme.md"
@@ -37,6 +38,12 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
+
+      - name: Install test dependencies
+        run: pip install pytest
+
+      - name: Run script tests
+        run: pytest scripts/test_prepare_gitbook_site.py -v
 
       - name: Check documentation links
         run: python scripts/check_docs.py

--- a/scripts/prepare_gitbook_site.py
+++ b/scripts/prepare_gitbook_site.py
@@ -227,7 +227,7 @@ def _inject_version_badge(content: str, version: str) -> str:
             while j < len(lines) and not lines[j].strip():
                 j += 1
             lines[j:j] = [
-                '{% hint style="info" %}',
+                '{% hint style="info" icon="tag" %}',
                 f"Version: {version}",
                 "{% endhint %}",
                 "",

--- a/scripts/prepare_gitbook_site.py
+++ b/scripts/prepare_gitbook_site.py
@@ -226,7 +226,12 @@ def _inject_version_badge(content: str, version: str) -> str:
             j = i + 1
             while j < len(lines) and not lines[j].strip():
                 j += 1
-            lines[j:j] = [f"*Version: {version}*", ""]
+            lines[j:j] = [
+                '{% hint style="info" %}',
+                f"Version: {version}",
+                "{% endhint %}",
+                "",
+            ]
             break
     return "\n".join(lines)
 

--- a/scripts/test_prepare_gitbook_site.py
+++ b/scripts/test_prepare_gitbook_site.py
@@ -9,12 +9,20 @@ class TestInjectVersionBadge:
     def test_inserts_after_heading_with_blank_line(self) -> None:
         content = "# Title\n\nBody text"
         result = _inject_version_badge(content, "1.2.3")
-        assert result == "# Title\n\n*Version: 1.2.3*\n\nBody text"
+        expected = (
+            '# Title\n\n{% hint style="info" icon="tag" %}\n'
+            "Version: 1.2.3\n{% endhint %}\n\nBody text"
+        )
+        assert result == expected
 
     def test_inserts_after_heading_without_blank_line(self) -> None:
         content = "# Title\nBody text"
         result = _inject_version_badge(content, "1.2.3")
-        assert result == "# Title\n*Version: 1.2.3*\n\nBody text"
+        expected = (
+            '# Title\n{% hint style="info" icon="tag" %}\n'
+            "Version: 1.2.3\n{% endhint %}\n\nBody text"
+        )
+        assert result == expected
 
     def test_no_heading_returns_unchanged(self) -> None:
         content = "No heading here"
@@ -24,13 +32,17 @@ class TestInjectVersionBadge:
     def test_only_first_heading_is_modified(self) -> None:
         content = "# First\n\nText\n\n# Second\n\nMore text"
         result = _inject_version_badge(content, "2.0.0")
-        assert result.count("*Version:") == 1
-        assert result.startswith("# First\n\n*Version: 2.0.0*\n\nText")
+        assert result.count("Version: ") == 1
+        assert '{% hint style="info" icon="tag" %}' in result
 
     def test_heading_only_content(self) -> None:
         content = "# Title"
         result = _inject_version_badge(content, "0.1.0")
-        assert result == "# Title\n*Version: 0.1.0*\n"
+        expected = (
+            '# Title\n{% hint style="info" icon="tag" %}\n'
+            "Version: 0.1.0\n{% endhint %}\n"
+        )
+        assert result == expected
 
     def test_h2_not_treated_as_top_level(self) -> None:
         content = "## Subtitle\n\nBody"
@@ -40,5 +52,5 @@ class TestInjectVersionBadge:
     def test_heading_inside_code_fence_is_skipped(self) -> None:
         content = "```\n# Not a heading\n```\n\n# Real heading\n\nBody"
         result = _inject_version_badge(content, "1.0.0")
-        assert "*Version: 1.0.0*" in result
-        assert result.index("*Version: 1.0.0*") > result.index("# Real heading")
+        assert "Version: 1.0.0" in result
+        assert result.index("Version: 1.0.0") > result.index("# Real heading")


### PR DESCRIPTION
## Summary

- Replaces the bare italic `*Version: vX.Y.Z*` with a GitBook `{% hint style="info" %}` block in `_inject_version_badge`; more semantic and renders reliably in GitBook.

## Test plan

- [ ] Merge, create a `docs/v*` release to trigger the deploy workflow
- [ ] Verify version badges render as info hint blocks on the live GitBook site

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the way version information is displayed in GitBook-generated documentation, so release-tagged docs now show a clearer info callout instead of a plain markdown line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->