### PR TITLE
docs(schema): clarify extension key omission guidance

### DIFF
--- a/schema/knowledge_unit.json
+++ b/schema/knowledge_unit.json
@@ -47,7 +47,7 @@
   "$defs": {
     "Extensions": {
       "type": "object",
-      "description": "Implementation-specific fields. Not portable across implementations; consumers MUST ignore unknown keys and MUST NOT rely on their presence. Keys MUST use namespace:key format with a lowercase implementation slug.",
+      "description": "Implementation-specific fields. Not portable across implementations; consumers MUST ignore unknown keys and MUST NOT rely on their presence. Keys MUST use namespace:key format with a lowercase implementation slug. Producers SHOULD only include keys they have actually set, and SHOULD NOT emit a key with a null or empty placeholder to represent an absent value, so that key-presence within a namespace is meaningful. This recommendation applies to producers and does not weaken the consumer-side rule above.",
       "patternProperties": {
         "^[a-z0-9][a-z0-9_-]*:\\S+$": true
       },


### PR DESCRIPTION
## Summary

- recommend that producers include only extension keys they have actually set
- discourage null or empty placeholders for absent extension values
- clarify that this producer-side guidance does not weaken the existing consumer-side rule

## Why

The schema currently allows any value under a namespaced extension key, but does not guide producers on how to represent an absent value. That can lead implementations to diverge between omitted keys and explicit placeholders, making key presence ambiguous.

This is documentation-only guidance. It does not change schema validation, SDK behavior, or the existing requirement for consumers to ignore unknown keys and avoid relying on foreign namespaces.

## Validation

- `make validate-schema`
- `mise exec go@1.26.1 -- make test-schema`

Closes #489


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified extension handling requirements, including how consumers should treat unknown keys.
  * Added guidance for producers to emit only explicitly set values and avoid empty or null placeholders.
  * Retained the requirement for lowercase `namespace:key` identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->