### PR TITLE
docs(plugin): clarify context tag guidance

### DIFF
--- a/plugins/cq/skills/cq/SKILL.md
+++ b/plugins/cq/skills/cq/SKILL.md
@@ -77,7 +77,7 @@ Each piece of information belongs in one field — do not repeat the same term a
 |-------|-----------------|---------|
 | `domains` | Subject area — what the insight is *about* (tools, protocols, concepts, layers). Avoid terms that describe the insight *type* (`"gotchas"`, `"tips"`, `"pitfalls"`) rather than its subject. | `"find"`, `"ci"`, `"http"`, `"connection-pooling"` |
 | `languages` | Programming languages the insight applies to or was observed in. Do not repeat in `domains`. | `"python"`, `"rust"`, `"go"` |
-| `frameworks` | Libraries or frameworks involved. Do not repeat in `domains`. | `"fastapi"`, `"react"`, `"pydantic"` |
+| `frameworks` | Libraries, frameworks, runtimes, or execution platforms the insight applies to. Do not repeat the same value in `domains`. | `"fastapi"`, `"pydantic"`, `"cloudflare-workers"`, `"macos"` |
 | `pattern` | A reusable cross-cutting concern, useful as a search axis independent of specific technology. Omit if it just rephrases the summary. | `"revocation-semantics"`, `"shell-quoting"` |
 
 | Scenario | `domains` | other call args |
@@ -87,7 +87,9 @@ Each piece of information belongs in one field — do not repeat the same term a
 | GitHub Actions CI for Rust | `["ci", "github-actions"]` | `languages: ["rust"], pattern: "ci-pipeline"` |
 | PostgreSQL connection pooling | `["database", "postgresql", "connection-pooling"]` | `languages: ["go"]` |
 
-When an insight applies across a family of tools or runtimes (e.g. all POSIX shells), include both a generic tag (`"shell"`, `"posix"`) and the specific one where it was observed (`"bash"`, `"zsh"`). Do not drop either.
+Tag where an insight applies, not merely where it was observed. Do not add repository or branch names simply because the work happened there; generalize that context into portable `domains` instead.
+
+When an insight applies across a family of tools or runtimes, keep both levels without duplicating identical values: put the generic subject in `domains` and the applicable runtimes or platforms in `frameworks`. For example, use `domains: ["shell", "posix"]` with `frameworks: ["bash", "zsh"]`. Do not drop either level of applicability.
 
 Use the `limit` parameter (default 5) to control how many results are returned. For broad exploratory queries, increase the limit.
 

--- a/sdk/go/prompts/SKILL.md
+++ b/sdk/go/prompts/SKILL.md
@@ -77,7 +77,7 @@ Each piece of information belongs in one field — do not repeat the same term a
 |-------|-----------------|---------|
 | `domains` | Subject area — what the insight is *about* (tools, protocols, concepts, layers). Avoid terms that describe the insight *type* (`"gotchas"`, `"tips"`, `"pitfalls"`) rather than its subject. | `"find"`, `"ci"`, `"http"`, `"connection-pooling"` |
 | `languages` | Programming languages the insight applies to or was observed in. Do not repeat in `domains`. | `"python"`, `"rust"`, `"go"` |
-| `frameworks` | Libraries or frameworks involved. Do not repeat in `domains`. | `"fastapi"`, `"react"`, `"pydantic"` |
+| `frameworks` | Libraries, frameworks, runtimes, or execution platforms the insight applies to. Do not repeat the same value in `domains`. | `"fastapi"`, `"pydantic"`, `"cloudflare-workers"`, `"macos"` |
 | `pattern` | A reusable cross-cutting concern, useful as a search axis independent of specific technology. Omit if it just rephrases the summary. | `"revocation-semantics"`, `"shell-quoting"` |
 
 | Scenario | `domains` | other call args |
@@ -87,7 +87,9 @@ Each piece of information belongs in one field — do not repeat the same term a
 | GitHub Actions CI for Rust | `["ci", "github-actions"]` | `languages: ["rust"], pattern: "ci-pipeline"` |
 | PostgreSQL connection pooling | `["database", "postgresql", "connection-pooling"]` | `languages: ["go"]` |
 
