### PR TITLE
perf(sdk): compute confidence buckets in SQL for PostgreSQL stores

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ lint-schema-python: sync-schema
 lint-schema: lint-schema-go lint-schema-python
 
 .PHONY: lint-sdk-go
-lint-sdk-go: check-prompts-sync-sdk-go
+lint-sdk-go: check-prompts-sync-sdk-go lint-sdk-go-postgres
 	cd sdk/go && $(MAKE) lint
 
 .PHONY: lint-sdk-python
@@ -218,11 +218,11 @@ test-schema-python:
 test-schema: test-schema-go test-schema-python
 
 .PHONY: test-sdk-go
-test-sdk-go:
+test-sdk-go: test-sdk-go-postgres
 	cd sdk/go && $(MAKE) test
 
 .PHONY: test-sdk-python
-test-sdk-python:
+test-sdk-python: test-sdk-python-postgres
 	cd sdk/python && $(MAKE) test
 
 .PHONY: lint-sdk-go-postgres

--- a/sdk/go/stores/postgres/confidence_sql_test.go
+++ b/sdk/go/stores/postgres/confidence_sql_test.go
@@ -45,4 +45,5 @@ func TestBuildConfidenceSQLTracksBuckets(t *testing.T) {
 	}
 
 	require.Equal(t, len(cq.ConfidenceBucketLabels()), strings.Count(sql, "THEN ")+strings.Count(sql, "ELSE "))
+	require.Equal(t, 1, strings.Count(sql, "ELSE "))
 }

--- a/sdk/go/stores/postgres/confidence_sql_test.go
+++ b/sdk/go/stores/postgres/confidence_sql_test.go
@@ -1,0 +1,48 @@
+package postgres
+
+import (
+	"fmt"
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	cq "github.com/mozilla-ai/cq/sdk/go"
+)
+
+// TestBuildConfidenceSQLGolden pins the exact query so any change to the
+// canonical bucket definitions that alters the generated SQL trips this test.
+func TestBuildConfidenceSQLGolden(t *testing.T) {
+	t.Parallel()
+	want := "SELECT CASE " +
+		"WHEN confidence < 0.3 THEN '0.0-0.3' " +
+		"WHEN confidence < 0.5 THEN '0.3-0.5' " +
+		"WHEN confidence < 0.7 THEN '0.5-0.7' " +
+		"ELSE '0.7-1.0' " +
+		"END AS bucket, COUNT(*) AS cnt " +
+		"FROM (SELECT COALESCE((data->'evidence'->>'confidence')::float, 0.5) " +
+		"AS confidence FROM knowledge_units) sub " +
+		"GROUP BY bucket"
+	require.Equal(t, want, buildConfidenceSQL())
+}
+
+// TestBuildConfidenceSQLTracksBuckets proves the SQL stays single-sourced: every
+// canonical label gets exactly one arm, finite bounds become WHEN clauses, and
+// the single infinite bound becomes the ELSE fallback.
+func TestBuildConfidenceSQLTracksBuckets(t *testing.T) {
+	t.Parallel()
+	sql := buildConfidenceSQL()
+
+	for _, label := range cq.ConfidenceBucketLabels() {
+		bound, err := cq.ConfidenceBucketBound(label)
+		require.NoError(t, err)
+		if math.IsInf(bound, 1) {
+			require.Contains(t, sql, fmt.Sprintf("ELSE '%s'", label))
+		} else {
+			require.Contains(t, sql, fmt.Sprintf("WHEN confidence < %g THEN '%s'", bound, label))
+		}
+	}
+
+	require.Equal(t, len(cq.ConfidenceBucketLabels()), strings.Count(sql, "THEN ")+strings.Count(sql, "ELSE "))
+}

--- a/sdk/go/stores/postgres/postgres.go
+++ b/sdk/go/stores/postgres/postgres.go
@@ -11,7 +11,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"runtime"
+	"strings"
 	"sync"
 	"time"
 
