### PR TITLE
docs: fix broken cq CLI link in plugins/cq/README.md

### DIFF
--- a/plugins/cq/README.md
+++ b/plugins/cq/README.md
@@ -6,7 +6,7 @@ The plugin works with Claude Code, OpenCode, Cursor, Windsurf, and Pi.
 
 ## Installation
 
-Requires: the [cq CLI](../cli/README.md).
+Requires: the [cq CLI](../../cli/README.md).
 
 ```bash
 cq install --target claude


### PR DESCRIPTION
The "cq CLI" link in `plugins/cq/README.md` resolved to `plugins/cli/README.md`, which does not exist, resulting in a 404 on GitHub.

The CLI README lives at `cli/README.md` (top-level). The correct relative path from `plugins/cq/` is `../../cli/README.md`.

## What changed
- `plugins/cq/README.md`: `../cli/README.md` → `../../cli/README.md`

## How to test
Click the [cq CLI](../../cli/README.md) link in `plugins/cq/README.md` on GitHub and confirm it navigates to `cli/README.md` without a 404.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a link in the CQ plugin installation prerequisites so it now points to the proper CLI reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->