### PR TITLE
fix(sdk/python): order Stats.Recent by insertion order, not last_confirmed

### DIFF
--- a/sdk/go/types.go
+++ b/sdk/go/types.go
@@ -108,7 +108,7 @@ type StoreStats struct {
 	// with any units a configured remote reports.
 	DomainCounts map[string]int `json:"domain_counts"`
 
-	// Recent holds the most recently confirmed units from the local store.
+	// Recent holds the most recently added units from the local store.
 	Recent []KnowledgeUnit `json:"recent"`
 
 	// ConfidenceDistribution covers the local store plus any private/org

--- a/sdk/python/src/cq/store.py
+++ b/sdk/python/src/cq/store.py
@@ -81,6 +81,7 @@ class StoreStats(BaseModel):
 
     total_count: int
     domain_counts: dict[str, int] = Field(default_factory=dict)
+    # Most recently added units from the local store.
     recent: list[KnowledgeUnit] = Field(default_factory=list)
     # Covers the local store plus any private/org units a configured remote
     # reports; it excludes the public commons. Keyed by the canonical bucket
@@ -627,16 +628,15 @@ class SqliteStore:
             domain_rows = self._conn.execute(
                 "SELECT domain, COUNT(*) AS cnt FROM knowledge_unit_domains GROUP BY domain ORDER BY cnt DESC"
             ).fetchall()
+            recent_rows = self._conn.execute(
+                "SELECT data FROM knowledge_units ORDER BY rowid DESC LIMIT ?",
+                (recent_limit,),
+            ).fetchall()
             all_rows = self._conn.execute("SELECT data FROM knowledge_units").fetchall()
 
         domain_counts = {row[0]: row[1] for row in domain_rows}
+        recent = [KnowledgeUnit.model_validate_json(row[0]) for row in recent_rows]
         units = [KnowledgeUnit.model_validate_json(row[0]) for row in all_rows]
-
-        units.sort(
-            key=lambda u: u.evidence.last_confirmed or _EPOCH_UTC,
-            reverse=True,
-        )
-        recent = units[:recent_limit]
 
         buckets = {label: 0 for _, label in _CONFIDENCE_BUCKETS}
         for unit in units:

--- a/sdk/python/tests/test_store.py
+++ b/sdk/python/tests/test_store.py
@@ -3,7 +3,6 @@
 import json
 import sqlite3
 from collections.abc import Iterator
-from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -11,7 +10,6 @@ import pytest
 
 from cq.models import (
     Context,
-    Evidence,
     FlagReason,
     Insight,
     KnowledgeUnit,
@@ -831,38 +829,15 @@ class TestStats:
         result = store.stats()
         assert result.domain_counts == {"api": 2, "databases": 2, "payments": 1}
 
-    def test_recent_ordered_by_last_confirmed_descending(self, store: LocalStore):
-        now = datetime.now(UTC)
-        old_unit = _make_unit(
-            domains=["api"],
-            context=Context(languages=["python"]),
-        )
-        old_unit = old_unit.model_copy(
-            update={
-                "evidence": Evidence(
-                    first_observed=now - timedelta(days=10),
-                    last_confirmed=now - timedelta(days=10),
-                ),
-            },
-        )
-        new_unit = _make_unit(
-            domains=["api"],
-            context=Context(languages=["go"]),
-        )
-        new_unit = new_unit.model_copy(
-            update={
-                "evidence": Evidence(
-                    first_observed=now - timedelta(days=1),
-                    last_confirmed=now - timedelta(days=1),
-                ),
-            },
-        )
-        store.insert(old_unit)
-        store.insert(new_unit)
+    def test_recent_ordered_by_insertion_order_descending(self, store: LocalStore):
+        first = _make_unit(domains=["api"], context=Context(languages=["python"]))
+        second = _make_unit(domains=["api"], context=Context(languages=["go"]))
+        store.insert(first)
+        store.insert(second)
         result = store.stats()
         assert len(result.recent) == 2
-        assert result.recent[0].id == new_unit.id
-        assert result.recent[1].id == old_unit.id
+        assert result.recent[0].id == second.id
+        assert result.recent[1].id == first.id
 
     def test_recent_respects_limit(self, store: LocalStore):
         for _ in range(10):


### PR DESCRIPTION
## Summary

- Replace in-memory `last_confirmed` sort with `ORDER BY rowid DESC LIMIT ?` SQL query in the Python SQLite store's `stats()` method, matching all other store implementations
- Update `StoreStats.Recent` docstring in Go (`sdk/go/types.go`) and field comment in Python (`sdk/python/src/cq/store.py`) to say "most recently added"
- Update test to verify insertion order instead of confirmation-date order

## Test plan

- [x] Python SDK tests pass (453 passed)
- [x] Go SDK tests pass
- [x] Python lint clean
- [x] Go lint clean (0 issues)

Fixes #473

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated “recent items” store statistics to represent the most recently **added** units, using insertion order rather than last confirmation time.
  * Existing totals and other breakdowns remain calculated from the full set of stored units.

* **Tests**
  * Updated test expectations and renamed the relevant assertion to verify “recent items” follow insertion order (most recently inserted first).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->