@@ -327,31 +329,27 @@ func (s *Store) Update(ctx context.Context, ku cq.KnowledgeUnit) error {
 	return tx.Commit(ctx)
 }
 
-// computeConfidenceBuckets loads all units and distributes them across the
-// canonical confidence buckets shared with the server and other SDKs.
+// computeConfidenceBuckets returns the count of units in each canonical
+// confidence bucket.
 func (s *Store) computeConfidenceBuckets(ctx context.Context) (map[string]int, error) {
-	units, err := s.scanUnits(ctx, sqlSelectAll)
-	if err != nil {
-		return nil, err
-	}
 	buckets := map[string]int{}
 	for _, label := range cq.ConfidenceBucketLabels() {
 		buckets[label] = 0
 	}
-	for _, ku := range units {
-		for _, label := range cq.ConfidenceBucketLabels() {
-			bound, err := cq.ConfidenceBucketBound(label)
-			if err != nil {
-				return nil, err
-			}
-			if ku.Evidence.Confidence >= bound {
-				continue
-			}
-			buckets[label]++
-			break
-		}
+	rows, err := s.pool.Query(ctx, buildConfidenceSQL())
+	if err != nil {
+		return nil, err
 	}
-	return buckets, nil
+	defer rows.Close()
+	for rows.Next() {
+		var bucket string
+		var cnt int
+		if err := rows.Scan(&bucket, &cnt); err != nil {
+			return nil, err
+		}
+		buckets[bucket] = cnt
+	}
+	return buckets, rows.Err()
 }
 
 // countUnits returns the total number of knowledge units in the store.
@@ -413,6 +411,29 @@ func (s *Store) scanUnits(ctx context.Context, sql string, args ...any) ([]cq.Kn
 		units = append(units, ku)
 	}
 	return units, rows.Err()
+}
+
+// buildConfidenceSQL renders the bucketing query from the canonical bucket
+// definitions so the CASE thresholds stay in lockstep with the SDK constants.
+// Exactly one label carries an infinite upper bound; it becomes the ELSE arm.
+func buildConfidenceSQL() string {
+	labels := cq.ConfidenceBucketLabels()
+	var whens []string
+	for _, label := range labels {
+		bound, err := cq.ConfidenceBucketBound(label)
+		if err != nil {
+			panic(fmt.Sprintf("confidence bucket %q has no upper bound: %v", label, err))
+		}
+		if math.IsInf(bound, 1) {
+			whens = append(whens, fmt.Sprintf("ELSE '%s'", label))
+		} else {
+			whens = append(whens, fmt.Sprintf("WHEN confidence < %g THEN '%s'", bound, label))
+		}
+	}
+	return "SELECT CASE " + strings.Join(whens, " ") + " END AS bucket, COUNT(*) AS cnt " +
+		"FROM (SELECT COALESCE((data->'evidence'->>'confidence')::float, 0.5) " +
+		"AS confidence FROM knowledge_units) sub " +
+		"GROUP BY bucket"
 }
 
 // stampWriter records the SDK version and timestamp in the metadata table

