### PR TITLE
feat(server): implement PostgreSQL backend for Database + repositories

### DIFF
--- a/.github/workflows/ci-server.yaml
+++ b/.github/workflows/ci-server.yaml
@@ -65,7 +65,7 @@ jobs:
         python-version: ["3.11", "3.12", "3.13"]
     services:
       postgres:
-        image: postgres:16-alpine
+        image: postgres:16-alpine@sha256:57c72fd2a128e416c7fcc499958864df5301e940bca0a56f58fddf30ffc07777
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/.github/workflows/ci-server.yaml
+++ b/.github/workflows/ci-server.yaml
@@ -63,6 +63,22 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: cq_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      CQ_TEST_DATABASE_URL: postgresql+psycopg://postgres:postgres@localhost:5432/cq_test
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/server/backend/pyproject.toml
+++ b/server/backend/pyproject.toml
@@ -47,6 +47,7 @@ tests = [
     "pytest>=9.0.3",
     "pytest-asyncio>=1.3.0",
     "httpx",
+    "testcontainers[postgres]>=4.9.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/server/backend/src/cq_server/app.py
+++ b/server/backend/src/cq_server/app.py
@@ -36,8 +36,9 @@ async def lifespan(app_instance: FastAPI) -> AsyncIterator[None]:
     settings = Settings()
     # Single URL feeds both the database wrapper and the migration runner,
     # so they can't diverge on which database they target. Build the
-    # ``Database`` first so a Postgres URL surfaces ``NotImplementedError``
-    # (#312) instead of failing inside Alembic with a cryptic driver error.
+    # ``Database`` first so an unsupported URL (bad scheme, non-canonical
+    # PG driver, or semantic-search-on-PG) fails fast here with a clear
+    # message instead of failing inside Alembic with a cryptic driver error.
     database = Database(settings)
     # Close the database if migrations fail — otherwise its engine and
     # SQLite file handle leak across in-process lifespan re-entries

--- a/server/backend/src/cq_server/core/config.py
+++ b/server/backend/src/cq_server/core/config.py
@@ -47,6 +47,10 @@ class Settings(BaseSettings):
     database_url: str | None = None
     db_path: Path = Path(_DEFAULT_SQLITE_PATH)
 
+    # PostgreSQL connection pool knobs (ignored by the SQLite backend).
+    db_pool_size: int = 5
+    db_max_overflow: int = 10
+
     # HTTP listener.
     port: int = 3000
 

--- a/server/backend/src/cq_server/core/config.py
+++ b/server/backend/src/cq_server/core/config.py
@@ -47,10 +47,6 @@ class Settings(BaseSettings):
     database_url: str | None = None
     db_path: Path = Path(_DEFAULT_SQLITE_PATH)
 
-    # PostgreSQL connection pool knobs (ignored by the SQLite backend).
-    db_pool_size: int = 5
-    db_max_overflow: int = 10
-
     # HTTP listener.
     port: int = 3000
 

--- a/server/backend/src/cq_server/core/db.py
+++ b/server/backend/src/cq_server/core/db.py
@@ -50,12 +50,12 @@ class Database:
     def __init__(self, settings: Settings) -> None:
         """Build the engine from ``settings`` and register dialect hooks.
 
-        SQLite URLs get a live engine with cq's required PRAGMAs.
-        The canonical ``postgresql+psycopg://`` URL raises
-        ``NotImplementedError`` until the Phase 2 implementation lands
-        (#312). Other PostgreSQL driver suffixes are rejected with a
-        message naming the canonical driver. Anything else raises
-        ``ValueError``.
+        SQLite URLs get a live engine with cq's required PRAGMAs. The
+        canonical ``postgresql+psycopg://`` URL gets a UTC-pinned engine
+        with env-configurable pool sizing (and fails fast if semantic
+        search is enabled, which has no PG backend yet). Other PostgreSQL
+        driver suffixes are rejected with a message naming the canonical
+        driver. Anything else raises ``ValueError``.
         """
         url = settings.resolved_database_url
         try:
@@ -76,9 +76,22 @@ class Database:
             if _SEMSEARCH_ENABLED:
                 event.listen(self._engine, "connect", semsearch_load)
         elif driver == "postgresql+psycopg":
-            raise NotImplementedError(
-                "PostgreSQL backend is not implemented yet; the psycopg "
-                "v3-backed implementation lands in epic #257 (issue #312)."
+            if _SEMSEARCH_ENABLED:
+                # semsearch runs sqlite-vec SQL; it has no PG implementation
+                # yet (pgvector is a later stage). Fail fast rather than blow
+                # up on the first insert. See #312 item 4.
+                raise RuntimeError(
+                    "semantic search is not yet supported on the PostgreSQL backend; "
+                    "unset TOKEN_EMBEDDING_URL to run cq against PostgreSQL."
+                )
+            self._engine = create_engine(
+                url,
+                # Force UTC so ``(col::timestamptz)::date`` truncates in UTC,
+                # matching SQLite's ``date()`` on ISO strings.
+                connect_args={"options": "-c timezone=utc"},
+                pool_size=settings.db_pool_size,
+                max_overflow=settings.db_max_overflow,
+                future=True,
             )
         elif driver == "postgresql" or driver.startswith("postgresql+"):
             raise NotImplementedError(

--- a/server/backend/src/cq_server/core/db.py
+++ b/server/backend/src/cq_server/core/db.py
@@ -52,8 +52,8 @@ class Database:
 
         SQLite URLs get a live engine with cq's required PRAGMAs. The
         canonical ``postgresql+psycopg://`` URL gets a UTC-pinned engine
-        with env-configurable pool sizing (and fails fast if semantic
-        search is enabled, which has no PG backend yet). Other PostgreSQL
+        (and fails fast if semantic search is enabled, which has no PG
+        backend yet). Other PostgreSQL
         driver suffixes are rejected with a message naming the canonical
         driver. Anything else raises ``ValueError``.
         """
@@ -88,8 +88,6 @@ class Database:
                 # Force UTC so ``to_char(col::timestamptz, ...)`` renders in UTC,
                 # matching SQLite's ``date()`` on ISO strings.
                 connect_args={"options": "-c timezone=utc", "connect_timeout": 10},
-                pool_size=settings.db_pool_size,
-                max_overflow=settings.db_max_overflow,
                 pool_pre_ping=True,
                 future=True,
             )

--- a/server/backend/src/cq_server/core/db.py
+++ b/server/backend/src/cq_server/core/db.py
@@ -78,8 +78,7 @@ class Database:
         elif driver == "postgresql+psycopg":
             if _SEMSEARCH_ENABLED:
                 # semsearch runs sqlite-vec SQL; it has no PG implementation
-                # yet (pgvector is a later stage). Fail fast rather than blow
-                # up on the first insert. See #312 item 4.
+                # yet. Fail fast rather than blow up on the first insert.
                 raise RuntimeError(
                     "semantic search is not yet supported on the PostgreSQL backend; "
                     "unset TOKEN_EMBEDDING_URL to run cq against PostgreSQL."

--- a/server/backend/src/cq_server/core/db.py
+++ b/server/backend/src/cq_server/core/db.py
@@ -86,11 +86,12 @@ class Database:
                 )
             self._engine = create_engine(
                 url,
-                # Force UTC so ``(col::timestamptz)::date`` truncates in UTC,
+                # Force UTC so ``to_char(col::timestamptz, ...)`` renders in UTC,
                 # matching SQLite's ``date()`` on ISO strings.
-                connect_args={"options": "-c timezone=utc"},
+                connect_args={"options": "-c timezone=utc", "connect_timeout": 10},
                 pool_size=settings.db_pool_size,
                 max_overflow=settings.db_max_overflow,
+                pool_pre_ping=True,
                 future=True,
             )
         elif driver == "postgresql" or driver.startswith("postgresql+"):

--- a/server/backend/src/cq_server/core/db.py
+++ b/server/backend/src/cq_server/core/db.py
@@ -96,8 +96,7 @@ class Database:
         elif driver == "postgresql" or driver.startswith("postgresql+"):
             raise NotImplementedError(
                 f"PostgreSQL driver {driver!r} is not supported; "
-                "use postgresql+psycopg:// once the PostgreSQL backend "
-                "implementation lands in epic #257 (issue #312)."
+                "use the canonical postgresql+psycopg:// driver instead."
             )
         else:
             raise ValueError(f"Unsupported database URL scheme: {driver!r}")

--- a/server/backend/src/cq_server/repositories/_queries.py
+++ b/server/backend/src/cq_server/repositories/_queries.py
@@ -29,8 +29,35 @@ dialect (``date(<textcol>)`` on SQLite; ``to_char(<textcol>::timestamptz,
 
 from __future__ import annotations
 
+from typing import Literal
+
 from sqlalchemy import bindparam
 from sqlalchemy.sql.expression import TextClause, text
+
+# The closed set of SQL dialects cq's queries support. Modelled as a type so the
+# dialect-keyed dicts and builders below are exhaustive by construction rather
+# than "safe because these are the only values we pass".
+Dialect = Literal["sqlite", "postgresql"]
+
+
+def resolve_dialect(name: str) -> Dialect:
+    """Validate a raw ``engine.dialect.name`` into the supported :data:`Dialect`.
+
+    Called once per repository (from ``__init__``) so an unknown backend fails
+    here with a domain-phrased error instead of surfacing as a bare ``KeyError``
+    from a dialect-keyed lookup deep in an aggregation query.
+    """
+    if name == "sqlite":
+        return "sqlite"
+    if name == "postgresql":
+        return "postgresql"
+    raise ValueError(f"Unsupported SQL dialect {name!r}; cq's queries support only 'sqlite' and 'postgresql'.")
+
+
+def _sql_str_literal(value: str) -> str:
+    """Escape ``value`` for safe interpolation inside a single-quoted SQL literal."""
+    return value.replace("'", "''")
+
 
 # --- knowledge_units --------------------------------------------------------
 
@@ -112,12 +139,12 @@ SELECT_RECENT_ACTIVITY: TextClause = text(
 #     is portable (Python-computed ISO string) either way.
 
 
-def _daily(column: str, status_clause: str) -> dict[str, TextClause]:
+def _daily(column: Literal["created_at", "reviewed_at"], status_clause: str) -> dict[Dialect, TextClause]:
     """Build the dialect-keyed daily-count query for one timestamp column.
 
-    ``column`` and ``status_clause`` are interpolated into the SQL text, so
-    callers must pass only trusted literal column names / clauses (they do:
-    the three module-level constants below are the only call sites).
+    NOTE: ``status_clause`` is interpolated into the SQL text unescaped; callers
+    must pass only trusted literal column names/clauses, never user input.
+    ``column`` is type-constrained to the two timestamp columns.
     """
     return {
         "sqlite": text(
@@ -131,18 +158,22 @@ def _daily(column: str, status_clause: str) -> dict[str, TextClause]:
     }
 
 
-SELECT_PROPOSED_DAILY: dict[str, TextClause] = _daily("created_at", "")
-SELECT_APPROVED_DAILY: dict[str, TextClause] = _daily("reviewed_at", "status = 'approved' AND ")
-SELECT_REJECTED_DAILY: dict[str, TextClause] = _daily("reviewed_at", "status = 'rejected' AND ")
+SELECT_PROPOSED_DAILY: dict[Dialect, TextClause] = _daily("created_at", "")
+SELECT_APPROVED_DAILY: dict[Dialect, TextClause] = _daily("reviewed_at", "status = 'approved' AND ")
+SELECT_REJECTED_DAILY: dict[Dialect, TextClause] = _daily("reviewed_at", "status = 'rejected' AND ")
 
 
-def confidence_distribution_sql(buckets: list[tuple[float, str]], dialect: str) -> TextClause:
+def confidence_distribution_sql(buckets: list[tuple[float, str]], dialect: Dialect) -> TextClause:
     """Build the approved-unit confidence-distribution query for one dialect.
 
     ``buckets`` is ``(exclusive upper bound, label)`` ordered low-to-high; the
     last entry is the ``inf`` catch-all (its bound is ignored, its label is the
-    ``ELSE``). The bounds/labels are interpolated into the SQL, so callers must
-    pass only the trusted literal bucket list defined in the repo.
+    ``ELSE``).
+
+    NOTE: bucket labels are interpolated into single-quoted SQL literals; they
+    are escaped via ``_sql_str_literal`` so a stray quote can't break out, but
+    the numeric bounds are interpolated unescaped and callers must keep passing
+    trusted literals there.
 
     COALESCE to 0.5 mirrors the ``Evidence.confidence`` default, so a row whose
     JSON omits the field buckets identically instead of hitting the catch-all.
@@ -155,9 +186,9 @@ def confidence_distribution_sql(buckets: list[tuple[float, str]], dialect: str) 
         "postgresql": "(data::jsonb #>> '{evidence,confidence}')::numeric",
     }[dialect]
     alias = " AS sub" if dialect == "postgresql" else ""
-    whens = " ".join(f"WHEN confidence < {bound} THEN '{label}'" for bound, label in buckets[:-1])
+    whens = " ".join(f"WHEN confidence < {bound} THEN '{_sql_str_literal(label)}'" for bound, label in buckets[:-1])
     return text(
-        f"SELECT CASE {whens} ELSE '{buckets[-1][1]}' END AS bucket, COUNT(*) AS cnt "
+        f"SELECT CASE {whens} ELSE '{_sql_str_literal(buckets[-1][1])}' END AS bucket, COUNT(*) AS cnt "
         f"FROM (SELECT COALESCE({extract}, 0.5) AS confidence "
         f"FROM knowledge_units WHERE status = 'approved'){alias} "
         "GROUP BY bucket"

--- a/server/backend/src/cq_server/repositories/_queries.py
+++ b/server/backend/src/cq_server/repositories/_queries.py
@@ -140,6 +140,35 @@ SELECT_PROPOSED_DAILY: dict[str, TextClause] = _daily("created_at", "")
 SELECT_APPROVED_DAILY: dict[str, TextClause] = _daily("reviewed_at", "status = 'approved' AND ")
 SELECT_REJECTED_DAILY: dict[str, TextClause] = _daily("reviewed_at", "status = 'rejected' AND ")
 
+
+def confidence_distribution_sql(buckets: list[tuple[float, str]], dialect: str) -> TextClause:
+    """Build the approved-unit confidence-distribution query for one dialect.
+
+    ``buckets`` is ``(exclusive upper bound, label)`` ordered low-to-high; the
+    last entry is the ``inf`` catch-all (its bound is ignored, its label is the
+    ``ELSE``). The bounds/labels are interpolated into the SQL, so callers must
+    pass only the trusted literal bucket list defined in the repo.
+
+    COALESCE to 0.5 mirrors the ``Evidence.confidence`` default, so a row whose
+    JSON omits the field buckets identically instead of hitting the catch-all.
+    SQLite reads the JSON blob with ``json_extract``; PostgreSQL casts the TEXT
+    column to ``jsonb``, extracts with ``#>>``, and must alias the derived
+    subquery (``AS sub``) — PG rejects an unnamed FROM-subquery.
+    """
+    extract = {
+        "sqlite": "json_extract(data, '$.evidence.confidence')",
+        "postgresql": "(data::jsonb #>> '{evidence,confidence}')::numeric",
+    }[dialect]
+    alias = " AS sub" if dialect == "postgresql" else ""
+    whens = " ".join(f"WHEN confidence < {bound} THEN '{label}'" for bound, label in buckets[:-1])
+    return text(
+        f"SELECT CASE {whens} ELSE '{buckets[-1][1]}' END AS bucket, COUNT(*) AS cnt "
+        f"FROM (SELECT COALESCE({extract}, 0.5) AS confidence "
+        f"FROM knowledge_units WHERE status = 'approved'){alias} "
+        "GROUP BY bucket"
+    )
+
+
 # Variable IN-list for ``KnowledgeRepository.query``. Bind ``:domains`` to the list
 # of normalised domain strings; SQLAlchemy expands it at execute time.
 # Empty list: SQLAlchemy 2.0 rewrites ``IN ()`` to a no-rows subquery

--- a/server/backend/src/cq_server/repositories/_queries.py
+++ b/server/backend/src/cq_server/repositories/_queries.py
@@ -1,10 +1,11 @@
 """Shared SQLAlchemy Core query helpers for portable cq server queries.
 
 Centralises every SQL statement that is portable between SQLite and
-PostgreSQL. Concrete ``Store`` implementations (``SqliteStore``,
-``PostgresStore``) compose these helpers for the boring queries while
-keeping dialect-specific code (PRAGMAs, advisory locks, vector search,
-full-text search) inside their own classes.
+PostgreSQL. The repository classes in this package compose these helpers
+for the boring queries. The few statements that diverge by dialect are
+kept as ``{"sqlite": ..., "postgresql": ...}`` dicts (here and in the
+repos) and resolved once from ``engine.dialect.name`` in each repo's
+``__init__`` — there is no per-dialect ``Store`` class.
 
 The module is pure: no engine, no connection, no metadata. Statements are
 either:
@@ -88,7 +89,7 @@ SELECT_APPROVED_DATA: TextClause = text("SELECT data FROM knowledge_units WHERE 
 # is re-sorted in Python by ``COALESCE(reviewed_at, created_at)`` and then
 # truncated, so over-fetching keeps the truncation honest when many KUs
 # have been reviewed since the most recent one was created. See
-# ``SqliteStore.recent_activity``.
+# ``ReviewRepository.recent_activity``.
 SELECT_RECENT_ACTIVITY: TextClause = text(
     "SELECT id, data, status, reviewed_by, reviewed_at "
     "FROM knowledge_units "
@@ -105,9 +106,11 @@ SELECT_RECENT_ACTIVITY: TextClause = text(
 #   * SQLite parses the ISO string natively with `date(<textcol>)`, which
 #     returns a 'YYYY-MM-DD' string.
 #   * PostgreSQL has no `date(text)` overload, so we cast the TEXT column to
-#     `timestamptz` then to `date`, and finally `::text` so the day key comes
-#     back as the same 'YYYY-MM-DD' string SQLite yields (bare `::date` would
-#     surface as a Python `datetime.date`, breaking the caller's string keys).
+#     `timestamptz` then format it with `to_char(..., 'YYYY-MM-DD')` so the day
+#     key comes back as the same 'YYYY-MM-DD' string SQLite yields. `to_char`
+#     is used rather than `::date::text` because the latter formats per session
+#     `DateStyle` (e.g. '01.07.2026' under `German`), which would break the
+#     caller's `strptime(day, "%Y-%m-%d")`; `to_char` is DateStyle-independent.
 #     The engine is pinned to UTC (see `core.db.Database`) so the truncation
 #     matches SQLite's UTC ISO strings. Phase 3 (#317) migrates PG timestamps
 #     to `TIMESTAMP WITH TIME ZONE` and removes the cast. The `>= :cutoff` half
@@ -115,14 +118,19 @@ SELECT_RECENT_ACTIVITY: TextClause = text(
 
 
 def _daily(column: str, status_clause: str) -> dict[str, TextClause]:
-    """Build the dialect-keyed daily-count query for one timestamp column."""
+    """Build the dialect-keyed daily-count query for one timestamp column.
+
+    ``column`` and ``status_clause`` are interpolated into the SQL text, so
+    callers must pass only trusted literal column names / clauses (they do:
+    the three module-level constants below are the only call sites).
+    """
     return {
         "sqlite": text(
             f"SELECT date({column}) AS day, COUNT(*) AS cnt "
             f"FROM knowledge_units WHERE {status_clause}{column} >= :cutoff GROUP BY day"
         ),
         "postgresql": text(
-            f"SELECT ({column}::timestamptz)::date::text AS day, COUNT(*) AS cnt "
+            f"SELECT to_char(({column}::timestamptz), 'YYYY-MM-DD') AS day, COUNT(*) AS cnt "
             f"FROM knowledge_units WHERE {status_clause}{column} >= :cutoff GROUP BY day"
         ),
     }
@@ -132,7 +140,7 @@ SELECT_PROPOSED_DAILY: dict[str, TextClause] = _daily("created_at", "")
 SELECT_APPROVED_DAILY: dict[str, TextClause] = _daily("reviewed_at", "status = 'approved' AND ")
 SELECT_REJECTED_DAILY: dict[str, TextClause] = _daily("reviewed_at", "status = 'rejected' AND ")
 
-# Variable IN-list for ``SqliteStore.query``. Bind ``:domains`` to the list
+# Variable IN-list for ``KnowledgeRepository.query``. Bind ``:domains`` to the list
 # of normalised domain strings; SQLAlchemy expands it at execute time.
 # Empty list: SQLAlchemy 2.0 rewrites ``IN ()`` to a no-rows subquery
 # (``IN (SELECT 1 FROM (SELECT 1) WHERE 1!=1)``) and the helper returns
@@ -149,13 +157,13 @@ SELECT_QUERY_UNITS: TextClause = text(
 
 
 def select_list_units(*, domain: str | None, status: str | None, apply_limit: bool) -> TextClause:
-    """Build the SELECT for ``SqliteStore.list_units``.
+    """Build the SELECT for ``ReviewRepository.list_units``.
 
     Pure SQL builder — does no normalization, the caller owns it. WHERE
     conditions on ``status`` and ``domain`` are inlined only when the
     argument is non-``None``; an empty or whitespace-only string is
     treated as a *real* filter value and binds literally (returning zero
-    rows). To mirror ``SqliteStore.list_units``, callers must (a) pass
+    rows). To mirror ``ReviewRepository.list_units``, callers must (a) pass
     ``None`` when the user-supplied filter is empty/whitespace, and (b)
     run ``domain`` through ``normalize_domains`` (lowercase + strip)
     first. ``apply_limit`` controls whether SQL-side ``LIMIT`` is

--- a/server/backend/src/cq_server/repositories/_queries.py
+++ b/server/backend/src/cq_server/repositories/_queries.py
@@ -20,13 +20,11 @@ Callers bind named parameters at execute time. Out of scope here:
 PRAGMAs, ``pg_advisory_lock``, vector (sqlite-vec / pgvector), full-text
 (FTS5 / ``tsvector``). Those live in their respective concrete stores.
 
-``daily_counts`` filters by a Python-computed ``:cutoff`` ISO date string
-(the SQLite-specific ``date('now', '-N days')`` form was removed per RFC
-#275), but the day-truncation half is dialect-specific: PostgreSQL has no
+``daily_counts`` filters by a Python-computed ``:cutoff`` ISO date string,
+but the day-truncation half is dialect-specific: PostgreSQL has no
 ``date(text)`` overload, so the daily-count helpers below are keyed by
 dialect (``date(<textcol>)`` on SQLite; ``to_char(<textcol>::timestamptz,
-'YYYY-MM-DD')`` on PostgreSQL). See ``_daily`` for detail. Phase 3 (#317)
-migrates PG timestamps to ``TIMESTAMP WITH TIME ZONE`` and can retire the cast.
+'YYYY-MM-DD')`` on PostgreSQL). See ``_daily`` for detail.
 """
 
 from __future__ import annotations
@@ -97,12 +95,10 @@ SELECT_RECENT_ACTIVITY: TextClause = text(
 )
 
 # `daily_counts()` — three queries that filter by a Python-computed date
-# string. The SQLite-specific `date('now', ?)` form is removed per RFC #275;
-# callers compute
+# string; callers compute
 # `cutoff = (datetime.now(UTC) - timedelta(days=...)).date().isoformat()`.
 #
-# Dialect-keyed and NON-PORTABLE. These run against a TEXT timestamp column
-# through Phase 2:
+# Dialect-keyed and NON-PORTABLE. These run against a TEXT timestamp column:
 #   * SQLite parses the ISO string natively with `date(<textcol>)`, which
 #     returns a 'YYYY-MM-DD' string.
 #   * PostgreSQL has no `date(text)` overload, so we cast the TEXT column to
@@ -112,8 +108,7 @@ SELECT_RECENT_ACTIVITY: TextClause = text(
 #     `DateStyle` (e.g. '01.07.2026' under `German`), which would break the
 #     caller's `strptime(day, "%Y-%m-%d")`; `to_char` is DateStyle-independent.
 #     The engine is pinned to UTC (see `core.db.Database`) so the truncation
-#     matches SQLite's UTC ISO strings. Phase 3 (#317) migrates PG timestamps
-#     to `TIMESTAMP WITH TIME ZONE` and removes the cast. The `>= :cutoff` half
+#     matches SQLite's UTC ISO strings. The `>= :cutoff` half
 #     is portable (Python-computed ISO string) either way.
 
 

--- a/server/backend/src/cq_server/repositories/_queries.py
+++ b/server/backend/src/cq_server/repositories/_queries.py
@@ -19,20 +19,13 @@ Callers bind named parameters at execute time. Out of scope here:
 PRAGMAs, ``pg_advisory_lock``, vector (sqlite-vec / pgvector), full-text
 (FTS5 / ``tsvector``). Those live in their respective concrete stores.
 
-``daily_counts`` is portable when the date cutoff is computed in Python
-and passed in as a ``:cutoff`` ISO date string; the SQLite-specific
-``date('now', '-N days')`` form has been removed here per RFC #275.
-
-Load-bearing assumption — ``date(reviewed_at)`` / ``date(created_at)`` in
-the daily-count helpers below: these run against ``TEXT`` columns through
-Phase 2. SQLite's ``date()`` parses ISO strings natively. PostgreSQL has
-no ``date(text)`` overload, but with the default ``DateStyle=ISO`` it
-implicit-casts ISO-8601-with-offset strings to ``timestamptz`` before
-applying the built-in ``date(timestamp)`` function. Operators running PG
-under a non-default ``DateStyle`` may see this fail. Phase 3 (#317)
-removes this dependency by migrating PG timestamps to
-``TIMESTAMP WITH TIME ZONE``; SQLite continues to store ISO strings.
-After #317 the same SQL is portable through two distinct mechanisms.
+``daily_counts`` filters by a Python-computed ``:cutoff`` ISO date string
+(the SQLite-specific ``date('now', '-N days')`` form was removed per RFC
+#275), but the day-truncation half is dialect-specific: PostgreSQL has no
+``date(text)`` overload, so the daily-count helpers below are keyed by
+dialect (``date(<textcol>)`` on SQLite; ``(<textcol>::timestamptz)::date``
+on PostgreSQL). See ``_daily`` for detail. Phase 3 (#317) migrates PG
+timestamps to ``TIMESTAMP WITH TIME ZONE`` and can retire the cast.
 """
 
 from __future__ import annotations
@@ -106,22 +99,38 @@ SELECT_RECENT_ACTIVITY: TextClause = text(
 # string. The SQLite-specific `date('now', ?)` form is removed per RFC #275;
 # callers compute
 # `cutoff = (datetime.now(UTC) - timedelta(days=...)).date().isoformat()`.
+#
+# Dialect-keyed and NON-PORTABLE. These run against a TEXT timestamp column
+# through Phase 2:
+#   * SQLite parses the ISO string natively with `date(<textcol>)`, which
+#     returns a 'YYYY-MM-DD' string.
+#   * PostgreSQL has no `date(text)` overload, so we cast the TEXT column to
+#     `timestamptz` then to `date`, and finally `::text` so the day key comes
+#     back as the same 'YYYY-MM-DD' string SQLite yields (bare `::date` would
+#     surface as a Python `datetime.date`, breaking the caller's string keys).
+#     The engine is pinned to UTC (see `core.db.Database`) so the truncation
+#     matches SQLite's UTC ISO strings. Phase 3 (#317) migrates PG timestamps
+#     to `TIMESTAMP WITH TIME ZONE` and removes the cast. The `>= :cutoff` half
+#     is portable (Python-computed ISO string) either way.
 
-SELECT_PROPOSED_DAILY: TextClause = text(
-    "SELECT date(created_at) AS day, COUNT(*) AS cnt FROM knowledge_units WHERE created_at >= :cutoff GROUP BY day"
-)
 
-SELECT_APPROVED_DAILY: TextClause = text(
-    "SELECT date(reviewed_at) AS day, COUNT(*) AS cnt "
-    "FROM knowledge_units "
-    "WHERE status = 'approved' AND reviewed_at >= :cutoff GROUP BY day"
-)
+def _daily(column: str, status_clause: str) -> dict[str, TextClause]:
+    """Build the dialect-keyed daily-count query for one timestamp column."""
+    return {
+        "sqlite": text(
+            f"SELECT date({column}) AS day, COUNT(*) AS cnt "
+            f"FROM knowledge_units WHERE {status_clause}{column} >= :cutoff GROUP BY day"
+        ),
+        "postgresql": text(
+            f"SELECT ({column}::timestamptz)::date::text AS day, COUNT(*) AS cnt "
+            f"FROM knowledge_units WHERE {status_clause}{column} >= :cutoff GROUP BY day"
+        ),
+    }
 
-SELECT_REJECTED_DAILY: TextClause = text(
-    "SELECT date(reviewed_at) AS day, COUNT(*) AS cnt "
-    "FROM knowledge_units "
-    "WHERE status = 'rejected' AND reviewed_at >= :cutoff GROUP BY day"
-)
+
+SELECT_PROPOSED_DAILY: dict[str, TextClause] = _daily("created_at", "")
+SELECT_APPROVED_DAILY: dict[str, TextClause] = _daily("reviewed_at", "status = 'approved' AND ")
+SELECT_REJECTED_DAILY: dict[str, TextClause] = _daily("reviewed_at", "status = 'rejected' AND ")
 
 # Variable IN-list for ``SqliteStore.query``. Bind ``:domains`` to the list
 # of normalised domain strings; SQLAlchemy expands it at execute time.

--- a/server/backend/src/cq_server/repositories/_queries.py
+++ b/server/backend/src/cq_server/repositories/_queries.py
@@ -5,7 +5,7 @@ PostgreSQL. The repository classes in this package compose these helpers
 for the boring queries. The few statements that diverge by dialect are
 kept as ``{"sqlite": ..., "postgresql": ...}`` dicts (here and in the
 repos) and resolved once from ``engine.dialect.name`` in each repo's
-``__init__`` — there is no per-dialect ``Store`` class.
+``__init__``.
 
 The module is pure: no engine, no connection, no metadata. Statements are
 either:
@@ -18,13 +18,10 @@ either:
 
 Callers bind named parameters at execute time. Out of scope here:
 PRAGMAs, ``pg_advisory_lock``, vector (sqlite-vec / pgvector), full-text
-(FTS5 / ``tsvector``). Those live in their respective concrete stores.
+(FTS5 / ``tsvector``).
 
-``daily_counts`` filters by a Python-computed ``:cutoff`` ISO date string,
-but the day-truncation half is dialect-specific: PostgreSQL has no
-``date(text)`` overload, so the daily-count helpers below are keyed by
-dialect (``date(<textcol>)`` on SQLite; ``to_char(<textcol>::timestamptz,
-'YYYY-MM-DD')`` on PostgreSQL). See ``_daily`` for detail.
+``daily_counts`` day-truncation is dialect-specific; see ``_daily`` and the
+comment above it.
 """
 
 from __future__ import annotations
@@ -35,8 +32,7 @@ from sqlalchemy import bindparam
 from sqlalchemy.sql.expression import TextClause, text
 
 # The closed set of SQL dialects cq's queries support. Modelled as a type so the
-# dialect-keyed dicts and builders below are exhaustive by construction rather
-# than "safe because these are the only values we pass".
+# dialect-keyed dicts and builders below are exhaustive by construction.
 Dialect = Literal["sqlite", "postgresql"]
 
 
@@ -143,8 +139,8 @@ def _daily(column: Literal["created_at", "reviewed_at"], status_clause: str) -> 
     """Build the dialect-keyed daily-count query for one timestamp column.
 
     NOTE: ``status_clause`` is interpolated into the SQL text unescaped; callers
-    must pass only trusted literal column names/clauses, never user input.
-    ``column`` is type-constrained to the two timestamp columns.
+    must pass only a trusted literal clause here, never user input. ``column`` is
+    type-constrained to the two timestamp columns.
     """
     return {
         "sqlite": text(

--- a/server/backend/src/cq_server/repositories/_queries.py
+++ b/server/backend/src/cq_server/repositories/_queries.py
@@ -24,9 +24,9 @@ PRAGMAs, ``pg_advisory_lock``, vector (sqlite-vec / pgvector), full-text
 (the SQLite-specific ``date('now', '-N days')`` form was removed per RFC
 #275), but the day-truncation half is dialect-specific: PostgreSQL has no
 ``date(text)`` overload, so the daily-count helpers below are keyed by
-dialect (``date(<textcol>)`` on SQLite; ``(<textcol>::timestamptz)::date``
-on PostgreSQL). See ``_daily`` for detail. Phase 3 (#317) migrates PG
-timestamps to ``TIMESTAMP WITH TIME ZONE`` and can retire the cast.
+dialect (``date(<textcol>)`` on SQLite; ``to_char(<textcol>::timestamptz,
+'YYYY-MM-DD')`` on PostgreSQL). See ``_daily`` for detail. Phase 3 (#317)
+migrates PG timestamps to ``TIMESTAMP WITH TIME ZONE`` and can retire the cast.
 """
 
 from __future__ import annotations

--- a/server/backend/src/cq_server/repositories/knowledge.py
+++ b/server/backend/src/cq_server/repositories/knowledge.py
@@ -9,7 +9,6 @@ from typing import Any
 from cq.models import KnowledgeUnit
 from cq.scoring import calculate_relevance
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.sql.expression import TextClause, text
 
 from ..core.db import Database
 from ..semsearch import _ENABLED as _SEMSEARCH_ENABLED
@@ -29,6 +28,7 @@ from ._queries import (
     SELECT_QUERY_UNITS,
     SELECT_TOTAL_COUNT,
     UPDATE_UNIT_DATA,
+    confidence_distribution_sql,
 )
 
 logger = logging.getLogger(__name__)
@@ -43,41 +43,10 @@ _CONFIDENCE_BUCKETS: list[tuple[float, str]] = [
     (float("inf"), "0.7-1.0"),
 ]
 
-# Bucket approved units by their persisted confidence in SQL rather than
-# parsing every unit into a model to read one float. The CASE thresholds must
-# stay in lockstep with `_CONFIDENCE_BUCKETS` above. COALESCE to 0.5 mirrors
-# the Evidence.confidence default that model-parsing applied, so a row whose
-# JSON omits the field buckets identically instead of falling to the catch-all.
-# Dialect-keyed: SQLite reads the JSON blob with `json_extract`; PostgreSQL
-# casts the TEXT column to `jsonb` and extracts with `#>>`. The derived
-# subquery MUST be aliased on PG (`AS sub`) — Postgres rejects an unnamed
-# FROM-subquery. Resolved once per repo from the engine dialect in `__init__`.
-_SELECT_CONFIDENCE_DISTRIBUTION: dict[str, TextClause] = {
-    "sqlite": text(
-        "SELECT "
-        "CASE "
-        "WHEN confidence < 0.3 THEN '0.0-0.3' "
-        "WHEN confidence < 0.5 THEN '0.3-0.5' "
-        "WHEN confidence < 0.7 THEN '0.5-0.7' "
-        "ELSE '0.7-1.0' "
-        "END AS bucket, COUNT(*) AS cnt "
-        "FROM (SELECT COALESCE(json_extract(data, '$.evidence.confidence'), 0.5) AS confidence "
-        "FROM knowledge_units WHERE status = 'approved') "
-        "GROUP BY bucket"
-    ),
-    "postgresql": text(
-        "SELECT "
-        "CASE "
-        "WHEN confidence < 0.3 THEN '0.0-0.3' "
-        "WHEN confidence < 0.5 THEN '0.3-0.5' "
-        "WHEN confidence < 0.7 THEN '0.5-0.7' "
-        "ELSE '0.7-1.0' "
-        "END AS bucket, COUNT(*) AS cnt "
-        "FROM (SELECT COALESCE((data::jsonb #>> '{evidence,confidence}')::numeric, 0.5) AS confidence "
-        "FROM knowledge_units WHERE status = 'approved') AS sub "
-        "GROUP BY bucket"
-    ),
-}
+# Bucket approved units by their persisted confidence in SQL (built from the
+# single `_CONFIDENCE_BUCKETS` source above) rather than parsing every unit
+# into a model to read one float. See `confidence_distribution_sql` for the
+# dialect handling; resolved once per repo from the engine dialect in `__init__`.
 
 
 class KnowledgeRepository:
@@ -86,7 +55,7 @@ class KnowledgeRepository:
     def __init__(self, db: Database) -> None:
         """Wire the repository to the shared ``Database``."""
         self._db = db
-        self._confidence_distribution_stmt = _SELECT_CONFIDENCE_DISTRIBUTION[db.engine.dialect.name]
+        self._confidence_distribution_stmt = confidence_distribution_sql(_CONFIDENCE_BUCKETS, db.engine.dialect.name)
 
     async def count(self) -> int:
         """Return the total number of stored units across all review statuses."""

--- a/server/backend/src/cq_server/repositories/knowledge.py
+++ b/server/backend/src/cq_server/repositories/knowledge.py
@@ -29,6 +29,7 @@ from ._queries import (
     SELECT_TOTAL_COUNT,
     UPDATE_UNIT_DATA,
     confidence_distribution_sql,
+    resolve_dialect,
 )
 
 logger = logging.getLogger(__name__)
@@ -55,7 +56,8 @@ class KnowledgeRepository:
     def __init__(self, db: Database) -> None:
         """Wire the repository to the shared ``Database``."""
         self._db = db
-        self._confidence_distribution_stmt = confidence_distribution_sql(_CONFIDENCE_BUCKETS, db.engine.dialect.name)
+        dialect = resolve_dialect(db.engine.dialect.name)
+        self._confidence_distribution_stmt = confidence_distribution_sql(_CONFIDENCE_BUCKETS, dialect)
 
     async def count(self) -> int:
         """Return the total number of stored units across all review statuses."""

--- a/server/backend/src/cq_server/repositories/knowledge.py
+++ b/server/backend/src/cq_server/repositories/knowledge.py
@@ -48,20 +48,36 @@ _CONFIDENCE_BUCKETS: list[tuple[float, str]] = [
 # stay in lockstep with `_CONFIDENCE_BUCKETS` above. COALESCE to 0.5 mirrors
 # the Evidence.confidence default that model-parsing applied, so a row whose
 # JSON omits the field buckets identically instead of falling to the catch-all.
-# SQLite-specific (`json_extract`), so it lives here rather than in the portable
-# `_queries` module; the backend is SQLite-only (see `core.db.Database`).
-_SELECT_CONFIDENCE_DISTRIBUTION: TextClause = text(
-    "SELECT "
-    "CASE "
-    "WHEN confidence < 0.3 THEN '0.0-0.3' "
-    "WHEN confidence < 0.5 THEN '0.3-0.5' "
-    "WHEN confidence < 0.7 THEN '0.5-0.7' "
-    "ELSE '0.7-1.0' "
-    "END AS bucket, COUNT(*) AS cnt "
-    "FROM (SELECT COALESCE(json_extract(data, '$.evidence.confidence'), 0.5) AS confidence "
-    "FROM knowledge_units WHERE status = 'approved') "
-    "GROUP BY bucket"
-)
+# Dialect-keyed: SQLite reads the JSON blob with `json_extract`; PostgreSQL
+# casts the TEXT column to `jsonb` and extracts with `#>>`. The derived
+# subquery MUST be aliased on PG (`AS sub`) — Postgres rejects an unnamed
+# FROM-subquery. Resolved once per repo from the engine dialect in `__init__`.
+_SELECT_CONFIDENCE_DISTRIBUTION: dict[str, TextClause] = {
+    "sqlite": text(
+        "SELECT "
+        "CASE "
+        "WHEN confidence < 0.3 THEN '0.0-0.3' "
+        "WHEN confidence < 0.5 THEN '0.3-0.5' "
+        "WHEN confidence < 0.7 THEN '0.5-0.7' "
+        "ELSE '0.7-1.0' "
+        "END AS bucket, COUNT(*) AS cnt "
+        "FROM (SELECT COALESCE(json_extract(data, '$.evidence.confidence'), 0.5) AS confidence "
+        "FROM knowledge_units WHERE status = 'approved') "
+        "GROUP BY bucket"
+    ),
+    "postgresql": text(
+        "SELECT "
+        "CASE "
+        "WHEN confidence < 0.3 THEN '0.0-0.3' "
+        "WHEN confidence < 0.5 THEN '0.3-0.5' "
+        "WHEN confidence < 0.7 THEN '0.5-0.7' "
+        "ELSE '0.7-1.0' "
+        "END AS bucket, COUNT(*) AS cnt "
+        "FROM (SELECT COALESCE((data::jsonb #>> '{evidence,confidence}')::numeric, 0.5) AS confidence "
+        "FROM knowledge_units WHERE status = 'approved') AS sub "
+        "GROUP BY bucket"
+    ),
+}
 
 
 class KnowledgeRepository:
@@ -70,6 +86,7 @@ class KnowledgeRepository:
     def __init__(self, db: Database) -> None:
         """Wire the repository to the shared ``Database``."""
         self._db = db
+        self._confidence_distribution_stmt = _SELECT_CONFIDENCE_DISTRIBUTION[db.engine.dialect.name]
 
     async def count(self) -> int:
         """Return the total number of stored units across all review statuses."""
@@ -188,7 +205,7 @@ class KnowledgeRepository:
         # returns rows for buckets that have at least one approved unit.
         buckets = {label: 0 for _, label in _CONFIDENCE_BUCKETS}
         with self._db.engine.connect() as conn:
-            rows = conn.execute(_SELECT_CONFIDENCE_DISTRIBUTION).fetchall()
+            rows = conn.execute(self._confidence_distribution_stmt).fetchall()
         for label, count in rows:
             buckets[label] = count
         return buckets

--- a/server/backend/src/cq_server/repositories/reviews.py
+++ b/server/backend/src/cq_server/repositories/reviews.py
@@ -19,6 +19,7 @@ from ._queries import (
     SELECT_REVIEW_STATUS_BY_ID,
     UPDATE_REVIEW_STATUS,
     confidence_distribution_sql,
+    resolve_dialect,
     select_list_units,
 )
 
@@ -40,7 +41,7 @@ class ReviewRepository:
     def __init__(self, db: Database) -> None:
         """Wire the repository to the shared ``Database``."""
         self._db = db
-        dialect = db.engine.dialect.name
+        dialect = resolve_dialect(db.engine.dialect.name)
         self._confidence_distribution_stmt = confidence_distribution_sql(_CONFIDENCE_BUCKETS, dialect)
         self._proposed_daily_stmt = SELECT_PROPOSED_DAILY[dialect]
         self._approved_daily_stmt = SELECT_APPROVED_DAILY[dialect]

--- a/server/backend/src/cq_server/repositories/reviews.py
+++ b/server/backend/src/cq_server/repositories/reviews.py
@@ -6,7 +6,6 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from cq.models import KnowledgeUnit
-from sqlalchemy.sql.expression import TextClause, text
 
 from ..core.db import Database
 from ._queries import (
@@ -19,44 +18,20 @@ from ._queries import (
     SELECT_REJECTED_DAILY,
     SELECT_REVIEW_STATUS_BY_ID,
     UPDATE_REVIEW_STATUS,
+    confidence_distribution_sql,
     select_list_units,
 )
 
-# Bucket approved units by their persisted confidence in SQL rather than
-# parsing every unit into a model to read one float. The review dashboard uses
-# different bucket boundaries (0.3/0.6/0.8) than the knowledge stats; keep them
-# distinct unless deliberately unified. COALESCE to 0.5 mirrors the
-# Evidence.confidence default that model-parsing applied, so a row whose JSON
-# omits the field buckets identically instead of falling to the catch-all.
-# Dialect-keyed: SQLite reads the JSON blob with `json_extract`; PostgreSQL
-# casts the TEXT column to `jsonb` and extracts with `#>>` (and must alias the
-# derived subquery `AS sub`). Resolved once per repo from the engine dialect.
-_SELECT_CONFIDENCE_DISTRIBUTION: dict[str, TextClause] = {
-    "sqlite": text(
-        "SELECT "
-        "CASE "
-        "WHEN confidence < 0.3 THEN '0.0-0.3' "
-        "WHEN confidence < 0.6 THEN '0.3-0.6' "
-        "WHEN confidence < 0.8 THEN '0.6-0.8' "
-        "ELSE '0.8-1.0' "
-        "END AS bucket, COUNT(*) AS cnt "
-        "FROM (SELECT COALESCE(json_extract(data, '$.evidence.confidence'), 0.5) AS confidence "
-        "FROM knowledge_units WHERE status = 'approved') "
-        "GROUP BY bucket"
-    ),
-    "postgresql": text(
-        "SELECT "
-        "CASE "
-        "WHEN confidence < 0.3 THEN '0.0-0.3' "
-        "WHEN confidence < 0.6 THEN '0.3-0.6' "
-        "WHEN confidence < 0.8 THEN '0.6-0.8' "
-        "ELSE '0.8-1.0' "
-        "END AS bucket, COUNT(*) AS cnt "
-        "FROM (SELECT COALESCE((data::jsonb #>> '{evidence,confidence}')::numeric, 0.5) AS confidence "
-        "FROM knowledge_units WHERE status = 'approved') AS sub "
-        "GROUP BY bucket"
-    ),
-}
+# The review dashboard uses different bucket boundaries (0.3/0.6/0.8) than the
+# knowledge stats; keep them distinct unless deliberately unified. Each entry is
+# `(exclusive upper bound, label)` low-to-high, last entry's `inf` bound is the
+# catch-all. Single source for both the SQL and the result dict's key set.
+_CONFIDENCE_BUCKETS: list[tuple[float, str]] = [
+    (0.3, "0.0-0.3"),
+    (0.6, "0.3-0.6"),
+    (0.8, "0.6-0.8"),
+    (float("inf"), "0.8-1.0"),
+]
 
 
 class ReviewRepository:
@@ -66,7 +41,7 @@ class ReviewRepository:
         """Wire the repository to the shared ``Database``."""
         self._db = db
         dialect = db.engine.dialect.name
-        self._confidence_distribution_stmt = _SELECT_CONFIDENCE_DISTRIBUTION[dialect]
+        self._confidence_distribution_stmt = confidence_distribution_sql(_CONFIDENCE_BUCKETS, dialect)
         self._proposed_daily_stmt = SELECT_PROPOSED_DAILY[dialect]
         self._approved_daily_stmt = SELECT_APPROVED_DAILY[dialect]
         self._rejected_daily_stmt = SELECT_REJECTED_DAILY[dialect]
@@ -127,7 +102,7 @@ class ReviewRepository:
     def _confidence_distribution_sync(self) -> dict[str, int]:
         # Seed every bucket so absent labels report 0; the SQL only returns
         # rows for buckets that have at least one approved unit.
-        buckets = {"0.0-0.3": 0, "0.3-0.6": 0, "0.6-0.8": 0, "0.8-1.0": 0}
+        buckets = {label: 0 for _, label in _CONFIDENCE_BUCKETS}
         with self._db.engine.connect() as conn:
             rows = conn.execute(self._confidence_distribution_stmt).fetchall()
         for label, count in rows:

--- a/server/backend/src/cq_server/repositories/reviews.py
+++ b/server/backend/src/cq_server/repositories/reviews.py
@@ -28,20 +28,35 @@ from ._queries import (
 # distinct unless deliberately unified. COALESCE to 0.5 mirrors the
 # Evidence.confidence default that model-parsing applied, so a row whose JSON
 # omits the field buckets identically instead of falling to the catch-all.
-# SQLite-specific (`json_extract`), so it lives here rather than in the portable
-# `_queries` module; the backend is SQLite-only (see `core.db.Database`).
-_SELECT_CONFIDENCE_DISTRIBUTION: TextClause = text(
-    "SELECT "
-    "CASE "
-    "WHEN confidence < 0.3 THEN '0.0-0.3' "
-    "WHEN confidence < 0.6 THEN '0.3-0.6' "
-    "WHEN confidence < 0.8 THEN '0.6-0.8' "
-    "ELSE '0.8-1.0' "
-    "END AS bucket, COUNT(*) AS cnt "
-    "FROM (SELECT COALESCE(json_extract(data, '$.evidence.confidence'), 0.5) AS confidence "
-    "FROM knowledge_units WHERE status = 'approved') "
-    "GROUP BY bucket"
-)
+# Dialect-keyed: SQLite reads the JSON blob with `json_extract`; PostgreSQL
+# casts the TEXT column to `jsonb` and extracts with `#>>` (and must alias the
+# derived subquery `AS sub`). Resolved once per repo from the engine dialect.
+_SELECT_CONFIDENCE_DISTRIBUTION: dict[str, TextClause] = {
+    "sqlite": text(
+        "SELECT "
+        "CASE "
+        "WHEN confidence < 0.3 THEN '0.0-0.3' "
+        "WHEN confidence < 0.6 THEN '0.3-0.6' "
+        "WHEN confidence < 0.8 THEN '0.6-0.8' "
+        "ELSE '0.8-1.0' "
+        "END AS bucket, COUNT(*) AS cnt "
+        "FROM (SELECT COALESCE(json_extract(data, '$.evidence.confidence'), 0.5) AS confidence "
+        "FROM knowledge_units WHERE status = 'approved') "
+        "GROUP BY bucket"
+    ),
+    "postgresql": text(
+        "SELECT "
+        "CASE "
+        "WHEN confidence < 0.3 THEN '0.0-0.3' "
+        "WHEN confidence < 0.6 THEN '0.3-0.6' "
+        "WHEN confidence < 0.8 THEN '0.6-0.8' "
+        "ELSE '0.8-1.0' "
+        "END AS bucket, COUNT(*) AS cnt "
+        "FROM (SELECT COALESCE((data::jsonb #>> '{evidence,confidence}')::numeric, 0.5) AS confidence "
+        "FROM knowledge_units WHERE status = 'approved') AS sub "
+        "GROUP BY bucket"
+    ),
+}
 
 
 class ReviewRepository:
@@ -50,6 +65,11 @@ class ReviewRepository:
     def __init__(self, db: Database) -> None:
         """Wire the repository to the shared ``Database``."""
         self._db = db
+        dialect = db.engine.dialect.name
+        self._confidence_distribution_stmt = _SELECT_CONFIDENCE_DISTRIBUTION[dialect]
+        self._proposed_daily_stmt = SELECT_PROPOSED_DAILY[dialect]
+        self._approved_daily_stmt = SELECT_APPROVED_DAILY[dialect]
+        self._rejected_daily_stmt = SELECT_REJECTED_DAILY[dialect]
 
     async def confidence_distribution(self) -> dict[str, int]:
         """Return approved-unit counts grouped into four confidence buckets."""
@@ -109,7 +129,7 @@ class ReviewRepository:
         # rows for buckets that have at least one approved unit.
         buckets = {"0.0-0.3": 0, "0.3-0.6": 0, "0.6-0.8": 0, "0.8-1.0": 0}
         with self._db.engine.connect() as conn:
-            rows = conn.execute(_SELECT_CONFIDENCE_DISTRIBUTION).fetchall()
+            rows = conn.execute(self._confidence_distribution_stmt).fetchall()
         for label, count in rows:
             buckets[label] = count
         return buckets
@@ -121,10 +141,11 @@ class ReviewRepository:
 
     def _daily_counts_sync(self, *, days: int) -> list[dict[str, Any]]:
         cutoff = (datetime.now(UTC) - timedelta(days=days)).date().isoformat()
+        params = {"cutoff": cutoff}
         with self._db.engine.connect() as conn:
-            proposed = {row[0]: row[1] for row in conn.execute(SELECT_PROPOSED_DAILY, {"cutoff": cutoff}).fetchall()}
-            approved = {row[0]: row[1] for row in conn.execute(SELECT_APPROVED_DAILY, {"cutoff": cutoff}).fetchall()}
-            rejected = {row[0]: row[1] for row in conn.execute(SELECT_REJECTED_DAILY, {"cutoff": cutoff}).fetchall()}
+            proposed = {row[0]: row[1] for row in conn.execute(self._proposed_daily_stmt, params).fetchall()}
+            approved = {row[0]: row[1] for row in conn.execute(self._approved_daily_stmt, params).fetchall()}
+            rejected = {row[0]: row[1] for row in conn.execute(self._rejected_daily_stmt, params).fetchall()}
         all_dates = set(proposed) | set(approved) | set(rejected)
         if not all_dates:
             return []

--- a/server/backend/tests/conftest.py
+++ b/server/backend/tests/conftest.py
@@ -169,8 +169,11 @@ async def pg_repos(pg_url: str, monkeypatch: pytest.MonkeyPatch) -> AsyncIterato
     """Yield repositories wired to the PostgreSQL container, cleaned per test."""
     # These tests don't exercise semantic search; disable it so the PG suite
     # runs even when CI sets TOKEN_EMBEDDING_URL (which would otherwise trip
-    # Database's semsearch-on-PG fail-fast guard).
+    # Database's semsearch-on-PG fail-fast guard *and* make the insert/query
+    # paths run sqlite-vec SQL against PG). Each module imported its own
+    # ``_SEMSEARCH_ENABLED`` binding, so both must be patched.
     monkeypatch.setattr("cq_server.core.db._SEMSEARCH_ENABLED", False)
+    monkeypatch.setattr("cq_server.repositories.knowledge._SEMSEARCH_ENABLED", False)
     db = Database(_build_pg_settings(pg_url))
     with db.engine.begin() as conn:
         conn.execute(text("TRUNCATE knowledge_units, knowledge_unit_domains, api_keys, users RESTART IDENTITY CASCADE"))

--- a/server/backend/tests/conftest.py
+++ b/server/backend/tests/conftest.py
@@ -11,15 +11,17 @@ the old ``Store`` while delegating to the new repositories.
 from __future__ import annotations
 
 import logging
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Iterator
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 import pytest_asyncio
+from sqlalchemy import text
 
 from cq_server.core.config import Settings
 from cq_server.core.db import Database
+from cq_server.migrations import run_migrations
 from cq_server.repositories import (
     APIKeyRepository,
     KnowledgeRepository,
@@ -56,6 +58,15 @@ def _build_settings(db_path: Path) -> Settings:
         api_key_pepper="test-pepper",  # pragma: allowlist secret
         database_url=f"sqlite:///{db_path}",
         db_path=db_path,
+    )
+
+
+def _build_pg_settings(url: str) -> Settings:
+    """Create a Settings instance pointed at the PostgreSQL container URL."""
+    return Settings(  # type: ignore[call-arg]
+        jwt_secret="test-jwt-secret",  # pragma: allowlist secret
+        api_key_pepper="test-pepper",  # pragma: allowlist secret
+        database_url=url,
     )
 
 
@@ -123,6 +134,42 @@ async def reviews_repo(repos: _RepoBundle) -> ReviewRepository:
         ReviewRepository: The review repository instance from the provided bundle.
     """
     return repos.reviews
+
+
+@pytest.fixture(scope="session")
+def pg_url() -> Iterator[str]:
+    """Start a session-scoped PostgreSQL container and yield its psycopg URL.
+
+    Skips the whole PG suite when Docker is unavailable so the SQLite
+    tests still run on a bare machine (see #312 DoD). Migrations run once
+    against the fresh container; per-test isolation is handled by
+    ``pg_repos`` truncating between tests.
+    """
+    testcontainers = pytest.importorskip("testcontainers.postgres")
+    try:
+        container = testcontainers.PostgresContainer("postgres:16-alpine", driver="psycopg")
+        container.start()
+    except Exception as exc:  # noqa: BLE001 — Docker missing/unreachable
+        pytest.skip(f"PostgreSQL container unavailable: {exc}")
+    try:
+        url = container.get_connection_url()
+        run_migrations(url)
+        yield url
+    finally:
+        container.stop()
+
+
+@pytest_asyncio.fixture
+async def pg_repos(pg_url: str) -> AsyncIterator[_RepoBundle]:
+    """Yield repositories wired to the PostgreSQL container, cleaned per test."""
+    db = Database(_build_pg_settings(pg_url))
+    with db.engine.begin() as conn:
+        conn.execute(text("TRUNCATE knowledge_units, knowledge_unit_domains, api_keys, users RESTART IDENTITY CASCADE"))
+    bundle = _RepoBundle(db)
+    try:
+        yield bundle
+    finally:
+        await bundle.close()
 
 
 @pytest_asyncio.fixture

--- a/server/backend/tests/conftest.py
+++ b/server/backend/tests/conftest.py
@@ -139,27 +139,31 @@ async def reviews_repo(repos: _RepoBundle) -> ReviewRepository:
 
 @pytest.fixture(scope="session")
 def pg_url() -> Iterator[str]:
-    """Start a session-scoped PostgreSQL container and yield its psycopg URL.
+    """Yield a PostgreSQL psycopg URL for the PG suite, migrated once per session.
 
-    When Docker is unavailable the PG suite skips locally but fails in CI
-    (see the except branch below). Migrations run once against the fresh
-    container; per-test isolation is handled by ``pg_repos`` truncating
-    between tests.
+    If ``CQ_TEST_DATABASE_URL`` is set, use it and do no provisioning here —
+    this is how CI (a ``services:`` Postgres) and any ``make`` target hand us a
+    ready database, keeping infra setup out of the test code. Otherwise spin a
+    session-scoped testcontainer so local runs work with just Docker present,
+    skipping cleanly when Docker is unavailable.
 
-    Not safe under ``pytest-xdist``: the container is shared session-wide,
-    so a ``pg_repos`` TRUNCATE in one worker would clobber another worker's
-    in-flight data. Give each xdist worker its own container before enabling
-    parallel PG runs.
+    Per-test isolation is handled by ``pg_repos`` truncating between tests.
+    Not safe under ``pytest-xdist``: the database is shared session-wide, so a
+    ``pg_repos`` TRUNCATE in one worker would clobber another worker's in-flight
+    data. Give each xdist worker its own database before enabling parallel runs.
     """
+    injected = os.getenv("CQ_TEST_DATABASE_URL")
+    if injected:
+        run_migrations(injected)
+        yield injected
+        return
+
     testcontainers = pytest.importorskip("testcontainers.postgres")
     try:
         container = testcontainers.PostgresContainer("postgres:16-alpine", driver="psycopg")
         container.start()
     except Exception as exc:  # noqa: BLE001 — Docker missing/unreachable
-        # CI has Docker, so an unavailable container is broken infra, not an opt-out.
-        if os.getenv("CI"):
-            pytest.fail(f"PostgreSQL container unavailable in CI: {exc}")
-        pytest.skip(f"PostgreSQL container unavailable: {exc}")
+        pytest.skip(f"PostgreSQL unavailable (set CQ_TEST_DATABASE_URL or start Docker): {exc}")
     try:
         url = container.get_connection_url()
         run_migrations(url)

--- a/server/backend/tests/conftest.py
+++ b/server/backend/tests/conftest.py
@@ -144,6 +144,11 @@ def pg_url() -> Iterator[str]:
     tests still run on a bare machine (see #312 DoD). Migrations run once
     against the fresh container; per-test isolation is handled by
     ``pg_repos`` truncating between tests.
+
+    Not safe under ``pytest-xdist``: the container is shared session-wide,
+    so a ``pg_repos`` TRUNCATE in one worker would clobber another worker's
+    in-flight data. Give each xdist worker its own container before enabling
+    parallel PG runs.
     """
     testcontainers = pytest.importorskip("testcontainers.postgres")
     try:

--- a/server/backend/tests/conftest.py
+++ b/server/backend/tests/conftest.py
@@ -11,6 +11,7 @@ the old ``Store`` while delegating to the new repositories.
 from __future__ import annotations
 
 import logging
+import os
 from collections.abc import AsyncIterator, Iterator
 from pathlib import Path
 from types import SimpleNamespace
@@ -140,10 +141,10 @@ async def reviews_repo(repos: _RepoBundle) -> ReviewRepository:
 def pg_url() -> Iterator[str]:
     """Start a session-scoped PostgreSQL container and yield its psycopg URL.
 
-    Skips the whole PG suite when Docker is unavailable so the SQLite
-    tests still run on a bare machine (see #312 DoD). Migrations run once
-    against the fresh container; per-test isolation is handled by
-    ``pg_repos`` truncating between tests.
+    When Docker is unavailable the PG suite skips locally but fails in CI
+    (see the except branch below). Migrations run once against the fresh
+    container; per-test isolation is handled by ``pg_repos`` truncating
+    between tests.
 
     Not safe under ``pytest-xdist``: the container is shared session-wide,
     so a ``pg_repos`` TRUNCATE in one worker would clobber another worker's
@@ -155,6 +156,9 @@ def pg_url() -> Iterator[str]:
         container = testcontainers.PostgresContainer("postgres:16-alpine", driver="psycopg")
         container.start()
     except Exception as exc:  # noqa: BLE001 — Docker missing/unreachable
+        # CI has Docker, so an unavailable container is broken infra, not an opt-out.
+        if os.getenv("CI"):
+            pytest.fail(f"PostgreSQL container unavailable in CI: {exc}")
         pytest.skip(f"PostgreSQL container unavailable: {exc}")
     try:
         url = container.get_connection_url()

--- a/server/backend/tests/conftest.py
+++ b/server/backend/tests/conftest.py
@@ -159,10 +159,15 @@ def pg_url() -> Iterator[str]:
         return
 
     testcontainers = pytest.importorskip("testcontainers.postgres")
+    from docker.errors import DockerException  # docker is a testcontainers dependency
+
     try:
         container = testcontainers.PostgresContainer("postgres:16-alpine", driver="psycopg")
         container.start()
-    except Exception as exc:  # noqa: BLE001 — Docker missing/unreachable
+    except DockerException as exc:
+        # Skip only when the Docker daemon itself is unreachable; other errors
+        # (image pull, port conflict, OOM) surface as real failures rather than
+        # a green suite that silently ran nothing.
         pytest.skip(f"PostgreSQL unavailable (set CQ_TEST_DATABASE_URL or start Docker): {exc}")
     try:
         url = container.get_connection_url()

--- a/server/backend/tests/conftest.py
+++ b/server/backend/tests/conftest.py
@@ -165,8 +165,12 @@ def pg_url() -> Iterator[str]:
 
 
 @pytest_asyncio.fixture
-async def pg_repos(pg_url: str) -> AsyncIterator[_RepoBundle]:
+async def pg_repos(pg_url: str, monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[_RepoBundle]:
     """Yield repositories wired to the PostgreSQL container, cleaned per test."""
+    # These tests don't exercise semantic search; disable it so the PG suite
+    # runs even when CI sets TOKEN_EMBEDDING_URL (which would otherwise trip
+    # Database's semsearch-on-PG fail-fast guard).
+    monkeypatch.setattr("cq_server.core.db._SEMSEARCH_ENABLED", False)
     db = Database(_build_pg_settings(pg_url))
     with db.engine.begin() as conn:
         conn.execute(text("TRUNCATE knowledge_units, knowledge_unit_domains, api_keys, users RESTART IDENTITY CASCADE"))

--- a/server/backend/tests/test_app.py
+++ b/server/backend/tests/test_app.py
@@ -568,15 +568,6 @@ class TestDatabaseUrlBoot:
         assert winning.exists()
         assert not losing.exists()
 
-    def test_postgres_url_fails_fast_with_guidance(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("CQ_JWT_SECRET", "test-secret-please-ignore-len")
-        monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")
-        monkeypatch.setenv("CQ_DATABASE_URL", "postgresql+psycopg://u:p@h/d")
-        with pytest.raises(NotImplementedError) as exc, TestClient(app):
-            pass
-        message = str(exc.value)
-        assert "#312" in message
-
 
 class TestApiKeyEnforcement:
     def test_propose_without_key_is_rejected(self, enforced_client: TestClient) -> None:

--- a/server/backend/tests/test_db.py
+++ b/server/backend/tests/test_db.py
@@ -22,7 +22,10 @@ class TestPostgresUrlDispatch:
         # runs without a live PostgreSQL.
         settings = _settings_with_url(monkeypatch, "postgresql+psycopg://u:p@h/d")
         db = Database(settings)
-        assert db.engine.dialect.name == "postgresql"
+        try:
+            assert db.engine.dialect.name == "postgresql"
+        finally:
+            db.engine.dispose()
 
     @pytest.mark.parametrize(
         "url",
@@ -39,20 +42,25 @@ class TestPostgresUrlDispatch:
         with pytest.raises(NotImplementedError) as exc:
             Database(settings)
         message = str(exc.value)
-        assert "#312" in message
         # The message must steer to the canonical driver, not just echo
-        # the URL.  "use postgresql+psycopg://" is unique to the
+        # the URL.  "use ... postgresql+psycopg://" is unique to the
         # non-canonical branch — it won't match a psycopg2 URL repr.
-        assert "use postgresql+psycopg://" in message
+        assert "postgresql+psycopg://" in message
 
     def test_pool_knobs_honoured_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("CQ_DB_POOL_SIZE", "7")
         monkeypatch.setenv("CQ_DB_MAX_OVERFLOW", "3")
         settings = _settings_with_url(monkeypatch, "postgresql+psycopg://u:p@h/d")
         db = Database(settings)
-        pool = db.engine.pool
-        assert pool.size() == 7
-        assert pool._max_overflow == 3
+        try:
+            pool = db.engine.pool
+            assert pool.size() == 7
+            # ``_max_overflow`` is a private QueuePool attr; SQLAlchemy exposes
+            # no public getter for it, and asserting it without a live PG means
+            # we can't observe it via a checked-out connection.
+            assert pool._max_overflow == 3
+        finally:
+            db.engine.dispose()
 
     def test_semsearch_enabled_on_postgres_fails_fast(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr("cq_server.core.db._SEMSEARCH_ENABLED", True)

--- a/server/backend/tests/test_db.py
+++ b/server/backend/tests/test_db.py
@@ -17,15 +17,12 @@ def _settings_with_url(monkeypatch: pytest.MonkeyPatch, url: str) -> Settings:
 class TestPostgresUrlDispatch:
     """URL dispatch for PostgreSQL drivers in ``Database.__init__``."""
 
-    def test_psycopg_url_raises_not_implemented_with_guidance(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_psycopg_url_builds_postgres_engine(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # ``create_engine`` is lazy — no connection is opened here, so this
+        # runs without a live PostgreSQL.
         settings = _settings_with_url(monkeypatch, "postgresql+psycopg://u:p@h/d")
-        with pytest.raises(NotImplementedError) as exc:
-            Database(settings)
-        message = str(exc.value)
-        assert "#312" in message
-        # #311 is closing with this change; the message should only
-        # reference the implementation issue.
-        assert "#311" not in message
+        db = Database(settings)
+        assert db.engine.dialect.name == "postgresql"
 
     @pytest.mark.parametrize(
         "url",
@@ -47,6 +44,21 @@ class TestPostgresUrlDispatch:
         # the URL.  "use postgresql+psycopg://" is unique to the
         # non-canonical branch — it won't match a psycopg2 URL repr.
         assert "use postgresql+psycopg://" in message
+
+    def test_pool_knobs_honoured_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CQ_DB_POOL_SIZE", "7")
+        monkeypatch.setenv("CQ_DB_MAX_OVERFLOW", "3")
+        settings = _settings_with_url(monkeypatch, "postgresql+psycopg://u:p@h/d")
+        db = Database(settings)
+        pool = db.engine.pool
+        assert pool.size() == 7
+        assert pool._max_overflow == 3
+
+    def test_semsearch_enabled_on_postgres_fails_fast(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("cq_server.core.db._SEMSEARCH_ENABLED", True)
+        settings = _settings_with_url(monkeypatch, "postgresql+psycopg://u:p@h/d")
+        with pytest.raises(RuntimeError, match="semantic search is not yet supported on the PostgreSQL backend"):
+            Database(settings)
 
     def test_unsupported_scheme_raises_value_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
         settings = _settings_with_url(monkeypatch, "mysql://u:p@h/d")

--- a/server/backend/tests/test_db.py
+++ b/server/backend/tests/test_db.py
@@ -20,6 +20,7 @@ class TestPostgresUrlDispatch:
     def test_psycopg_url_builds_postgres_engine(self, monkeypatch: pytest.MonkeyPatch) -> None:
         # ``create_engine`` is lazy — no connection is opened here, so this
         # runs without a live PostgreSQL.
+        monkeypatch.setattr("cq_server.core.db._SEMSEARCH_ENABLED", False)
         settings = _settings_with_url(monkeypatch, "postgresql+psycopg://u:p@h/d")
         db = Database(settings)
         try:
@@ -48,6 +49,7 @@ class TestPostgresUrlDispatch:
         assert "postgresql+psycopg://" in message
 
     def test_pool_knobs_honoured_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("cq_server.core.db._SEMSEARCH_ENABLED", False)
         monkeypatch.setenv("CQ_DB_POOL_SIZE", "7")
         monkeypatch.setenv("CQ_DB_MAX_OVERFLOW", "3")
         settings = _settings_with_url(monkeypatch, "postgresql+psycopg://u:p@h/d")

--- a/server/backend/tests/test_db.py
+++ b/server/backend/tests/test_db.py
@@ -48,22 +48,6 @@ class TestPostgresUrlDispatch:
         # non-canonical branch — it won't match a psycopg2 URL repr.
         assert "postgresql+psycopg://" in message
 
-    def test_pool_knobs_honoured_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr("cq_server.core.db._SEMSEARCH_ENABLED", False)
-        monkeypatch.setenv("CQ_DB_POOL_SIZE", "7")
-        monkeypatch.setenv("CQ_DB_MAX_OVERFLOW", "3")
-        settings = _settings_with_url(monkeypatch, "postgresql+psycopg://u:p@h/d")
-        db = Database(settings)
-        try:
-            pool = db.engine.pool
-            assert pool.size() == 7
-            # ``_max_overflow`` is a private QueuePool attr; SQLAlchemy exposes
-            # no public getter for it, and asserting it without a live PG means
-            # we can't observe it via a checked-out connection.
-            assert pool._max_overflow == 3
-        finally:
-            db.engine.dispose()
-
     def test_semsearch_enabled_on_postgres_fails_fast(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr("cq_server.core.db._SEMSEARCH_ENABLED", True)
         settings = _settings_with_url(monkeypatch, "postgresql+psycopg://u:p@h/d")

--- a/server/backend/tests/test_postgres.py
+++ b/server/backend/tests/test_postgres.py
@@ -2,14 +2,18 @@
 
 These exercise the queries that diverge between SQLite and PostgreSQL
 (confidence distribution, daily counts) plus a basic round-trip smoke
-test, all against the session-scoped ``pg_repos`` fixture (a real
-PostgreSQL container). The whole module skips when Docker is unavailable.
+test, all against the ``pg_repos`` fixture (function-scoped repositories
+sharing the session-scoped ``pg_url`` PostgreSQL container). The whole
+module skips when Docker is unavailable.
 """
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from cq.models import Evidence, Insight, KnowledgeUnit, create_knowledge_unit
+from sqlalchemy import text
+
+from cq_server.repositories._queries import SELECT_PROPOSED_DAILY
 
 from .db_helpers import _RepoBundle
 
@@ -28,11 +32,15 @@ def _make_unit(*, confidence: float = 0.9, **overrides: Any) -> KnowledgeUnit:
     return unit
 
 
-async def _insert_and_approve(repos: _RepoBundle, **kwargs: Any) -> KnowledgeUnit:
+async def _insert_and_review(repos: _RepoBundle, status: str, **kwargs: Any) -> KnowledgeUnit:
     unit = _make_unit(**kwargs)
     await repos.insert(unit)
-    await repos.set_review_status(unit.id, "approved", "reviewer")
+    await repos.set_review_status(unit.id, status, "reviewer")
     return unit
+
+
+async def _insert_and_approve(repos: _RepoBundle, **kwargs: Any) -> KnowledgeUnit:
+    return await _insert_and_review(repos, "approved", **kwargs)
 
 
 async def test_pg_insert_query_roundtrip(pg_repos: _RepoBundle) -> None:
@@ -68,3 +76,49 @@ async def test_pg_daily_counts(pg_repos: _RepoBundle) -> None:
     by_date = {r["date"]: r for r in rows}
     assert by_date[today]["proposed"] == 1
     assert by_date[today]["approved"] == 1
+
+
+async def test_pg_daily_counts_rejected(pg_repos: _RepoBundle) -> None:
+    # The rejected-daily query is a distinct dialect-keyed branch; cover it too.
+    await _insert_and_review(pg_repos, "rejected")
+    rows = await pg_repos.daily_counts(days=7)
+    today = datetime.now(UTC).date().isoformat()
+    by_date = {r["date"]: r for r in rows}
+    assert by_date[today]["rejected"] == 1
+    assert by_date[today]["approved"] == 0
+
+
+async def test_pg_daily_counts_excludes_before_cutoff(pg_repos: _RepoBundle) -> None:
+    # The ``>= :cutoff`` filter is copy-pasted into the PG variant of ``_daily``
+    # (not shared with the SQLite one), and on PG it is a lexicographic text
+    # comparison against the TEXT column. Pin it directly: a row dated exactly
+    # on the cutoff is included, one a second before is excluded.
+    now = datetime.now(UTC)
+    cutoff_date = (now - timedelta(days=30)).date()
+    midnight = datetime(cutoff_date.year, cutoff_date.month, cutoff_date.day, tzinfo=UTC)
+    on_cutoff = await _insert_and_approve(pg_repos, domains=["on"])
+    before_cutoff = await _insert_and_approve(pg_repos, domains=["before"])
+    with pg_repos._engine.begin() as conn:
+        update = text("UPDATE knowledge_units SET created_at = :when WHERE id = :id")
+        conn.execute(update, {"when": midnight.isoformat(), "id": on_cutoff.id})
+        conn.execute(update, {"when": (midnight - timedelta(seconds=1)).isoformat(), "id": before_cutoff.id})
+    with pg_repos._engine.connect() as conn:
+        rows = conn.execute(SELECT_PROPOSED_DAILY["postgresql"], {"cutoff": cutoff_date.isoformat()}).fetchall()
+    counts = {row[0]: row[1] for row in rows}
+    assert counts.get(cutoff_date.isoformat()) == 1  # on-cutoff row included
+    assert sum(counts.values()) == 1  # before-cutoff row excluded entirely
+
+
+async def test_pg_daily_counts_datestyle_independent(pg_repos: _RepoBundle) -> None:
+    # The day key uses ``to_char(..., 'YYYY-MM-DD')`` rather than ``::date::text``
+    # precisely so it stays ISO regardless of the session ``DateStyle``. Run the
+    # proposed-daily query on a connection pinned to a non-ISO DateStyle and
+    # assert the key is still ISO — a regression to ``::date::text`` would yield
+    # e.g. '16.07.2026' and fail here.
+    await _insert_and_approve(pg_repos)
+    cutoff = (datetime.now(UTC) - timedelta(days=7)).date().isoformat()
+    with pg_repos._engine.connect() as conn:
+        conn.execute(text("SET DateStyle = 'German, DMY'"))
+        rows = conn.execute(SELECT_PROPOSED_DAILY["postgresql"], {"cutoff": cutoff}).fetchall()
+    today = datetime.now(UTC).date().isoformat()
+    assert today in {row[0] for row in rows}

--- a/server/backend/tests/test_postgres.py
+++ b/server/backend/tests/test_postgres.py
@@ -1,0 +1,70 @@
+"""Behavior tests for the repository layer running on PostgreSQL.
+
+These exercise the queries that diverge between SQLite and PostgreSQL
+(confidence distribution, daily counts) plus a basic round-trip smoke
+test, all against the session-scoped ``pg_repos`` fixture (a real
+PostgreSQL container). The whole module skips when Docker is unavailable.
+"""
+
+from datetime import UTC, datetime
+from typing import Any
+
+from cq.models import Evidence, Insight, KnowledgeUnit, create_knowledge_unit
+
+from .db_helpers import _RepoBundle
+
+
+def _make_unit(*, confidence: float = 0.9, **overrides: Any) -> KnowledgeUnit:
+    defaults: dict[str, Any] = {
+        "domains": ["databases", "performance"],
+        "insight": Insight(
+            summary="Use connection pooling",
+            detail="Database connections are expensive to create.",
+            action="Configure a connection pool with a max size of 10.",
+        ),
+    }
+    unit = create_knowledge_unit(**{**defaults, **overrides})
+    unit.evidence = Evidence(confidence=confidence)
+    return unit
+
+
+async def _insert_and_approve(repos: _RepoBundle, **kwargs: Any) -> KnowledgeUnit:
+    unit = _make_unit(**kwargs)
+    await repos.insert(unit)
+    await repos.set_review_status(unit.id, "approved", "reviewer")
+    return unit
+
+
+async def test_pg_insert_query_roundtrip(pg_repos: _RepoBundle) -> None:
+    unit = await _insert_and_approve(pg_repos, domains=["databases"])
+    results = await pg_repos.query(["databases"])
+    assert [u.id for u in results] == [unit.id]
+
+
+async def test_pg_knowledge_confidence_distribution(pg_repos: _RepoBundle) -> None:
+    # Buckets: 0.0-0.3, 0.3-0.5, 0.5-0.7, 0.7-1.0
+    await _insert_and_approve(pg_repos, confidence=0.2)
+    await _insert_and_approve(pg_repos, confidence=0.6)
+    await _insert_and_approve(pg_repos, confidence=0.95)
+    dist = await pg_repos.knowledge.confidence_distribution()
+    assert dist == {"0.0-0.3": 1, "0.3-0.5": 0, "0.5-0.7": 1, "0.7-1.0": 1}
+
+
+async def test_pg_reviews_confidence_distribution(pg_repos: _RepoBundle) -> None:
+    # Review dashboard buckets: 0.0-0.3, 0.3-0.6, 0.6-0.8, 0.8-1.0
+    await _insert_and_approve(pg_repos, confidence=0.2)
+    await _insert_and_approve(pg_repos, confidence=0.5)
+    await _insert_and_approve(pg_repos, confidence=0.9)
+    dist = await pg_repos.reviews.confidence_distribution()
+    assert dist == {"0.0-0.3": 1, "0.3-0.6": 1, "0.6-0.8": 0, "0.8-1.0": 1}
+
+
+async def test_pg_daily_counts(pg_repos: _RepoBundle) -> None:
+    # One proposed+approved unit today; daily_counts must aggregate it by day
+    # via the ``(created_at::timestamptz)::date`` PG cast, not ``date(text)``.
+    await _insert_and_approve(pg_repos)
+    rows = await pg_repos.daily_counts(days=7)
+    today = datetime.now(UTC).date().isoformat()
+    by_date = {r["date"]: r for r in rows}
+    assert by_date[today]["proposed"] == 1
+    assert by_date[today]["approved"] == 1

--- a/server/backend/tests/test_postgres.py
+++ b/server/backend/tests/test_postgres.py
@@ -61,7 +61,7 @@ async def test_pg_reviews_confidence_distribution(pg_repos: _RepoBundle) -> None
 
 async def test_pg_daily_counts(pg_repos: _RepoBundle) -> None:
     # One proposed+approved unit today; daily_counts must aggregate it by day
-    # via the ``(created_at::timestamptz)::date`` PG cast, not ``date(text)``.
+    # via ``to_char(created_at::timestamptz, 'YYYY-MM-DD')``, not ``date(text)``.
     await _insert_and_approve(pg_repos)
     rows = await pg_repos.daily_counts(days=7)
     today = datetime.now(UTC).date().isoformat()

--- a/server/backend/tests/test_queries.py
+++ b/server/backend/tests/test_queries.py
@@ -392,7 +392,7 @@ def _backdate(engine: Engine, *, column: str, unit_id: str, when: datetime) -> N
 
 
 class TestDailyCounts:
-    """Cutoff is computed in Python per RFC #275."""
+    """Cutoff is computed in Python, not in SQL."""
 
     async def test_proposed_daily(self, db: tuple[_RepoBundle, Engine]) -> None:
         store, engine = db

--- a/server/backend/tests/test_queries.py
+++ b/server/backend/tests/test_queries.py
@@ -404,7 +404,7 @@ class TestDailyCounts:
         _backdate(engine, column="created_at", unit_id=u_old.id, when=now - timedelta(days=60))
         cutoff = (now - timedelta(days=30)).date().isoformat()
         with engine.connect() as conn:
-            rows = conn.execute(q.SELECT_PROPOSED_DAILY, {"cutoff": cutoff}).fetchall()
+            rows = conn.execute(q.SELECT_PROPOSED_DAILY["sqlite"], {"cutoff": cutoff}).fetchall()
         # u_old is older than the cutoff and excluded.
         assert sum(row[1] for row in rows) == 1
 
@@ -416,7 +416,7 @@ class TestDailyCounts:
         await store.set_review_status(u.id, "approved", "rev")
         cutoff = (now - timedelta(days=30)).date().isoformat()
         with engine.connect() as conn:
-            rows = conn.execute(q.SELECT_APPROVED_DAILY, {"cutoff": cutoff}).fetchall()
+            rows = conn.execute(q.SELECT_APPROVED_DAILY["sqlite"], {"cutoff": cutoff}).fetchall()
         assert sum(row[1] for row in rows) == 1
 
     async def test_rejected_daily_excludes_old(self, db: tuple[_RepoBundle, Engine]) -> None:
@@ -428,7 +428,7 @@ class TestDailyCounts:
         _backdate(engine, column="reviewed_at", unit_id=u.id, when=now - timedelta(days=60))
         cutoff = (now - timedelta(days=30)).date().isoformat()
         with engine.connect() as conn:
-            rows = conn.execute(q.SELECT_REJECTED_DAILY, {"cutoff": cutoff}).fetchall()
+            rows = conn.execute(q.SELECT_REJECTED_DAILY["sqlite"], {"cutoff": cutoff}).fetchall()
         assert rows == []
 
     async def test_daily_helpers_match_store(self, db: tuple[_RepoBundle, Engine]) -> None:
@@ -460,9 +460,9 @@ class TestDailyCounts:
         days = 30
         cutoff = (now - timedelta(days=days)).date().isoformat()
         with engine.connect() as conn:
-            proposed_rows = conn.execute(q.SELECT_PROPOSED_DAILY, {"cutoff": cutoff}).fetchall()
-            approved_rows = conn.execute(q.SELECT_APPROVED_DAILY, {"cutoff": cutoff}).fetchall()
-            rejected_rows = conn.execute(q.SELECT_REJECTED_DAILY, {"cutoff": cutoff}).fetchall()
+            proposed_rows = conn.execute(q.SELECT_PROPOSED_DAILY["sqlite"], {"cutoff": cutoff}).fetchall()
+            approved_rows = conn.execute(q.SELECT_APPROVED_DAILY["sqlite"], {"cutoff": cutoff}).fetchall()
+            rejected_rows = conn.execute(q.SELECT_REJECTED_DAILY["sqlite"], {"cutoff": cutoff}).fetchall()
         proposed = {row[0]: row[1] for row in proposed_rows}
         approved = {row[0]: row[1] for row in approved_rows}
         rejected = {row[0]: row[1] for row in rejected_rows}

--- a/server/backend/uv.lock
+++ b/server/backend/uv.lock
@@ -153,6 +153,95 @@ wheels = [
 ]
 
 [[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/d7/b5b7020a0565c2e9fa8c09f4b5fa6232feb326b8c20081ccded47ea368fd/charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7641bb8895e77f921102f72833904dcd9901df5d6d72a2ab8f31d04b7e51e4e7", size = 309705, upload-time = "2026-04-02T09:26:02.191Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/53/58c29116c340e5456724ecd2fff4196d236b98f3da97b404bc5e51ac3493/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:202389074300232baeb53ae2569a60901f7efadd4245cf3a3bf0617d60b439d7", size = 206419, upload-time = "2026-04-02T09:26:03.583Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/02/e8146dc6591a37a00e5144c63f29fb7c97a734ea8a111190783c0e60ab63/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:30b8d1d8c52a48c2c5690e152c169b673487a2a58de1ec7393196753063fcd5e", size = 227901, upload-time = "2026-04-02T09:26:04.738Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/73/77486c4cd58f1267bf17db420e930c9afa1b3be3fe8c8b8ebbebc9624359/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:532bc9bf33a68613fd7d65e4b1c71a6a38d7d42604ecf239c77392e9b4e8998c", size = 222742, upload-time = "2026-04-02T09:26:06.36Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/fa/f74eb381a7d94ded44739e9d94de18dc5edc9c17fb8c11f0a6890696c0a9/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2fe249cb4651fd12605b7288b24751d8bfd46d35f12a20b1ba33dea122e690df", size = 214061, upload-time = "2026-04-02T09:26:08.347Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/92/42bd3cefcf7687253fb86694b45f37b733c97f59af3724f356fa92b8c344/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:65bcd23054beab4d166035cabbc868a09c1a49d1efe458fe8e4361215df40265", size = 199239, upload-time = "2026-04-02T09:26:09.823Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/3d/069e7184e2aa3b3cddc700e3dd267413dc259854adc3380421c805c6a17d/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:08e721811161356f97b4059a9ba7bafb23ea5ee2255402c42881c214e173c6b4", size = 210173, upload-time = "2026-04-02T09:26:10.953Z" },
+    { url = "https://files.pythonhosted.org/packages/62/51/9d56feb5f2e7074c46f93e0ebdbe61f0848ee246e2f0d89f8e20b89ebb8f/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e060d01aec0a910bdccb8be71faf34e7799ce36950f8294c8bf612cba65a2c9e", size = 209841, upload-time = "2026-04-02T09:26:12.142Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/59/893d8f99cc4c837dda1fe2f1139079703deb9f321aabcb032355de13b6c7/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:38c0109396c4cfc574d502df99742a45c72c08eff0a36158b6f04000043dbf38", size = 200304, upload-time = "2026-04-02T09:26:13.711Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/1d/ee6f3be3464247578d1ed5c46de545ccc3d3ff933695395c402c21fa6b77/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:1c2a768fdd44ee4a9339a9b0b130049139b8ce3c01d2ce09f67f5a68048d477c", size = 229455, upload-time = "2026-04-02T09:26:14.941Z" },
+    { url = "https://files.pythonhosted.org/packages/54/bb/8fb0a946296ea96a488928bdce8ef99023998c48e4713af533e9bb98ef07/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:1a87ca9d5df6fe460483d9a5bbf2b18f620cbed41b432e2bddb686228282d10b", size = 210036, upload-time = "2026-04-02T09:26:16.478Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/bc/015b2387f913749f82afd4fcba07846d05b6d784dd16123cb66860e0237d/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:d635aab80466bc95771bb78d5370e74d36d1fe31467b6b29b8b57b2a3cd7d22c", size = 224739, upload-time = "2026-04-02T09:26:17.751Z" },
+    { url = "https://files.pythonhosted.org/packages/17/ab/63133691f56baae417493cba6b7c641571a2130eb7bceba6773367ab9ec5/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ae196f021b5e7c78e918242d217db021ed2a6ace2bc6ae94c0fc596221c7f58d", size = 216277, upload-time = "2026-04-02T09:26:18.981Z" },
+    { url = "https://files.pythonhosted.org/packages/06/6d/3be70e827977f20db77c12a97e6a9f973631a45b8d186c084527e53e77a4/charset_normalizer-3.4.7-cp311-cp311-win32.whl", hash = "sha256:adb2597b428735679446b46c8badf467b4ca5f5056aae4d51a19f9570301b1ad", size = 147819, upload-time = "2026-04-02T09:26:20.295Z" },
+    { url = "https://files.pythonhosted.org/packages/20/d9/5f67790f06b735d7c7637171bbfd89882ad67201891b7275e51116ed8207/charset_normalizer-3.4.7-cp311-cp311-win_amd64.whl", hash = "sha256:8e385e4267ab76874ae30db04c627faaaf0b509e1ccc11a95b3fc3e83f855c00", size = 159281, upload-time = "2026-04-02T09:26:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/83/6413f36c5a34afead88ce6f66684d943d91f233d76dd083798f9602b75ae/charset_normalizer-3.4.7-cp311-cp311-win_arm64.whl", hash = "sha256:d4a48e5b3c2a489fae013b7589308a40146ee081f6f509e047e0e096084ceca1", size = 147843, upload-time = "2026-04-02T09:26:22.901Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2", size = 208061, upload-time = "2026-04-02T09:26:25.568Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f0/3dd1045c47f4a4604df85ec18ad093912ae1344ac706993aff91d38773a2/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b", size = 229031, upload-time = "2026-04-02T09:26:26.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/67/675a46eb016118a2fbde5a277a5d15f4f69d5f3f5f338e5ee2f8948fcf43/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a", size = 225239, upload-time = "2026-04-02T09:26:28.044Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116", size = 216589, upload-time = "2026-04-02T09:26:29.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f1/6d2b0b261b6c4ceef0fcb0d17a01cc5bc53586c2d4796fa04b5c540bc13d/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb", size = 202733, upload-time = "2026-04-02T09:26:30.5Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/7b1f943f7e87cc3db9626ba17807d042c38645f0a1d4415c7a14afb5591f/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1", size = 212652, upload-time = "2026-04-02T09:26:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15", size = 211229, upload-time = "2026-04-02T09:26:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ff/531a1cad5ca855d1c1a8b69cb71abfd6d85c0291580146fda7c82857caa1/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5", size = 203552, upload-time = "2026-04-02T09:26:34.845Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4c/a5fb52d528a8ca41f7598cb619409ece30a169fbdf9cdce592e53b46c3a6/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d", size = 230806, upload-time = "2026-04-02T09:26:36.152Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7a/071feed8124111a32b316b33ae4de83d36923039ef8cf48120266844285b/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7", size = 212316, upload-time = "2026-04-02T09:26:37.672Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/35/f7dba3994312d7ba508e041eaac39a36b120f32d4c8662b8814dab876431/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464", size = 227274, upload-time = "2026-04-02T09:26:38.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49", size = 218468, upload-time = "2026-04-02T09:26:40.17Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/890922a8b03a568ca2f336c36585a4713c55d4d67bf0f0c78924be6315ca/charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c", size = 148460, upload-time = "2026-04-02T09:26:41.416Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6", size = 159330, upload-time = "2026-04-02T09:26:42.554Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5d/481bcc2a7c88ea6b0878c299547843b2521ccbc40980cb406267088bc701/charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d", size = 147828, upload-time = "2026-04-02T09:26:44.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -228,6 +317,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "ruff" },
+    { name = "testcontainers" },
     { name = "ty" },
 ]
 lint = [
@@ -240,6 +330,7 @@ tests = [
     { name = "jsonschema" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "testcontainers" },
 ]
 
 [package.metadata]
@@ -268,6 +359,7 @@ dev = [
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "ruff", specifier = ">=0.15.4" },
+    { name = "testcontainers", extras = ["postgres"], specifier = ">=4.9.0" },
     { name = "ty", specifier = ">=0.0.59" },
 ]
 lint = [
@@ -280,6 +372,7 @@ tests = [
     { name = "jsonschema", specifier = ">=4.23.0" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
+    { name = "testcontainers", extras = ["postgres"], specifier = ">=4.9.0" },
 ]
 
 [[package]]
@@ -289,6 +382,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c9/02/bd72be9134d25ed783ecbbc38a539ffaefbf90c78418c7fb7229600dbac7/distlib-0.4.3.tar.gz", hash = "sha256:f152097224a0ae24be5a0f6bae1b9359af82133bce63f98a95f86cae1aede9ed", size = 615141, upload-time = "2026-06-12T08:04:52.847Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/02/08/9c41fb51ab5b43eb21674aff13df270e8ba6c4b29c8624e328dc7a9482af/distlib-0.4.3-py2.py3-none-any.whl", hash = "sha256:4b0ce306c966eb73bc3a7b6abad017c556dadd92c44701562cd528ac7fde4d5b", size = 470628, upload-time = "2026-06-12T08:04:50.506Z" },
+]
+
+[[package]]
+name = "docker"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834, upload-time = "2024-05-23T11:13:57.216Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774, upload-time = "2024-05-23T11:13:55.01Z" },
 ]
 
 [[package]]
@@ -1015,6 +1122,28 @@ wheels = [
 ]
 
 [[package]]
+name = "pywin32"
+version = "312"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/f5/10a6e845a00fc5e7afd0a988b744f403d4d57162a28d160a093c4d9322f0/pywin32-312-cp311-cp311-win32.whl", hash = "sha256:17948aeadbdb091f0ced6ef0841620794e68327b94ee415571c1203594b7215c", size = 6362659, upload-time = "2026-06-04T07:49:21.349Z" },
+    { url = "https://files.pythonhosted.org/packages/35/c4/dcd2d62b5944b6d5db53413a5899016ccd57ffcb7278f3f81655d25d2027/pywin32-312-cp311-cp311-win_amd64.whl", hash = "sha256:d11417d84412f859b722fad0841b3614459ed0047f7542d8362e77884f6b6e8a", size = 6928825, upload-time = "2026-06-04T07:49:23.934Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/56/3cbb433fe4501cdba2eb9040f56a4e1a8243faa4186b25295564d1a7a79d/pywin32-312-cp311-cp311-win_arm64.whl", hash = "sha256:b2200a054ca6d6625c4842fc56a4976a4b47f96b73dbe5538c3f813a80359f47", size = 6721875, upload-time = "2026-06-04T07:49:26.416Z" },
+    { url = "https://files.pythonhosted.org/packages/83/ff/32aa7d2ed0ab12b323aaa64f9b75e6ad4f8fd09f9ccfc28c79414d46838d/pywin32-312-cp312-cp312-win32.whl", hash = "sha256:dab4f65ac9c4e48400a2a0530c46c3c579cd5905ecd11b80692373915269208b", size = 6371877, upload-time = "2026-06-04T07:49:28.836Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d9/77040d3b43df3f3be32ea289433d660d2727f5ba327bc73be835127d9d60/pywin32-312-cp312-cp312-win_amd64.whl", hash = "sha256:b457f6d628a47e8a7346ce22acb7e1a46a4a78b52e1d17e1af56871bd19a93bc", size = 6914841, upload-time = "2026-06-04T07:49:31.85Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/cc/7b1ec671775756020a0ee7f4feeaf3c568f0ab86bd3900088cf986937a92/pywin32-312-cp312-cp312-win_arm64.whl", hash = "sha256:6017c58e12f6809fbb0555b75df144c2922a9ffd18e4b9b5afa863b6c1a9d950", size = 6727901, upload-time = "2026-06-04T07:49:34.244Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/41/12fbfd7f36ed2146d8bc9de96c2741296bf0d490b98508496cff322e274c/pywin32-312-cp313-cp313-win32.whl", hash = "sha256:7a27df850933d16a8eabfbaeb73d52b273e2da667f80d70b01a89d1f6828d02c", size = 6370184, upload-time = "2026-06-04T07:49:36.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/db/36a78e3403099d31d9746d13fdcde5accc43c1155f375a34d15983a479a7/pywin32-312-cp313-cp313-win_amd64.whl", hash = "sha256:c53e878d15a1c44788082bfe712a905433473aa38f86375b7cf8b45e3acbaaf9", size = 6914298, upload-time = "2026-06-04T07:49:38.876Z" },
+    { url = "https://files.pythonhosted.org/packages/84/37/c1697194092b76de9ed47ca124323f02c57ffc8a45c06f88a3d5acaf01eb/pywin32-312-cp313-cp313-win_arm64.whl", hash = "sha256:59aba5d5940842075343a5ddc6b11f1cdf0d1567fe745290359dfbcc7c2eb831", size = 6727640, upload-time = "2026-06-04T07:49:41.083Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/2b/1f3cded5822fd49c02f40544cbb5f58c7cfd6b1694869fd476cb6170ee97/pywin32-312-cp314-cp314-win32.whl", hash = "sha256:a77a90fbb6881238d2ca9c6fd797b25817f3768fe78d214a90137ff055a75f5b", size = 6468928, upload-time = "2026-06-04T07:49:43.188Z" },
+    { url = "https://files.pythonhosted.org/packages/21/82/3bf86d2e2808902013132e1ce905a7da0da53790f3836c64bf44d55e24f3/pywin32-312-cp314-cp314-win_amd64.whl", hash = "sha256:a4dd3a848290ef724347b19f301045831d8e802fa4464f491b98b1e0a081432e", size = 7024157, upload-time = "2026-06-04T07:49:45.34Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/0e/73f6d6800b4f27655abd9e9f6aaeaefcddb2b946e4674efa2bab184a7f7b/pywin32-312-cp314-cp314-win_arm64.whl", hash = "sha256:9fce94568364e0155e6dfb781ac5d95903be8baf28670632beab1b523f300daa", size = 6839598, upload-time = "2026-06-04T07:49:47.613Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/61/caa39686032d2ebdd04ff0ab5cbe163126c0066d98e00c9018646e42393b/pywin32-312-cp315-cp315-win32.whl", hash = "sha256:5c1fbe4a937a73ae9297384a3da38518cbc694c68ad8a809b2e19acd350f03ed", size = 6471159, upload-time = "2026-06-04T07:49:50.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/cd/7e1de64a4a6f69c04214169657ccab0d93a670ea50e35eb8f489d7378249/pywin32-312-cp315-cp315-win_amd64.whl", hash = "sha256:c2f03a0f73f804a13c2735b99392b0cd426bb4f2c4d0178e5ac966a0f21618d5", size = 7025293, upload-time = "2026-06-04T07:49:54.857Z" },
+    { url = "https://files.pythonhosted.org/packages/23/ed/4532e9388e65fa16b46776ef47ad631a64eda1631884488af707666350ed/pywin32-312-cp315-cp315-win_arm64.whl", hash = "sha256:a8597d28f267b39074aef51fa593530082b39cbe5a074226096857b1fed2dfb9", size = 6840337, upload-time = "2026-06-04T07:49:57.531Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1081,6 +1210,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
 ]
 
 [[package]]
@@ -1319,6 +1463,22 @@ wheels = [
 ]
 
 [[package]]
+name = "testcontainers"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docker" },
+    { name = "python-dotenv" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/ac/a597c3a0e02b26cbed6dd07df68be1e57684766fd1c381dee9b170a99690/testcontainers-4.14.2.tar.gz", hash = "sha256:1340ccf16fe3acd9389a6c9e1d9ab21d9fe99a8afdf8165f89c3e69c1967d239", size = 166841, upload-time = "2026-03-18T05:19:16.696Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/2d/26b8b30067d94339afee62c3edc9b803a6eb9332f521ba77d8aaab5de873/testcontainers-4.14.2-py3-none-any.whl", hash = "sha256:0d0522c3cd8f8d9627cda41f7a6b51b639fa57bdc492923c045117933c668d68", size = 125712, upload-time = "2026-03-18T05:19:15.29Z" },
+]
+
+[[package]]
 name = "ty"
 version = "0.0.59"
 source = { registry = "https://pypi.org/simple" }
@@ -1371,6 +1531,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]
@@ -1611,4 +1780,79 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a5/8f/aea9c71cc92bf9b6cc0f7f70df8f0b420636b6c96ef4feee1e16f80f75dd/websockets-16.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0298d07ee155e2e9fda5be8a9042200dd2e3bb0b8a38482156576f863a9d457c", size = 176968, upload-time = "2026-01-10T09:23:41.031Z" },
     { url = "https://files.pythonhosted.org/packages/9a/3f/f70e03f40ffc9a30d817eef7da1be72ee4956ba8d7255c399a01b135902a/websockets-16.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:a653aea902e0324b52f1613332ddf50b00c06fdaf7e92624fbf8c77c78fa5767", size = 178735, upload-time = "2026-01-10T09:23:42.259Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/a4/282c8e64300a59fc834518a54bf0afabb4ff9218b5fa76958b450459a844/wrapt-2.2.2.tar.gz", hash = "sha256:0788e321027c999bf221b667bd4a54aaefd1a36283749a860ac3eb77daed0302", size = 129068, upload-time = "2026-06-20T23:49:44.49Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/15/0c2d55168707465abfc41f33c0b23d792a5fa9b65c26983606940900a120/wrapt-2.2.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f1a2ff355ece6a111ca7a20dc86df6659c9205d3fcee674ca34f2a2854fd4e73", size = 80782, upload-time = "2026-06-20T23:47:44.367Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/b5/5c0b093eb48f8a062ef6267d3cb36e9bb1b88440181f6545a383c60efdf8/wrapt-2.2.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:55b9a899e6fff5444f229d30aa6e9ac92d2216d9d60f33c771b5d76a760d5f8e", size = 81678, upload-time = "2026-06-20T23:47:45.857Z" },
+    { url = "https://files.pythonhosted.org/packages/34/f3/de70937472dd3e8a4e6811192f9c6075efdffd4a2cd9b4596bf160f89668/wrapt-2.2.2-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a2d78c363f97d8bd718ee40432c66395685e9e98528ccaa423c3355d1715a26d", size = 159671, upload-time = "2026-06-20T23:47:47.345Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ec/40aed2330e7f02ecf74386ffcfef9ccb7108c6a430f15b6a252b663b1bed/wrapt-2.2.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d619e1eed9bd4f6ed9f24cd61971aa086fa86505289628d464bcf8a2c2e3f328", size = 160785, upload-time = "2026-06-20T23:47:48.759Z" },
+    { url = "https://files.pythonhosted.org/packages/45/04/aa5309beed5344b00220ae6b3b24055852192656194c27947bee1736306a/wrapt-2.2.2-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:518b0c5e323511ec56a38894802ddd5e1222626484e68efe63f201854ad788e5", size = 153699, upload-time = "2026-06-20T23:47:50.177Z" },
+    { url = "https://files.pythonhosted.org/packages/01/df/2def7e99d1fe87eea413f95f671924cdddcb08823b1ffd212748dfa6d062/wrapt-2.2.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4bccea5cdecffa9dd70e343741f0e41e0a16619313d04b72f78bb525162ebcd0", size = 159695, upload-time = "2026-06-20T23:47:51.602Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/f6/a906d01a2ce12157bad2404957b3e2140da354b8a70b2fa48bbf282871c0/wrapt-2.2.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:209112cafd963710a05d199aae431d79a28bc76eb8e6d1bbbb8ad24340722cae", size = 152813, upload-time = "2026-06-20T23:47:53.03Z" },
+    { url = "https://files.pythonhosted.org/packages/02/49/bc0086292d239575b4c08f4cf8a4079fa58abbad58ec23abf84833a283ed/wrapt-2.2.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:e5a5290e4bf2f332fc29ce72ffb9a2fff678aaac047e2e9f5f7165cd7792e099", size = 158809, upload-time = "2026-06-20T23:47:54.391Z" },
+    { url = "https://files.pythonhosted.org/packages/55/83/8fbd034de1f3e907edaa18786d5dd8f6932874edee0826c7cecb5cab03a1/wrapt-2.2.2-cp311-cp311-win32.whl", hash = "sha256:5499236ad1dc116012e2a5dd943f3f31af12fce452128e2bbcbd55a7d3d4d14c", size = 77414, upload-time = "2026-06-20T23:47:55.882Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/9c/23695baa331c6de4e874c3d78b8e0bed92e1d2a274e665b29858f6841672/wrapt-2.2.2-cp311-cp311-win_amd64.whl", hash = "sha256:8636809939152be6ae20a6cef0fed9fe60f411b47847d0426a826884b469e971", size = 80368, upload-time = "2026-06-20T23:47:57.237Z" },
+    { url = "https://files.pythonhosted.org/packages/08/49/40cefc342bf89b234a4490d741290fce781774b831aefb39c25471da96c9/wrapt-2.2.2-cp311-cp311-win_arm64.whl", hash = "sha256:5d0a142f7af07caeb5e5da87493162a7b8efa19ba919e550a746f7446e13fb30", size = 79489, upload-time = "2026-06-20T23:47:58.56Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/85/180b40628b23772692a0c76e8030114e1c0ae068470ed531919f0a5f2a4a/wrapt-2.2.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8417fd3c674d3c8023d080292d29301531a12daf8bd938dd419710dd2f464f2b", size = 81484, upload-time = "2026-06-20T23:47:59.924Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f2/21c90f2a16689702e2aaff45795b11018dff2c9b1242bac10d225483f676/wrapt-2.2.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0e7070c7472582e31af3dfc2622b2381a0df7435110a9388ed8db5ffbce67efb", size = 82151, upload-time = "2026-06-20T23:48:01.303Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/b3/7e6e9fcf4fe7e1b69a49fe6cc5a44e8224bab6283c5233c97e132f14908e/wrapt-2.2.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2e096c9d39a59b35b63c9aacfbbbec2088ff51ff1fc31051acc60a07f42f273a", size = 169828, upload-time = "2026-06-20T23:48:02.719Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/43/894f132d857ed5a9904d937baf368badcbe5ea9e436e2f1930fe21c9f1f0/wrapt-2.2.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d1a6050405bf334be33bf66296f113563622972a34900ae6fa60fd283a1a900", size = 171544, upload-time = "2026-06-20T23:48:04.266Z" },
+    { url = "https://files.pythonhosted.org/packages/29/de/3c833e03725b477e9ea34028224dd21a48781830101e4e036f77e8b6b102/wrapt-2.2.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:10adb01371408c6de504a6658b9886480f1a4919a83752748a387a504a21df79", size = 160663, upload-time = "2026-06-20T23:48:05.708Z" },
+    { url = "https://files.pythonhosted.org/packages/33/be/27edce350b24e3054d9d047f65f16d4c4d4c1f3f31c4278a1f8a95c723c8/wrapt-2.2.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3442eee2a5798f9b451f1b2cd7518ce8b7e28a2a364696c414460a0e295c012a", size = 169387, upload-time = "2026-06-20T23:48:07.243Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/c4/9fd9679af8bf38e146652c7f47b6b352c3e5795b4ad1c0b7f94e15ac2aa7/wrapt-2.2.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:6c99012a22f735a85eed7c4b86a3e99c30fdd57d9e115b2b45f796264b58d0bf", size = 158849, upload-time = "2026-06-20T23:48:08.91Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/c2/aa6c0c2206803068c6859dabe01f8c84c43744da93d4c67b8946d21655ee/wrapt-2.2.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3b686cfc008776a3952d6213cb296ed7f45d782a8453936406faa89eac0835ab", size = 168147, upload-time = "2026-06-20T23:48:10.374Z" },
+    { url = "https://files.pythonhosted.org/packages/42/63/3eb25da41049d20ae18fcab2dd8b056e02387c4bfa626cbdfb7c3b872e4f/wrapt-2.2.2-cp312-cp312-win32.whl", hash = "sha256:ef2cce266b5b0b07e19fa82e59673b81142b7a3607c8ed1254113d048ed668da", size = 77734, upload-time = "2026-06-20T23:48:11.769Z" },
+    { url = "https://files.pythonhosted.org/packages/da/09/0390e008a305360948fa9ce69507d041ac12cb2ee5d28e34467e2ee79391/wrapt-2.2.2-cp312-cp312-win_amd64.whl", hash = "sha256:abf8c20a2d72ee69e16328b3c91342c446e723bfe48bfcc4dded3b9722ac027f", size = 80585, upload-time = "2026-06-20T23:48:13.117Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b3/84c445c66969f2d3457276b183a48c91097d59bbef9af6c075366b0f8c36/wrapt-2.2.2-cp312-cp312-win_arm64.whl", hash = "sha256:c6c64c5d02578bc4c4bca4f0aef1504de933c1d5b4ac2710b9131111459506c8", size = 79553, upload-time = "2026-06-20T23:48:14.5Z" },
+    { url = "https://files.pythonhosted.org/packages/43/fc/f32f4b22c6511173c11d9e541ab4e7d8467a0f1b3455acaf784115d31ff8/wrapt-2.2.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9e8b648270c613720a202d9a45ebabc33261b22c3a839b115ac5bce8c0bb0d69", size = 81296, upload-time = "2026-06-20T23:48:15.881Z" },
+    { url = "https://files.pythonhosted.org/packages/72/06/4d117d5d77a9344776c0248b24dae3d3dd2f58e5f765fa08cf887072e719/wrapt-2.2.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6fb7e94e8fe3e4c3067bb1653a91cce7c5e83acc119fdd41501b1bf74654617", size = 81841, upload-time = "2026-06-20T23:48:17.262Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ff/63ad96f98eb58a742b1a20d80f21da88924405910149950b912368150468/wrapt-2.2.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fb18fc51e813df0d9c98049e3bf2298a5495a648602040e21fa3c7329371159e", size = 167882, upload-time = "2026-06-20T23:48:18.764Z" },
+    { url = "https://files.pythonhosted.org/packages/20/1f/8bb62d8933df7acf3247194e6e9fc68edf9d2fa203252c89c94b319dd472/wrapt-2.2.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94b00b00f806eb3ef2abe9049ed45994a81ee9284884d96e6b8314927c6cea3d", size = 167411, upload-time = "2026-06-20T23:48:20.315Z" },
+    { url = "https://files.pythonhosted.org/packages/17/09/8789dcb09ee1de715727db7521aabbb68ffa68dfade3a49468440cfced49/wrapt-2.2.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:62415fd095bc590b842b6d092f2b5d9ccbaeb7e0b28535c03dcea2718b48636b", size = 158607, upload-time = "2026-06-20T23:48:21.728Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/20/66e02562d53ee67d841f175e38e3c993c2d78a3e104c576cad61c028b43c/wrapt-2.2.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a41e758d80dc0ab8c210f641ac892009d356cf1f955d97db544c8dd317b4d14c", size = 166367, upload-time = "2026-06-20T23:48:23.177Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a3/832ac4e41222fb263b3042d42c2f08d305db7d0f0c9b1d3a271a9eede8f6/wrapt-2.2.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:b84cd4058001c9727b0e9980b7a9e66325b5ca748b1b578e822cade1bc6b304f", size = 157176, upload-time = "2026-06-20T23:48:24.711Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/01/1bd5e4d2df9c0178989ac8da9186543465388588ee2ef153e2591accebef/wrapt-2.2.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:26fc73a1b15e0946d2942b9a4426d162b51676338327dc067ccd8d2d76385f94", size = 167025, upload-time = "2026-06-20T23:48:26.118Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/69/583ed25291ab53e1ec117135fb1c33425e2f46d2bc8f29c17f7a94cf4274/wrapt-2.2.2-cp313-cp313-win32.whl", hash = "sha256:3c4095803491f6ef72128914c28ec05bbad9758433bb35f6715a3e9c8e46fb2d", size = 77605, upload-time = "2026-06-20T23:48:27.643Z" },
+    { url = "https://files.pythonhosted.org/packages/29/68/e69fc6d06e1523c68e0d00f95c9aed1158ce9908ee41603f7f2eae3d5db6/wrapt-2.2.2-cp313-cp313-win_amd64.whl", hash = "sha256:2cb07f414fab25dbe6b5c7398e1491423a5c81a6209533639969a6c928d474a4", size = 80508, upload-time = "2026-06-20T23:48:29.013Z" },
+    { url = "https://files.pythonhosted.org/packages/55/21/fe7a393d9e5dc0923bed8f5d857e9dcff210f1fa0888c02cc8f3ffaa55aa/wrapt-2.2.2-cp313-cp313-win_arm64.whl", hash = "sha256:1fc7691f070220215cccb2a20836b9adbaecb8ff22ad47abe63de5f110994fac", size = 79565, upload-time = "2026-06-20T23:48:30.429Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/e5/c120d13bf5091164f68c3c1657e84f16f57e71d978421b626393ac5bd7eb/wrapt-2.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:ec8f83949028366531383603139403cac7a826e4011955813cdd640017845ce5", size = 83264, upload-time = "2026-06-20T23:48:31.807Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b0/d4a1eb97e0e286625bdf21bc7f702637f9607787ffbbdb5ec14d50c79dbf/wrapt-2.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4b481fb0c40d9fd90a5809911208da700987d373a20a4709dc9e3944af7a6bec", size = 83791, upload-time = "2026-06-20T23:48:33.482Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1e/f060df47755e87b57684cee7bfc1362b204df55fac96ffebc0631b697b79/wrapt-2.2.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0065a3b657cec06813b4241d2462ccec287f6863103d7445b725fb3a889736f9", size = 203399, upload-time = "2026-06-20T23:48:34.97Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/de/2316a757a1abb6453700b79d83e532146dcef2611348282d4d8889792161/wrapt-2.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:30f7424af5c5c345b7f26490e097f74a2ef45b3d08b664dc33571aee3bd3b56c", size = 210461, upload-time = "2026-06-20T23:48:36.569Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/29/d1160785ae18ca2495a6d82a21154103d74f656c9fd457fb35f6b11b965a/wrapt-2.2.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:07fdcb012821859168641acf68afad61ef9783cf37100af85f152550e9677194", size = 195313, upload-time = "2026-06-20T23:48:38.175Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/2d/7caa9598ae61a9cf0989cc501739cbeeb7d650ab3193cca1407b9af0c6ab/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f90038ab58fafb584801ca62d72384d7d5225d93c76f7b773c22fae545bd8066", size = 206116, upload-time = "2026-06-20T23:48:39.804Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/02/281ea1088b8650d865f311b35cf86fd21df89128e2909714f1161e01c9d0/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:c5d7825491bfa2d08b97e9557768987952c7b9ae687d06c3320b40a37ccb7f20", size = 192668, upload-time = "2026-06-20T23:48:41.346Z" },
+    { url = "https://files.pythonhosted.org/packages/be/7d/976e2d5b4b5c5babda40974edd54d0a5585cb60132ed86b46f4b80239b16/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:0ad520e6daa9bbf136f14de735474dbec7dcc0891f718e1d274ce8dc92e645af", size = 198891, upload-time = "2026-06-20T23:48:43.056Z" },
+    { url = "https://files.pythonhosted.org/packages/59/b7/e47651797c097f75a37e2ce86dcf04048ff576f3a674f7c558df7b5e9622/wrapt-2.2.2-cp313-cp313t-win32.whl", hash = "sha256:25904acb9475f46c24fe0423dbc8fda8cc5fbc282ab3dc6e72e919748c53f4e9", size = 78537, upload-time = "2026-06-20T23:48:44.509Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/6f/9fa5d59fb06d890defb5a8f727ce6a14d2932c8760153f96956628559fee/wrapt-2.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:305d4c247d61c4115794a169141823c62f719525ddb90b23aa332741c77d2c28", size = 82005, upload-time = "2026-06-20T23:48:46.391Z" },
+    { url = "https://files.pythonhosted.org/packages/15/80/4c7bd9873d1f9f7d138d93556b500469dbe24f42710b877519c2b9eb380d/wrapt-2.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:c20279cd1a29800815d7b2d6338b60a6c6e78263f9d6e62e0eda251ba9cae2d0", size = 80762, upload-time = "2026-06-20T23:48:47.964Z" },
+    { url = "https://files.pythonhosted.org/packages/24/05/7fd9c3f83b2c74cbfc572a0b88aa37431e04bd8aed70d2c0efd3464206de/wrapt-2.2.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:0e64826f920c42d9d9f87e8cc09ffae66c51ede12d59061a5a426deb9aa71745", size = 81341, upload-time = "2026-06-20T23:48:49.39Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/68/1bfa43100dd90d4ef74a05897b86275cf57e1313ca14aae2545bc9f872c9/wrapt-2.2.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:dcaa5e1451bd8751d7bd1568dfa3321c78092a52a7ecb5d1a0f18a5791e1fd00", size = 81921, upload-time = "2026-06-20T23:48:50.986Z" },
+    { url = "https://files.pythonhosted.org/packages/74/eb/df7b7f0b631dbbc750f39be27d8b55f65777d8ac86da80e12be41a644c4b/wrapt-2.2.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0abfd648dac9ac9c5b3aa9b523d27f1789046640b58dcd5652a720ddb325e1fc", size = 167713, upload-time = "2026-06-20T23:48:52.598Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/9a/d1bd36f6d088c8e652a9383cabbd49af30b8c576302a7eccddbab6963e3f/wrapt-2.2.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f4bfd8d1eb438153eff8b8cfe87f032ba65731e1ce06138b5090f745a33f6f95", size = 166779, upload-time = "2026-06-20T23:48:54.33Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/ae/24ffacd4187fac2740a1972093929e836dea092d42c87d728cd98fee11a6/wrapt-2.2.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c427c9d06d859848a69f0d928fe28b5c33a941b2265d10a0e1f15cd244f1ee33", size = 158407, upload-time = "2026-06-20T23:48:55.944Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ed/974427668249a356051e8d67d47fa54ef6c777f0fcf3bae9d292c047d4b6/wrapt-2.2.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4250b43d1a129d947e083c4dc6baf333c9bb34edd26f912d5b0457841fc858ab", size = 166594, upload-time = "2026-06-20T23:48:57.617Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/5f/e1d7c6e4523f78db2fbd7826babd0348da1d5e0834c4f918b9ab5757dfae/wrapt-2.2.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:173e5bb5ca350a6e0abab60b7ec7cdd7992a814cb14b4de670a28f067f105663", size = 157068, upload-time = "2026-06-20T23:48:59.171Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c1/7ebd1027f00700c0b0233b20aceef2b4784294ed64971424c4a78e069e34/wrapt-2.2.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:aa14b01804bce36c6d63d7b6a4f55df390f29f8648cc13a1f40b166f4d54680d", size = 166470, upload-time = "2026-06-20T23:49:00.737Z" },
+    { url = "https://files.pythonhosted.org/packages/99/eb/974e471a6a978b8180186b8a9dc5ae3361ce269a967190b709b8ce17abfb/wrapt-2.2.2-cp314-cp314-win32.whl", hash = "sha256:58f9f8d637c9a6e245c6ef5b109b67ec187d2faed23d1405656b51d96e0a5b56", size = 78062, upload-time = "2026-06-20T23:49:02.327Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ec/e1281156cdc7a66693838ad7a0865ad641c74abd337a957d668b575aaffb/wrapt-2.2.2-cp314-cp314-win_amd64.whl", hash = "sha256:385cb1866f20479e83299af585375bfa0a4b0c6c9907a981483ea782ea8ae406", size = 80832, upload-time = "2026-06-20T23:49:03.837Z" },
+    { url = "https://files.pythonhosted.org/packages/45/7d/1b6b5ddd94005a2dac97a4490c9838f3154977850d633abcb65b30089437/wrapt-2.2.2-cp314-cp314-win_arm64.whl", hash = "sha256:8ffbeaea6771a6eba6e6eeb09767864995726bc8240bb54baf88a9bb1db34d5c", size = 80029, upload-time = "2026-06-20T23:49:05.237Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/33/9ebcf8aafe91c601127cbd93708c16aa8f688f34a10bf004046803ecdc4f/wrapt-2.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:09f811d43f6f33ec7515f0be76b159569f4057ab54d3e079c3204dddb90afa2a", size = 83357, upload-time = "2026-06-20T23:49:06.632Z" },
+    { url = "https://files.pythonhosted.org/packages/39/38/ec45b635153327b52e52732a0ea980e5f00b7efba65f9e018828f1e69daa/wrapt-2.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a795d3c06e5fbf9ea2f13196180b77aeab1b4685917256ee0d014cc163d90063", size = 83794, upload-time = "2026-06-20T23:49:08.098Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/ea/1a89e6d3b7a83c3affe5c09cde77792c947e63e4bc85ad84cd5bb9abb0d8/wrapt-2.2.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:45c2f2768e790c9f8db90f239ef23a2af8e7570f25a35619ef902df4a738447f", size = 203362, upload-time = "2026-06-20T23:49:09.811Z" },
+    { url = "https://files.pythonhosted.org/packages/19/d8/3b58763d9863b5a73771c0d97110f9595d248db454009e07e1535ee905a4/wrapt-2.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bbf00ee0cb55ec24e2b0995a71942b85b21a066db8f3f46e1dbfdb9433ffba81", size = 210449, upload-time = "2026-06-20T23:49:11.521Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/6f/17fd9e053103d8be148d20d5d7505facc72d5fe1f9127973904ceaed79cf/wrapt-2.2.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2252f77663651b89255895f58cc6ac08fcb206d4371813e5af61bb62d4f7689c", size = 195349, upload-time = "2026-06-20T23:49:13.346Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/04/d0d1ccaaa12cb7dccf28a23f0279a608ba498f71e81d949d5ed54bcfd5c1/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2cd7181ab1c31192ff5219269830744b5a62020b3a6d433588c4f1c95b8f8bff", size = 206099, upload-time = "2026-06-20T23:49:15.051Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b3/e8aa07b619890a2aa6cde1931b1887abb08820721b564a5f80b7ca3f3aa0/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:6fe35fd51b74867d8b80174c277bd6bbf6a73e443f908129dc531c4b688a20d5", size = 192728, upload-time = "2026-06-20T23:49:16.854Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/f0/1819fb50f0d3c9bd758d8a83b56f1b470dee8b5b8eac8702b7c137cea9d4/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:11d95fc2fbad3163596c39d440e6f21ca9fccece74b56e30a37ac2fca786a07c", size = 198842, upload-time = "2026-06-20T23:49:18.504Z" },
+    { url = "https://files.pythonhosted.org/packages/67/7c/e88313f16a99930b899ef970d91c281544a470749a359decad994483bbda/wrapt-2.2.2-cp314-cp314t-win32.whl", hash = "sha256:d8a15813215f33fa83667bfc978b300e35669ea8bb424e970a1426bcb7bc6cca", size = 79059, upload-time = "2026-06-20T23:49:20.107Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/4f/ac12fda57a55068a094ec42851fb0a40e8489d8941863d517452de62e507/wrapt-2.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:d09db0f7e8357060d3c38fc22a018aba683a796bf184360fd1a58f6fc180dc77", size = 82462, upload-time = "2026-06-20T23:49:21.631Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a7/df732dac86d9b2027c56bd163dbc883e037b16c3469614752e148d219c61/wrapt-2.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:f32fe639c39561ccc187bcae17e9271be0eb45f1c2952510d2f29b33ab577347", size = 81182, upload-time = "2026-06-20T23:49:23.199Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/d2/6317eb6d4554855bbf12d61857774af34747bf88a42c19bf306de67e2fa3/wrapt-2.2.2-py3-none-any.whl", hash = "sha256:5bad217350f19ce99ca5b5e71d406765ea86fe541628426772b657375ee1c048", size = 61460, upload-time = "2026-06-20T23:49:42.966Z" },
 ]


### PR DESCRIPTION
Closes #312. Folds in #314.

Refs the [PostgreSQL backend RFC](https://github.com/mozilla-ai/cq/discussions/275) and epic #257.

Implements the PostgreSQL backend against the **shipped** architecture (the layered `Database` + `repositories` shape), per the re-scoping brief in #312 — **not** the stale original issue text (no `PostgresStore`, no `Store` protocol).

## Approach

Dialect divergence is handled with **dialect-keyed query constants resolved once** from `engine.dialect.name` — no runtime `if dialect` in method bodies, no new class hierarchy. A full-tree audit confirmed the divergence is tiny: 5 queries + one engine branch.

## Changes

- **`core/db.py`** — the `postgresql+psycopg://` branch builds a real engine instead of raising: session TZ pinned to UTC (so `(col::timestamptz)::date` truncates like SQLite's `date()`) and none of the SQLite-only connect args / PRAGMA / semsearch listeners. **Fails fast** with a clear error if the resolved dialect is PostgreSQL *and* semantic search is enabled (pgvector is a later stage).
- **`repositories/_queries.py`** — the 3 daily-count queries are now dialect-keyed. PG form casts the TEXT column `(col::timestamptz)::date::text` — the trailing `::text` keeps the day key an ISO string (bare `::date` returns a Python `date`, which breaks the caller's string-keyed merge). Corrected the module docstring's wrong "works on PG under DateStyle=ISO" claim.
- **`repositories/knowledge.py` / `reviews.py`** — `_SELECT_CONFIDENCE_DISTRIBUTION` is dialect-keyed (`json_extract` → `data::jsonb #>> '{evidence,confidence}'::numeric`, with the derived subquery aliased `AS sub` as PG requires). Each repo picks by dialect once in `__init__`. Distinct bucket bounds per file preserved.
- **Tests** — added `testcontainers[postgres]` dev dep + a session-scoped PG container fixture (`pg_repos`) that skips cleanly when Docker is absent; new `test_postgres.py` covers the divergent queries (confidence distribution × 2, daily counts) + an insert/query round-trip smoke test. SQLite tests are untouched.

## Out of scope (per brief)

- pgvector / semantic search on PG — separate future stage (#312 only fails fast).
- `pg_advisory_lock` migration guard — #313.
- TEXT → `TIMESTAMP WITH TIME ZONE` — Phase 3 (#316/#317); the `::timestamptz` casts bridge until then.
- CI matrix — #315.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PostgreSQL support for backend integration tests and CI, including repository-level confidence distributions and daily count reporting.
* **Bug Fixes**
  * Improved PostgreSQL database URL handling to fail early with clearer guidance, and added safeguards when semantic search is enabled.
  * Fixed PostgreSQL daily aggregations to be stable across date formats and handle cutoff boundaries correctly.
* **Tests**
  * Expanded PostgreSQL-specific query/aggregation tests (confidence buckets, rejected counts, ISO day keys, and cutoff inclusion/exclusion).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
