### PR TITLE
fix(sdk): stamp writer metadata on every store mutation

### DIFF
--- a/sdk/go/store_sqlite.go
+++ b/sdk/go/store_sqlite.go
@@ -53,6 +53,12 @@ const (
 	keyLastWriteAt = "last_write_at"
 )
 
+// execer runs a single SQL statement, whether against a database handle
+// directly or within an open transaction.
+type execer interface {
+	Exec(query string, args ...any) (sql.Result, error)
+}
+
 // sqliteStore is a SQLite-backed Store implementation.
 type sqliteStore struct {
 	mu     sync.Mutex
@@ -172,6 +178,10 @@ func (s *sqliteStore) Delete(ctx context.Context, unitID string) error {
 		return fmt.Errorf("unit %q not found", unitID)
 	}
 
+	if err := stampWriter(tx); err != nil {
+		return err
+	}
+
 	return tx.Commit()
 }
 
@@ -218,6 +228,10 @@ func (s *sqliteStore) Insert(ctx context.Context, ku KnowledgeUnit) error {
 	}
 
 	if err := insertFTS(ctx, tx, stored); err != nil {
+		return err
+	}
+
+	if err := stampWriter(tx); err != nil {
 		return err
 	}
 
@@ -518,6 +532,10 @@ func (s *sqliteStore) Update(ctx context.Context, ku KnowledgeUnit) error {
 		return err
 	}
 
+	if err := stampWriter(tx); err != nil {
+		return err
+	}
+
 	return tx.Commit()
 }
 
@@ -593,14 +611,14 @@ func marshalUnit(ku KnowledgeUnit) ([]byte, error) {
 }
 
 // stampWriter updates the last_writer and last_write_at metadata.