--- a/sdk/go/stores/postgres/postgres.go
+++ b/sdk/go/stores/postgres/postgres.go
@@ -419,16 +419,21 @@ func (s *Store) scanUnits(ctx context.Context, sql string, args ...any) ([]cq.Kn
 func buildConfidenceSQL() string {
 	labels := cq.ConfidenceBucketLabels()
 	var whens []string
+	elseCount := 0
 	for _, label := range labels {
 		bound, err := cq.ConfidenceBucketBound(label)
 		if err != nil {
 			panic(fmt.Sprintf("confidence bucket %q has no upper bound: %v", label, err))
 		}
 		if math.IsInf(bound, 1) {
+			elseCount++
 			whens = append(whens, fmt.Sprintf("ELSE '%s'", label))
 		} else {
 			whens = append(whens, fmt.Sprintf("WHEN confidence < %g THEN '%s'", bound, label))
 		}
+	}
+	if elseCount != 1 {
+		panic(fmt.Sprintf("confidence buckets must have exactly one infinite upper bound, got %d", elseCount))
 	}
 	return "SELECT CASE " + strings.Join(whens, " ") + " END AS bucket, COUNT(*) AS cnt " +
 		"FROM (SELECT COALESCE((data->'evidence'->>'confidence')::float, 0.5) " +

--- a/sdk/python/src/cq/stores/postgres.py
+++ b/sdk/python/src/cq/stores/postgres.py
@@ -87,11 +87,15 @@ def _build_confidence_sql() -> str:
     the SQL CASE expression.
     """
     whens: list[str] = []
+    else_count = 0
     for threshold, label in _CONFIDENCE_BUCKETS:
         if threshold == float("inf"):
+            else_count += 1
             whens.append(f"ELSE '{label}'")
         else:
             whens.append(f"WHEN confidence < {threshold} THEN '{label}'")
+    if else_count != 1:
+        raise ValueError(f"confidence buckets must have exactly one infinite upper bound, got {else_count}")
     case_expr = " ".join(whens)
     return (
         f"SELECT CASE {case_expr} END AS bucket, COUNT(*) AS cnt "

--- a/sdk/python/src/cq/stores/postgres.py
+++ b/sdk/python/src/cq/stores/postgres.py
@@ -8,7 +8,7 @@ search is not yet implemented (the SPI degrades gracefully).
 import sys
 import threading
 from datetime import UTC, datetime
-from typing import Any, LiteralString
+from typing import Any, LiteralString, cast
 
 import psycopg
 import psycopg.sql
@@ -77,6 +77,32 @@ _SQL_UPSERT_METADATA = """
     INSERT INTO metadata (key, value) VALUES (%s, %s)
     ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value
 """
+
+
+def _build_confidence_sql() -> str:
+    """Build a SQL query that buckets confidence scores server-side.
+
+    Generated from ``_CONFIDENCE_BUCKETS`` so the thresholds stay
+    single-sourced and cannot drift between the Python constants and
+    the SQL CASE expression.
+    """
+    whens: list[str] = []
+    for threshold, label in _CONFIDENCE_BUCKETS:
+        if threshold == float("inf"):
+            whens.append(f"ELSE '{label}'")
+        else:
+            whens.append(f"WHEN confidence < {threshold} THEN '{label}'")
+    case_expr = " ".join(whens)
+    return (
+        f"SELECT CASE {case_expr} END AS bucket, COUNT(*) AS cnt "
+        "FROM (SELECT COALESCE((data->'evidence'->>'confidence')::float, 0.5) "
+        "AS confidence FROM knowledge_units) sub "
+        "GROUP BY bucket"
+    )
+
+
+# Safe: built entirely from the hard-coded _CONFIDENCE_BUCKETS constant.
+_SQL_CONFIDENCE_DISTRIBUTION: LiteralString = cast(LiteralString, _build_confidence_sql())
 
 
 class PostgresStore:
@@ -268,16 +294,11 @@ class PostgresStore:
             raise RuntimeError("store is closed")
 
     def _compute_confidence_buckets(self) -> dict[str, int]:
-        """Distribute all units across the canonical confidence buckets."""
-        units = self._scan_units(_SQL_SELECT_ALL)
+        """Return the count of units in each canonical confidence bucket."""
         buckets: dict[str, int] = {label: 0 for _, label in _CONFIDENCE_BUCKETS}
-        for unit in units:
-            c = unit.evidence.confidence
-            for threshold, label in _CONFIDENCE_BUCKETS:
-                if c >= threshold:
-                    continue
-                buckets[label] += 1
-                break
+        rows = self._conn.execute(_SQL_CONFIDENCE_DISTRIBUTION).fetchall()
+        for bucket, cnt in rows:
+            buckets[bucket] = cnt
         return buckets
 
     def _count_units(self) -> int:

--- a/sdk/python/tests/test_store_postgres_conformance.py
+++ b/sdk/python/tests/test_store_postgres_conformance.py
@@ -25,3 +25,38 @@ class TestPostgresStoreConstructor:
 
         with pytest.raises(psycopg.OperationalError):
             PostgresStore("postgres://localhost:1/nonexistent")
+
+
+class TestConfidenceSQL:
+    """Verify the generated SQL stays in sync with the canonical bucket definitions."""
+
+    def test_golden_sql(self) -> None:
+        """Pin the exact query so a bucket-definition change that alters it trips here."""
+        from cq.stores.postgres import _SQL_CONFIDENCE_DISTRIBUTION
+
+        want = (
+            "SELECT CASE "
+            "WHEN confidence < 0.3 THEN '0.0-0.3' "
+            "WHEN confidence < 0.5 THEN '0.3-0.5' "
+            "WHEN confidence < 0.7 THEN '0.5-0.7' "
+            "ELSE '0.7-1.0' "
+            "END AS bucket, COUNT(*) AS cnt "
+            "FROM (SELECT COALESCE((data->'evidence'->>'confidence')::float, 0.5) "
+            "AS confidence FROM knowledge_units) sub "
+            "GROUP BY bucket"
+        )
+        assert want == _SQL_CONFIDENCE_DISTRIBUTION
+
+    def test_sql_tracks_canonical_buckets(self) -> None:
+        """Every label gets one arm: finite bounds become WHEN, the infinite bound ELSE."""
+        from cq.store import _CONFIDENCE_BUCKETS
+        from cq.stores.postgres import _SQL_CONFIDENCE_DISTRIBUTION
+
+        for threshold, label in _CONFIDENCE_BUCKETS:
+            if threshold == float("inf"):
+                assert f"ELSE '{label}'" in _SQL_CONFIDENCE_DISTRIBUTION
+            else:
+                assert f"WHEN confidence < {threshold} THEN '{label}'" in _SQL_CONFIDENCE_DISTRIBUTION
+
+        arms = _SQL_CONFIDENCE_DISTRIBUTION.count("THEN ") + _SQL_CONFIDENCE_DISTRIBUTION.count("ELSE ")
+        assert arms == len(_CONFIDENCE_BUCKETS)

--- a/sdk/python/tests/test_store_postgres_conformance.py
+++ b/sdk/python/tests/test_store_postgres_conformance.py
@@ -60,3 +60,4 @@ class TestConfidenceSQL:
 
         arms = _SQL_CONFIDENCE_DISTRIBUTION.count("THEN ") + _SQL_CONFIDENCE_DISTRIBUTION.count("ELSE ")
         assert arms == len(_CONFIDENCE_BUCKETS)
+        assert _SQL_CONFIDENCE_DISTRIBUTION.count("ELSE ") == 1


### PR DESCRIPTION
## Summary

Computes the confidence-distribution buckets for the PostgreSQL stores in SQL instead of materializing every knowledge unit into memory.
The Go and Python adapters previously loaded all units to count four buckets in Stats; this pushes the work into the database with a CASE expression over the JSONB confidence field, returning only the four bucket counts.

The CASE thresholds are generated from the canonical bucket definitions so the SQL stays single-sourced and cannot drift from the SDK constants.

Also wires the existing postgres store make targets into the aggregate lint/test targets, which previously skipped the Go postgres adapter (a separate Go module) entirely.

## Testing

- make lint — passes
- make test — passes
- Golden tests pin the exact generated SQL for both SDKs; drift tests assert every canonical bucket label maps to exactly one CASE arm.

Fixes #469

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved confidence bucketing for PostgreSQL-backed data by computing bucket distributions in the database, resulting in more consistent, canonical results.
* **Tests**
  * Added PostgreSQL conformance coverage with golden SQL and bucket-synchronisation checks (Go and Python) to keep confidence bucket SQL aligned.
* **Chores**
  * Updated standard Go and Python lint/test workflows so PostgreSQL-specific linting and tests run automatically alongside existing SDK tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->