### PR TITLE
docs: clarify local vs remote onboarding setup paths

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -8,6 +8,23 @@ Re-running is idempotent, so it is safe to run again after an upgrade.
 
 Install the `cq` CLI first — via Homebrew, Scoop, or a GitHub release. See the [CLI README](../cli/README.md#installation) for the options. The CLI must be on your `PATH`, because the installer writes its resolved path into each host's configuration.
 
+## Local vs remote setup
+
+Pick a path before you configure hosts. Both use the same `cq install` step; remote only adds environment variables afterward.
+
+| Setup | What you get | What you configure |
+|-------|--------------|--------------------|
+| **Local only (default)** | Knowledge stays on this machine in a local SQLite store (`~/.local/share/cq/local.db`, or `$XDG_DATA_HOME/cq/local.db`). | Run `cq install --target <host>`. Do **not** set `CQ_ADDR` / `CQ_API_KEY`. |
+| **Remote (hosted or self-hosted)** | Agents can read/write a shared store; local proposals can drain to the remote when the plugin starts. | Run `cq install` first, then add `CQ_ADDR` and (for writes) `CQ_API_KEY` to the host entry the installer created. See [Connect to a remote cq server](#connect-to-a-remote-cq-server). |
+
+Common choices for `CQ_ADDR`:
+
+- Hosted service: `https://cq.exchange`
+- Local docker-compose server: `http://localhost:3000`
+- Your own deployment: your server URL
+
+The installer never writes `CQ_ADDR` or `CQ_API_KEY`. Leaving them unset is the supported local-only mode. For choosing hosted vs self-hosted, see [Remote storage](../README.md#remote-storage).
+
 ## Quick start
 
 ```bash
@@ -49,7 +66,9 @@ Claude Code manages its own plugins, so `cq install --target claude` shells out 
 
 ## Connect to a remote cq server
 
-With no remote configured, knowledge stays local on the machine running the agent. To sync knowledge to a shared or hosted store, point the agent at a remote server with two environment variables:
+Use this section only after you chose the **remote** path in [Local vs remote setup](#local-vs-remote-setup). With no remote configured, knowledge stays local on the machine running the agent.
+
+To sync knowledge to a shared or hosted store, point the agent at a remote server with two environment variables:
 
 | Variable     | Purpose                                                                 |
 |--------------|-------------------------------------------------------------------------|

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -2,6 +2,8 @@
 
 After [installing cq into your coding agent](install.md), verify it works and add your first knowledge unit.
 
+This walkthrough assumes the **local-only** default: no `CQ_ADDR` / `CQ_API_KEY`. Knowledge is written to the local SQLite store on this machine. If you already pointed your host at a remote server, `/cq:status` and `propose` talk to that remote instead; see [Local vs remote setup](install.md#local-vs-remote-setup) and [Remote storage](../README.md#remote-storage).
+
 ## Verify the plugin is working
 
 Run `/cq:status` in your AI coding agent's terminal session:
@@ -58,4 +60,6 @@ Confidence starts at 0.5 and increases as other agents confirm the knowledge.
 ## Next steps
 
 - [How cq works in practice](../README.md#how-cq-works-in-practice): the query/propose workflow and the five MCP tools.
-- [Remote storage](../README.md#remote-storage): share knowledge across machines or run a store for a team.
+- [Local vs remote setup](install.md#local-vs-remote-setup): decide whether knowledge stays on this machine or syncs to a shared store.
+- [Remote storage](../README.md#remote-storage): hosted service vs self-hosted server, plus docker-compose for a local remote.
+- Per-host `CQ_ADDR` / `CQ_API_KEY` snippets: [Installation → Connect to a remote cq server](install.md#connect-to-a-remote-cq-server).


### PR DESCRIPTION
## Summary

Fixes #487.

The install and quickstart guides already document remote `CQ_ADDR` / `CQ_API_KEY` setup, but the default local-only path was easy to miss. Readers had to infer that leaving those variables unset is the supported single-machine mode.

This change adds an explicit local vs remote decision section to the install guide, points quickstart at that choice up front, and tightens the remote section so it is clearly the optional follow-up after install.

## Changes

- `docs/install.md`: new "Local vs remote setup" table; remote section now links back to that choice.
- `docs/quickstart.md`: local-only default called out; next steps link local vs remote and remote storage.

## AI disclosure

Prepared with AI assistance (Cursor / Grok). Documentation-only change. Human review: Stan Shih (stantheman0128).

## Evidence

Docs-only diff. Reviewed against current `docs/install.md` and `docs/quickstart.md` on `main` (`90af064`). No code build required.

```
git diff --stat origin/main...HEAD
 docs/install.md    | 21 ++++++++++++++++++++-
 docs/quickstart.md |  6 +++++-
 2 files changed, 25 insertions(+), 2 deletions(-)
```

## What was not tested

- Full docs site preview build (mdBook / publish pipeline not run in this session). Markdown links target existing anchors (`#local-vs-remote-setup`, `#connect-to-a-remote-cq-server`, README remote storage).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the difference between local-only and remote setup.
  * Added guidance on configuring remote storage and connection settings.
  * Updated the Quickstart to explain local SQLite usage by default.
  * Expanded next steps with hosted, self-hosted, and per-host remote setup guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->