### PR TITLE
docs(cli): document Homebrew tap trust for third-party tap installs

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -23,6 +23,14 @@ cd cq/cli
 make build
 ```
 
+> **Homebrew tap trust:** `mozilla-ai/tap` is a third-party tap, and Homebrew will require explicit [tap trust](https://docs.brew.sh/Tap-Trust) for non-official taps from versions 5.2.0 and 6.0.0 onwards. Installing by the fully-qualified cask name (`mozilla-ai/tap/cq`, as above) trusts only the `cq` cask, so that command keeps working without extra steps. If you prefer to tap first and install by short name, trust the cask explicitly:
+>
+> ```bash
+> brew tap mozilla-ai/tap
+> brew trust --cask mozilla-ai/tap/cq
+> brew install --cask cq
+> ```
+
 ## Usage
 
 ```bash


### PR DESCRIPTION
## What

Adds a tap-trust note to `cli/README.md` (the canonical install doc referenced by `README.md` and `DEVELOPMENT.md`).

## Why

Homebrew is moving to require explicit trust for non-official (third-party) taps — warnings now via `brew doctor` and install commands, enforced by default in Homebrew 6.0.0 or 5.2.0, whichever comes first. See [docs.brew.sh/Tap-Trust](https://docs.brew.sh/Tap-Trust).

Our documented command `brew install --cask mozilla-ai/tap/cq` is already **fully-qualified**, which trusts only the `cq` cask, so it keeps working untouched under tap trust. The note makes that explicit and documents the `brew trust --cask` path for users who `brew tap` first and install by short name. `cq` ships as a cask, so the short-name path uses `--cask` (not `--formula`).

No command was changed — this is documentation only.

## Verification

- Content checked against the live Homebrew Tap-Trust docs (not from memory).
- Pre-commit hooks pass, including the docs link check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the CLI installation guide with clearer Homebrew guidance for third-party taps.
  * Added a note explaining when extra trust steps may be needed, including an alternative install flow for the short cask name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->