-When an insight applies across a family of tools or runtimes (e.g. all POSIX shells), include both a generic tag (`"shell"`, `"posix"`) and the specific one where it was observed (`"bash"`, `"zsh"`). Do not drop either.
+Tag where an insight applies, not merely where it was observed. Do not add repository or branch names simply because the work happened there; generalize that context into portable `domains` instead.
+
+When an insight applies across a family of tools or runtimes, keep both levels without duplicating identical values: put the generic subject in `domains` and the applicable runtimes or platforms in `frameworks`. For example, use `domains: ["shell", "posix"]` with `frameworks: ["bash", "zsh"]`. Do not drop either level of applicability.
 
 Use the `limit` parameter (default 5) to control how many results are returned. For broad exploratory queries, increase the limit.
 

--- a/sdk/python/src/cq/prompts/SKILL.md
+++ b/sdk/python/src/cq/prompts/SKILL.md
@@ -77,7 +77,7 @@ Each piece of information belongs in one field — do not repeat the same term a
 |-------|-----------------|---------|
 | `domains` | Subject area — what the insight is *about* (tools, protocols, concepts, layers). Avoid terms that describe the insight *type* (`"gotchas"`, `"tips"`, `"pitfalls"`) rather than its subject. | `"find"`, `"ci"`, `"http"`, `"connection-pooling"` |
 | `languages` | Programming languages the insight applies to or was observed in. Do not repeat in `domains`. | `"python"`, `"rust"`, `"go"` |
-| `frameworks` | Libraries or frameworks involved. Do not repeat in `domains`. | `"fastapi"`, `"react"`, `"pydantic"` |
+| `frameworks` | Libraries, frameworks, runtimes, or execution platforms the insight applies to. Do not repeat the same value in `domains`. | `"fastapi"`, `"pydantic"`, `"cloudflare-workers"`, `"macos"` |
 | `pattern` | A reusable cross-cutting concern, useful as a search axis independent of specific technology. Omit if it just rephrases the summary. | `"revocation-semantics"`, `"shell-quoting"` |
 
 | Scenario | `domains` | other call args |
@@ -87,7 +87,9 @@ Each piece of information belongs in one field — do not repeat the same term a
 | GitHub Actions CI for Rust | `["ci", "github-actions"]` | `languages: ["rust"], pattern: "ci-pipeline"` |
 | PostgreSQL connection pooling | `["database", "postgresql", "connection-pooling"]` | `languages: ["go"]` |
 
-When an insight applies across a family of tools or runtimes (e.g. all POSIX shells), include both a generic tag (`"shell"`, `"posix"`) and the specific one where it was observed (`"bash"`, `"zsh"`). Do not drop either.
+Tag where an insight applies, not merely where it was observed. Do not add repository or branch names simply because the work happened there; generalize that context into portable `domains` instead.
+
+When an insight applies across a family of tools or runtimes, keep both levels without duplicating identical values: put the generic subject in `domains` and the applicable runtimes or platforms in `frameworks`. For example, use `domains: ["shell", "posix"]` with `frameworks: ["bash", "zsh"]`. Do not drop either level of applicability.
 
 Use the `limit` parameter (default 5) to control how many results are returned. For broad exploratory queries, increase the limit.
 


### PR DESCRIPTION
## Summary

- clarify that `frameworks` also carries runtimes, execution platforms, and version-pinned environments
- tell agents to generalize repository and branch context into portable domains instead of tagging observation locations
- show how to retain generic subject tags alongside specific runtime applicability
- sync the canonical cq skill into the Go and Python prompt copies

## Why

Issue #170 identified that agents reach for repository or branch names when they lack guidance on how to express where knowledge applies. Follow-up implementation feedback showed that the missing scope is usually portable runtime or platform context, which the existing `frameworks` field can carry without adding a schema axis.

This guidance keeps knowledge reusable across repositories while preserving useful applicability filters such as `cloudflare-workers`, `macos`, or `postgres-16.4`.

## Impact

This is prompt guidance only. It does not change the schema, query API, or storage behavior.

## Validation

- `make check-prompts-sync`
- skill structure validation (`quick_validate.py plugins/cq/skills/cq`)
- independent forward-test covering private repo/branch, runtime, platform, and version metadata

Refs #170


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how to set domain tags based on where an insight **applies** (not where it was merely observed).
  * Expanded the **frameworks** guidance to cover libraries/frameworks, runtimes, execution platforms, and version-pinned environments.
  * Strengthened cross-family tagging rules: keep generic applicability in `domains` and place specific runtimes/platforms in `frameworks`.
  * Added/updated examples, including PostgreSQL “connection pooling” with Go and a revised POSIX-shell example.
  * Warned against using repository or branch names as domain tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->