-func stampWriter(db *sql.DB) error {
+func stampWriter(e execer) error {
 	now := time.Now().UTC().Format(time.RFC3339)
 	tag := writerTag()
 	for _, kv := range [][2]string{
 		{keyLastWriter, tag},
 		{keyLastWriteAt, now},
 	} {
-		if _, err := db.Exec(
+		if _, err := e.Exec(
 			"INSERT OR REPLACE INTO metadata (key, value) VALUES (?, ?)",
 			kv[0], kv[1],
 		); err != nil {

--- a/sdk/go/store_sqlite.go
+++ b/sdk/go/store_sqlite.go
@@ -56,7 +56,7 @@ const (
 // execer runs a single SQL statement, whether against a database handle
 // directly or within an open transaction.
 type execer interface {
-	Exec(query string, args ...any) (sql.Result, error)
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
 }
 
 // sqliteStore is a SQLite-backed Store implementation.
@@ -87,7 +87,13 @@ func newSQLiteStore(dbPath string) (*sqliteStore, error) {
 		return nil, fmt.Errorf("applying schema: %w", err)
 	}
 
-	if err := ensureMetadata(db); err != nil {
+	if _, err := db.Exec(metadataDDL); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("creating metadata table: %w", err)
+	}
+
+	// Construction has no caller context; stamp with a background context.
+	if err := stampWriter(context.Background(), db); err != nil {
 		_ = db.Close()
 		return nil, err
 	}
@@ -178,7 +184,7 @@ func (s *sqliteStore) Delete(ctx context.Context, unitID string) error {
 		return fmt.Errorf("unit %q not found", unitID)
 	}
 
-	if err := stampWriter(tx); err != nil {
+	if err := stampWriter(ctx, tx); err != nil {
 		return err
 	}
 
@@ -231,7 +237,7 @@ func (s *sqliteStore) Insert(ctx context.Context, ku KnowledgeUnit) error {
 		return err
 	}
 
-	if err := stampWriter(tx); err != nil {
+	if err := stampWriter(ctx, tx); err != nil {
 		return err
 	}
 
@@ -532,7 +538,7 @@ func (s *sqliteStore) Update(ctx context.Context, ku KnowledgeUnit) error {
 		return err
 	}
 
-	if err := stampWriter(tx); err != nil {
+	if err := stampWriter(ctx, tx); err != nil {
 		return err
 	}
 
@@ -562,15 +568,6 @@ func applyPragmas(db *sql.DB) error {
 	}
 
 	return nil
-}
-
-// ensureMetadata creates the metadata table and stamps the writer.
-func ensureMetadata(db *sql.DB) error {
-	if _, err := db.Exec(metadataDDL); err != nil {
-		return fmt.Errorf("creating metadata table: %w", err)
-	}
-
-	return stampWriter(db)
 }
 
 // insertDomains writes domain rows for a unit within an existing transaction.
@@ -611,14 +608,15 @@ func marshalUnit(ku KnowledgeUnit) ([]byte, error) {
 }
 
 // stampWriter updates the last_writer and last_write_at metadata.
-func stampWriter(e execer) error {
+func stampWriter(ctx context.Context, e execer) error {
 	now := time.Now().UTC().Format(time.RFC3339)
 	tag := writerTag()
 	for _, kv := range [][2]string{
 		{keyLastWriter, tag},
 		{keyLastWriteAt, now},
 	} {
-		if _, err := e.Exec(
+		if _, err := e.ExecContext(
+			ctx,
 			"INSERT OR REPLACE INTO metadata (key, value) VALUES (?, ?)",
 			kv[0], kv[1],
 		); err != nil {

--- a/sdk/go/store_sqlite_test.go
+++ b/sdk/go/store_sqlite_test.go
@@ -903,36 +903,41 @@ func TestWriterStampUpdatedOnMutation(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = db.Close() }()
 
-	readTimestamp := func() string {
+	const sentinel = "2000-01-01T00:00:00Z"
+
+	readMetadata := func(key string) string {
 		var v string
-		require.NoError(t, db.QueryRow("SELECT value FROM metadata WHERE key = ?", keyLastWriteAt).Scan(&v))
+		require.NoError(t, db.QueryRow("SELECT value FROM metadata WHERE key = ?", key).Scan(&v))
 		return v
+	}
+
+	// Overwrite both writer keys with a sentinel so we can detect a restamp.
+	staleBothKeys := func() {
+		for _, key := range []string{keyLastWriter, keyLastWriteAt} {
+			_, err := db.Exec("UPDATE metadata SET value = ? WHERE key = ?", sentinel, key)
+			require.NoError(t, err)
+			require.Equal(t, sentinel, readMetadata(key))
+		}
+	}
+
+	// requireRestamped asserts both writer keys moved off the sentinel.
+	requireRestamped := func() {
+		require.NotEqual(t, sentinel, readMetadata(keyLastWriter))
+		require.NotEqual(t, sentinel, readMetadata(keyLastWriteAt))
 	}
 
 	ku := newFakeKU(t, []string{"testing"})
 
-	// Overwrite the timestamp to a known old value so we can detect change.
-	_, err = db.Exec("UPDATE metadata SET value = '2000-01-01T00:00:00Z' WHERE key = ?", keyLastWriteAt)
-	require.NoError(t, err)
-	require.Equal(t, "2000-01-01T00:00:00Z", readTimestamp())
-
-	// Insert should refresh the stamp.
+	staleBothKeys()
 	require.NoError(t, s.Insert(context.Background(), ku))
-	ts := readTimestamp()
-	require.NotEqual(t, "2000-01-01T00:00:00Z", ts)
+	requireRestamped()
 
-	// Reset and verify Update refreshes.
-	_, err = db.Exec("UPDATE metadata SET value = '2000-01-01T00:00:00Z' WHERE key = ?", keyLastWriteAt)
-	require.NoError(t, err)
+	staleBothKeys()
 	ku.Insight.Summary = "updated"
 	require.NoError(t, s.Update(context.Background(), ku))
-	ts = readTimestamp()
-	require.NotEqual(t, "2000-01-01T00:00:00Z", ts)
+	requireRestamped()
 
-	// Reset and verify Delete refreshes.
-	_, err = db.Exec("UPDATE metadata SET value = '2000-01-01T00:00:00Z' WHERE key = ?", keyLastWriteAt)
-	require.NoError(t, err)
+	staleBothKeys()
 	require.NoError(t, s.Delete(context.Background(), ku.ID))
-	ts = readTimestamp()
-	require.NotEqual(t, "2000-01-01T00:00:00Z", ts)
+	requireRestamped()
 }

--- a/sdk/go/store_sqlite_test.go
+++ b/sdk/go/store_sqlite_test.go
@@ -890,3 +890,49 @@ func TestWriterStamp(t *testing.T) {
 	require.NoError(t, db.QueryRow("SELECT value FROM metadata WHERE key = ?", keyLastWriteAt).Scan(&lastWriteAt))
 	require.NotEmpty(t, lastWriteAt)
 }
+
+func TestWriterStampUpdatedOnMutation(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	s, err := newSQLiteStore(dbPath)
+	require.NoError(t, err)
+	defer func() { _ = s.Close() }()
+
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	readTimestamp := func() string {
+		var v string
+		require.NoError(t, db.QueryRow("SELECT value FROM metadata WHERE key = ?", keyLastWriteAt).Scan(&v))
+		return v
+	}
+
+	ku := newFakeKU(t, []string{"testing"})
+
+	// Overwrite the timestamp to a known old value so we can detect change.
+	_, err = db.Exec("UPDATE metadata SET value = '2000-01-01T00:00:00Z' WHERE key = ?", keyLastWriteAt)
+	require.NoError(t, err)
+	require.Equal(t, "2000-01-01T00:00:00Z", readTimestamp())
+
+	// Insert should refresh the stamp.
+	require.NoError(t, s.Insert(context.Background(), ku))
+	ts := readTimestamp()
+	require.NotEqual(t, "2000-01-01T00:00:00Z", ts)
+
+	// Reset and verify Update refreshes.
+	_, err = db.Exec("UPDATE metadata SET value = '2000-01-01T00:00:00Z' WHERE key = ?", keyLastWriteAt)
+	require.NoError(t, err)
+	ku.Insight.Summary = "updated"
+	require.NoError(t, s.Update(context.Background(), ku))
+	ts = readTimestamp()
+	require.NotEqual(t, "2000-01-01T00:00:00Z", ts)
+
+	// Reset and verify Delete refreshes.
+	_, err = db.Exec("UPDATE metadata SET value = '2000-01-01T00:00:00Z' WHERE key = ?", keyLastWriteAt)
+	require.NoError(t, err)
+	require.NoError(t, s.Delete(context.Background(), ku.ID))
+	ts = readTimestamp()
+	require.NotEqual(t, "2000-01-01T00:00:00Z", ts)
+}

--- a/sdk/go/stores/postgres/postgres.go
+++ b/sdk/go/stores/postgres/postgres.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	cq "github.com/mozilla-ai/cq/sdk/go"
@@ -76,6 +77,12 @@ const (
 		INSERT INTO metadata (key, value) VALUES ($1, $2)
 		ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`
 )
+
+// execer runs a single SQL statement, whether against the connection pool
+// directly or within an open transaction.
+type execer interface {
+	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
+}
 
 // Store is a PostgreSQL-backed implementation of cq.Store.
 // All methods are safe for concurrent use.
@@ -143,14 +150,22 @@ func (s *Store) Delete(ctx context.Context, id string) error {
 	if s.closed {
 		return cq.ErrStoreClosed
 	}
-	ct, err := s.pool.Exec(ctx, sqlDeleteUnit, id)
+	tx, err := s.pool.Begin(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("beginning transaction: %w", err)
+	}
+	defer rollback(tx)
+	ct, err := tx.Exec(ctx, sqlDeleteUnit, id)
+	if err != nil {
+		return fmt.Errorf("deleting unit: %w", err)
 	}
 	if ct.RowsAffected() == 0 {
 		return fmt.Errorf("unit %s not found", id)
 	}
-	return nil
+	if err := stampWriter(ctx, tx); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
 }
 
 // Insert stores a new knowledge unit.
@@ -180,6 +195,9 @@ func (s *Store) Insert(ctx context.Context, ku cq.KnowledgeUnit) error {
 		return fmt.Errorf("inserting unit %s: %w", ku.ID, err)
 	}
 	if err := insertDomains(ctx, tx, ku.ID, domains); err != nil {
+		return err
+	}
+	if err := stampWriter(ctx, tx); err != nil {
 		return err
 	}
 	return tx.Commit(ctx)
@@ -303,6 +321,9 @@ func (s *Store) Update(ctx context.Context, ku cq.KnowledgeUnit) error {
 	if err := insertDomains(ctx, tx, ku.ID, domains); err != nil {
 		return err
 	}
+	if err := stampWriter(ctx, tx); err != nil {
+		return err
+	}
 	return tx.Commit(ctx)
 }
 
@@ -349,7 +370,7 @@ func (s *Store) ensureSchema(ctx context.Context) error {
 	if _, err := s.pool.Exec(ctx, schemaDDL); err != nil {
 		return err
 	}
-	return s.stampWriter(ctx)
+	return stampWriter(ctx, s.pool)
 }
 
 // queryDomainCounts returns the number of knowledge units per domain tag.
@@ -396,13 +417,16 @@ func (s *Store) scanUnits(ctx context.Context, sql string, args ...any) ([]cq.Kn
 
 // stampWriter records the SDK version and timestamp in the metadata table
 // so operators can identify which SDK last modified the database.
-func (s *Store) stampWriter(ctx context.Context) error {
+func stampWriter(ctx context.Context, e execer) error {
 	tag := fmt.Sprintf(writerTagFmt, runtime.Version())
 	now := time.Now().UTC().Format(time.RFC3339)
-	batch := &pgx.Batch{}
-	batch.Queue(sqlUpsertMetadata, keyLastWriter, tag)
-	batch.Queue(sqlUpsertMetadata, keyLastWriteAt, now)
-	return s.pool.SendBatch(ctx, batch).Close()
+	if _, err := e.Exec(ctx, sqlUpsertMetadata, keyLastWriter, tag); err != nil {
+		return fmt.Errorf("writing writer metadata: %w", err)
+	}
+	if _, err := e.Exec(ctx, sqlUpsertMetadata, keyLastWriteAt, now); err != nil {
+		return fmt.Errorf("writing timestamp metadata: %w", err)
+	}
+	return nil
 }
 
 // insertDomains writes domain tag rows for a unit within an existing transaction.

--- a/sdk/python/src/cq/store.py
+++ b/sdk/python/src/cq/store.py
@@ -358,10 +358,15 @@ class SqliteStore:
         self._conn.executescript(_SCHEMA_SQL)
         self._conn.executescript(_FTS_SCHEMA_SQL)
         self._conn.executescript(_METADATA_SQL)
-        self._stamp_writer()
+        with self._conn:
+            self._stamp_writer()
 
     def _stamp_writer(self) -> None:
-        """Record this SDK as the last writer for cross-SDK diagnostics."""
+        """Record this SDK as the last writer for cross-SDK diagnostics.
+
+        NOTE: callers must ensure this runs inside a transaction (either an
+        explicit ``with self._conn:`` block or as part of an existing one).
+        """
         import importlib.metadata
         import sys
 
@@ -379,7 +384,6 @@ class SqliteStore:
             "INSERT OR REPLACE INTO metadata (key, value) VALUES (?, ?)",
             ("last_write_at", now),
         )
-        self._conn.commit()
 
     def _check_open(self) -> None:
         """Raise if the store has been closed."""
@@ -441,6 +445,7 @@ class SqliteStore:
                         fts_sql,
                         (unit.id, unit.insight.summary, unit.insight.detail, unit.insight.action),
                     )
+                    self._stamp_writer()
             except sqlite3.IntegrityError as exc:
                 raise DuplicateUnitError(f"Knowledge unit already exists: {unit.id}") from exc
 
@@ -484,6 +489,7 @@ class SqliteStore:
                 )
                 if cursor.rowcount == 0:
                     raise KeyError(f"Knowledge unit not found: {unit_id}")
+                self._stamp_writer()
 
     def update(self, unit: KnowledgeUnit) -> None:
         """Replace an existing knowledge unit in the store.
@@ -523,6 +529,7 @@ class SqliteStore:
                     fts_sql,
                     (unit.id, unit.insight.summary, unit.insight.detail, unit.insight.action),
                 )
+                self._stamp_writer()
 
     def query(self, params: QueryParams) -> StoreQueryResult:
         """Search for knowledge units by domain tags with relevance ranking.

--- a/sdk/python/src/cq/stores/postgres.py
+++ b/sdk/python/src/cq/stores/postgres.py
@@ -138,6 +138,7 @@ class PostgresStore:
                 with self._conn.transaction():
                     self._conn.execute(_SQL_INSERT_UNIT, (unit.id, data))
                     self._insert_domains(unit.id, domains)
+                    self._stamp_writer()
             except psycopg.errors.UniqueViolation as exc:
                 raise DuplicateUnitError(f"Knowledge unit already exists: {unit.id}") from exc
 
@@ -163,6 +164,7 @@ class PostgresStore:
                     raise KeyError(f"Knowledge unit not found: {unit.id}")
                 self._conn.execute(_SQL_DELETE_DOMAINS, (unit.id,))
                 self._insert_domains(unit.id, domains)
+                self._stamp_writer()
 
     def delete(self, unit_id: str) -> None:
         """Remove a knowledge unit by ID.
@@ -172,9 +174,11 @@ class PostgresStore:
         """
         with self._lock:
             self._check_open()
-            cur = self._conn.execute(_SQL_DELETE_UNIT, (unit_id,))
-            if cur.rowcount == 0:
-                raise KeyError(f"Knowledge unit not found: {unit_id}")
+            with self._conn.transaction():
+                cur = self._conn.execute(_SQL_DELETE_UNIT, (unit_id,))
+                if cur.rowcount == 0:
+                    raise KeyError(f"Knowledge unit not found: {unit_id}")
+                self._stamp_writer()
 
     def query(self, params: QueryParams) -> StoreQueryResult:
         """Search for knowledge units by domain tags with relevance ranking.

--- a/sdk/python/tests/test_store.py
+++ b/sdk/python/tests/test_store.py
@@ -1099,6 +1099,24 @@ class TestGoCompatibility:
         assert data["flags"][0]["reason"] == "stale"
 
 
+_WRITER_STAMP_SENTINEL = "2000-01-01T00:00:00"
+
+
+def _stale_writer_keys(store: LocalStore) -> None:
+    """Overwrite both writer-metadata keys with a sentinel so a restamp is detectable."""
+    for key in ("last_writer", "last_write_at"):
+        store._conn.execute("UPDATE metadata SET value = ? WHERE key = ?", (_WRITER_STAMP_SENTINEL, key))
+    store._conn.commit()
+
+
+def _assert_writer_restamped(store: LocalStore) -> None:
+    """Assert both writer-metadata keys moved off the sentinel."""
+    for key in ("last_writer", "last_write_at"):
+        row = store._conn.execute("SELECT value FROM metadata WHERE key = ?", (key,)).fetchone()
+        assert row is not None
+        assert row[0] != _WRITER_STAMP_SENTINEL
+
+
 class TestMetadata:
     """Tests for the metadata table."""
 
@@ -1124,30 +1142,20 @@ class TestMetadata:
         s2.close()
 
     def test_insert_refreshes_writer_stamp(self, store: LocalStore) -> None:
-        store._conn.execute("UPDATE metadata SET value = '2000-01-01T00:00:00' WHERE key = 'last_write_at'")
-        store._conn.commit()
+        _stale_writer_keys(store)
         store.insert(_make_unit())
-        row = store._conn.execute("SELECT value FROM metadata WHERE key = 'last_write_at'").fetchone()
-        assert row is not None
-        assert row[0] != "2000-01-01T00:00:00"
+        _assert_writer_restamped(store)
 
     def test_update_refreshes_writer_stamp(self, store: LocalStore) -> None:
         unit = _make_unit()
         store.insert(unit)
-        store._conn.execute("UPDATE metadata SET value = '2000-01-01T00:00:00' WHERE key = 'last_write_at'")
-        store._conn.commit()
-        updated = unit.model_copy(update={"insight": _make_insight(summary="changed")})
-        store.update(updated)
-        row = store._conn.execute("SELECT value FROM metadata WHERE key = 'last_write_at'").fetchone()
-        assert row is not None
-        assert row[0] != "2000-01-01T00:00:00"
+        _stale_writer_keys(store)
+        store.update(unit.model_copy(update={"insight": _make_insight(summary="changed")}))
+        _assert_writer_restamped(store)
 
     def test_delete_refreshes_writer_stamp(self, store: LocalStore) -> None:
         unit = _make_unit()
         store.insert(unit)
-        store._conn.execute("UPDATE metadata SET value = '2000-01-01T00:00:00' WHERE key = 'last_write_at'")
-        store._conn.commit()
+        _stale_writer_keys(store)
         store.delete(unit.id)
-        row = store._conn.execute("SELECT value FROM metadata WHERE key = 'last_write_at'").fetchone()
-        assert row is not None
-        assert row[0] != "2000-01-01T00:00:00"
+        _assert_writer_restamped(store)

--- a/sdk/python/tests/test_store.py
+++ b/sdk/python/tests/test_store.py
@@ -1122,3 +1122,32 @@ class TestMetadata:
         s1.close()
         s2 = LocalStore(db_path=db_path)
         s2.close()
+
+    def test_insert_refreshes_writer_stamp(self, store: LocalStore) -> None:
+        store._conn.execute("UPDATE metadata SET value = '2000-01-01T00:00:00' WHERE key = 'last_write_at'")
+        store._conn.commit()
+        store.insert(_make_unit())
+        row = store._conn.execute("SELECT value FROM metadata WHERE key = 'last_write_at'").fetchone()
+        assert row is not None
+        assert row[0] != "2000-01-01T00:00:00"
+
+    def test_update_refreshes_writer_stamp(self, store: LocalStore) -> None:
+        unit = _make_unit()
+        store.insert(unit)
+        store._conn.execute("UPDATE metadata SET value = '2000-01-01T00:00:00' WHERE key = 'last_write_at'")
+        store._conn.commit()
+        updated = unit.model_copy(update={"insight": _make_insight(summary="changed")})
+        store.update(updated)
+        row = store._conn.execute("SELECT value FROM metadata WHERE key = 'last_write_at'").fetchone()
+        assert row is not None
+        assert row[0] != "2000-01-01T00:00:00"
+
+    def test_delete_refreshes_writer_stamp(self, store: LocalStore) -> None:
+        unit = _make_unit()
+        store.insert(unit)
+        store._conn.execute("UPDATE metadata SET value = '2000-01-01T00:00:00' WHERE key = 'last_write_at'")
+        store._conn.commit()
+        store.delete(unit.id)
+        row = store._conn.execute("SELECT value FROM metadata WHERE key = 'last_write_at'").fetchone()
+        assert row is not None
+        assert row[0] != "2000-01-01T00:00:00"


### PR DESCRIPTION
## What

The store metadata (`last_writer`, `last_write_at`) was stamped only at store construction, during `ensureSchema`/`ensureMetadata`. After the first connection, every insert/update/delete left the metadata stale — lying about the most recent write. This affected all persistent store implementations across both SDKs (SQLite and PostgreSQL).

For a shared multi-agent PostgreSQL store, operators want this metadata to reflect which agent actually wrote last. This PR stamps the writer on every mutation, inside the same transaction as the mutation itself, so the metadata stays accurate and the stamp is atomic with the write.

## How

- **Go SDK**: `stampWriter` becomes a free function taking a small `execer` interface, satisfied by both a connection/pool and a transaction, so it can run within a mutation's transaction. The PostgreSQL `Delete` is now wrapped in a transaction so the stamp is atomic with the delete.
- **Python SDK**: `_stamp_writer` no longer commits on its own and runs within the caller's transaction. The PostgreSQL `delete` is wrapped in a transaction for the same atomicity.
- In-memory stores are unaffected (they hold no metadata table).

## Testing

- Added Go and Python tests asserting the writer timestamp is refreshed on insert, update, and delete.
- `make lint`: clean (0 issues)
- `make test`: Go 456, Python 308 (+11 skipped), frontend 11 — all pass

Fixes #470

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Write operations now refresh “last writer” metadata across the SQLite, PostgreSQL and Python stores.
  * Insert, update and delete now record the latest write activity more consistently.

* **Bug Fixes**
  * Metadata updates are applied in the same transaction as the data change, improving consistency after successful writes.
  * Delete and update no longer advance write timestamps when no rows are affected.

* **Tests**
  * Added coverage to verify writer-stamp metadata is updated after insert, update and delete operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->