### PR TITLE
Bump SDK version in CLI to v0.14.0

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -5,7 +5,7 @@ go 1.26.1
 require (
 	github.com/BurntSushi/toml v1.6.0
 	github.com/mark3labs/mcp-go v0.55.0
-	github.com/mozilla-ai/cq/sdk/go v0.13.0
+	github.com/mozilla-ai/cq/sdk/go v0.14.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -35,8 +35,8 @@ github.com/mattn/go-isatty v0.0.22 h1:j8l17JJ9i6VGPUFUYoTUKPSgKe/83EYU2zBC7YNKMw
 github.com/mattn/go-isatty v0.0.22/go.mod h1:ZXfXG4SQHsB/w3ZeOYbR0PrPwLy+n6xiMrJlRFqopa4=
 github.com/mozilla-ai/cq/schema v0.2.0 h1:Kd8x08vOQVUrk8SejcHlNI9/EKffc/wDi+U+x8wY1wc=
 github.com/mozilla-ai/cq/schema v0.2.0/go.mod h1:9T+ORUPz850IheKjwTCL90rB5nbOGrYqijZn1bsvAZU=
-github.com/mozilla-ai/cq/sdk/go v0.13.0 h1:+K7j5lcU21OywSHQRSNxwP/hB4FEDvwEuqcqIwoOLtg=
-github.com/mozilla-ai/cq/sdk/go v0.13.0/go.mod h1:ck05OshvY3b2VSVyuYc3nDQt2aN0A1NpqOw7GGfHU7U=
+github.com/mozilla-ai/cq/sdk/go v0.14.0 h1:X/f7JuKCuyHcDgsE42HR0Xu7uYZ8HPwti1gsSNL2YkU=
+github.com/mozilla-ai/cq/sdk/go v0.14.0/go.mod h1:ck05OshvY3b2VSVyuYc3nDQt2aN0A1NpqOw7GGfHU7U=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a Go SDK dependency to the latest supported version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->