### PR TITLE
docs(schema): complete extensions coverage

### DIFF
--- a/schema/Makefile
+++ b/schema/Makefile
@@ -46,7 +46,8 @@ validate-fixtures:
 		fixtures/valid-unit.json \
 		fixtures/minimal-unit.json \
 		fixtures/flagged-unit.json \
-		fixtures/duplicate-flag.json
+		fixtures/duplicate-flag.json \
+		fixtures/extensions-unit.json
 	uv run --locked --project python check-jsonschema \
 		--schemafile node_discovery.json \
 		fixtures/node_discovery_minimal.json \

--- a/schema/README.md
+++ b/schema/README.md
@@ -26,6 +26,7 @@ A single unit of shared agent knowledge. This is the core data type; other schem
 | `tier` | `"local"` \| `"private"` \| `"public"` | no | Storage tier. |
 | `created_by` | string | no | Identifier of the agent or user that created this unit. |
 | `superseded_by` | string (`ku_<32 hex>`) | no | ID of the replacing knowledge unit, if any. |
+| `extensions` | Extensions | no | Implementation-specific namespaced fields; not portable across implementations. |
 | `flags` | Flag[] | no | Recorded flags against this unit. |
 
 #### Defined types
@@ -45,6 +46,8 @@ A single unit of shared agent knowledge. This is the core data type; other schem
 | `languages` | string[] | no | Programming languages. |
 | `frameworks` | string[] | no | Frameworks. |
 | `pattern` | string | no | Reusable cross-cutting pattern. |
+
+**Extensions** — implementation-specific fields carried under namespaced keys, not portable across implementations. See the `Extensions` definition in `knowledge_unit.json` for the normative producer and consumer rules.
 
 **Evidence** — confidence and confirmation metrics.
 
@@ -92,6 +95,7 @@ Request to propose a new knowledge unit.
 | `domains` | string[] (>= 1) | yes | At least one domain is required. |
 | `insight` | Insight | yes | Tripartite insight (defined in knowledge_unit.json). |
 | `context` | Context | no | Language, framework, and pattern context. |
+| `extensions` | Extensions | no | Implementation-specific namespaced fields (defined in knowledge_unit.json). |
 | `created_by` | string | no | Identifier of the proposing agent or user. |
 
 ---


### PR DESCRIPTION
## Summary

- add `extensions` to the published `KnowledgeUnit` and `ProposeRequest` schema reference tables
- document the namespacing, portability, producer omission, and key-count contract for `Extensions`
- include `extensions-unit.json` in the fixtures exercised by `make validate-schema`

## Why

PR #453 added the extensions slot and a representative fixture, but the manually maintained schema reference and validation fixture list predated that change. As a result, the published GitBook reference omitted the field and the advertised validation command skipped its fixture.

## Impact

The public schema reference now matches the canonical schema, and the validation target covers the existing extensions fixture. This does not change schema or runtime behavior.

## Validation

- `make validate-schema`
- `mise exec go@1.26.1 -- make test-schema`
- `uv run --with pytest pytest scripts/test_prepare_gitbook_site.py -v`
- `python3 scripts/check_docs.py`
- `python3 scripts/prepare_gitbook_site.py`

Refs #453
Related to #493


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Documented optional `extensions` support in the wire-protocol schemas, including guidance that it is implementation-specific namespaced data.
  * Updated `propose` request documentation to reference the shared `Extensions` type.
* **Tests**
  * Extended schema fixture validation to include the additional extensions fixture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->