### PR TITLE
fix(sdk): populate TierCounts in built-in store Stats implementations

### DIFF
--- a/sdk/go/store_memory.go
+++ b/sdk/go/store_memory.go
@@ -217,6 +217,7 @@ func (s *inMemoryStore) Stats(ctx context.Context, recentLimit int) (StoreStats,
 		DomainCounts:           domainCounts,
 		Recent:                 recent,
 		ConfidenceDistribution: buckets,
+		TierCounts:             map[Tier]int{Local: len(s.order)},
 	}, nil
 }
 

--- a/sdk/go/store_sqlite.go
+++ b/sdk/go/store_sqlite.go
@@ -452,6 +452,7 @@ func (s *sqliteStore) Stats(ctx context.Context, recentLimit int) (StoreStats, e
 		DomainCounts:           domainCounts,
 		Recent:                 recent,
 		ConfidenceDistribution: buckets,
+		TierCounts:             map[Tier]int{Local: totalCount},
 	}, nil
 }
 

--- a/sdk/go/storetest/storetest.go
+++ b/sdk/go/storetest/storetest.go
@@ -11,6 +11,7 @@ package storetest
 
 import (
 	"context"
+	"maps"
 	"testing"
 
 	cq "github.com/mozilla-ai/cq/sdk/go"
@@ -266,6 +267,22 @@ func RunConformance(t *testing.T, newStore func() cq.Store) {
 			if stats.ConfidenceDistribution[label] != want {
 				t.Fatalf("ConfidenceDistribution[%s] = %d, want %d", label, stats.ConfidenceDistribution[label], want)
 			}
+		}
+		wantTiers := map[cq.Tier]int{cq.Local: len(confidences)}
+		if !maps.Equal(stats.TierCounts, wantTiers) {
+			t.Fatalf("TierCounts = %v, want %v", stats.TierCounts, wantTiers)
+		}
+	})
+
+	t.Run("stats reports local tier on an empty store", func(t *testing.T) {
+		s := newStore()
+		t.Cleanup(func() { _ = s.Close() })
+
+		stats, err := s.Stats(context.Background(), 5)
+		noErr(t, err)
+		wantTiers := map[cq.Tier]int{cq.Local: 0}
+		if !maps.Equal(stats.TierCounts, wantTiers) {
+			t.Fatalf("TierCounts = %v, want %v", stats.TierCounts, wantTiers)
 		}
 	})
 

--- a/sdk/python/src/cq/store.py
+++ b/sdk/python/src/cq/store.py
@@ -675,6 +675,7 @@ class SqliteStore:
             domain_counts=domain_counts,
             recent=recent,
             confidence_distribution=buckets,
+            tier_counts={Tier.LOCAL: total},
         )
 
 

--- a/sdk/python/src/cq/stores/memory.py
+++ b/sdk/python/src/cq/stores/memory.py
@@ -11,7 +11,7 @@ not an advertised capability.
 
 import threading
 
-from ..models import KnowledgeUnit
+from ..models import KnowledgeUnit, Tier
 from ..store import (
     _CONFIDENCE_BUCKETS,
     _EPOCH_UTC,
@@ -198,4 +198,5 @@ class InMemoryStore:
             domain_counts=domain_counts,
             recent=recent,
             confidence_distribution=buckets,
+            tier_counts={Tier.LOCAL: len(units)},
         )

--- a/sdk/python/tests/conformance.py
+++ b/sdk/python/tests/conformance.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 import pytest
 
-from cq.models import Context, Evidence, Insight, KnowledgeUnit, create_knowledge_unit
+from cq.models import Context, Evidence, Insight, KnowledgeUnit, Tier, create_knowledge_unit
 from cq.scoring import apply_confirmation
 from cq.store import (
     _MAX_QUERY_FRAMEWORKS,
@@ -264,6 +264,7 @@ def _assert_stats_aggregates(make_store: StoreFactory) -> None:
             "0.5-0.7": 0,
             "0.7-1.0": 0,
         }
+        assert empty.tier_counts == {Tier.LOCAL: 0}
 
         now = datetime.now(UTC)
         old_when = now - timedelta(days=10)
@@ -282,6 +283,7 @@ def _assert_stats_aggregates(make_store: StoreFactory) -> None:
         assert stats.domain_counts == {"api": 2, "databases": 1, "payments": 1}
         assert [u.id for u in stats.recent] == [newer.id, older.id]
         assert stats.confidence_distribution["0.5-0.7"] == 2
+        assert stats.tier_counts == {Tier.LOCAL: 2}
 
         with pytest.raises(ValueError, match="recent_limit must be non-negative"):
             store.stats(recent_limit=-1)


### PR DESCRIPTION
## Summary

`StoreStats.TierCounts` (Go) / `tier_counts` (Python) was returned nil by the built-in `SqliteStore` and `InMemoryStore` in both SDKs. The `Client` compensated by setting `{Local: TotalCount}` after reading store stats, so callers going through the client were unaffected — but anyone using a `Store` directly got incomplete stats, and the built-ins diverged from the PostgreSQL adapter (added in #462) which already populates it.

This sets `TierCounts` to `{Local: total}` in all four built-in `Stats` methods, matching the PostgreSQL reference exactly (including `{Local: 0}` for an empty store).

## Changes

- `sdk/go/store_sqlite.go`, `sdk/go/store_memory.go` — populate `TierCounts: {Local: total}`
- `sdk/python/src/cq/store.py`, `sdk/python/src/cq/stores/memory.py` — populate `tier_counts={Tier.LOCAL: total}`
- `sdk/go/storetest/storetest.go`, `sdk/python/tests/conformance.py` — assert tier counts for populated and empty stores; these suites run against every store (sqlite, memory, postgres), so the contract is now enforced uniformly

## Testing

- Go: `make -C sdk/go test` and `make -C sdk/go lint` pass
- Python: `make -C sdk/python test` (461 passed) and `ruff` lint/format pass
- Test-first: added the conformance assertions, confirmed both suites failed (`TierCounts = map[]` / empty `tier_counts`), then implemented to green

Fixes #465


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Store statistics now include tier breakdowns, so the local item count is shown consistently across in-memory and SQLite-backed stores.
  * Empty stores now report a zero count for the local tier instead of leaving the field unset.

* **Tests**
  * Expanded stats checks to verify tier counts alongside existing totals and distribution values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->