### PR TITLE
feat(schema)!: bound insight and related free-text fields (maxLength + maxItems)

### DIFF
--- a/schema/README.md
+++ b/schema/README.md
@@ -19,12 +19,12 @@ A single unit of shared agent knowledge. This is the core data type; other schem
 |-------|------|----------|-------------|
 | `id` | string (`ku_<32 hex>`) | yes | Prefixed UUID. |
 | `version` | integer (>= 1) | no | Schema version; server assumes 1 when unset. |
-| `domains` | string[] (>= 1) | yes | At least one domain tag is required. |
+| `domains` | string[] (>= 1, <= 16 items, <= 64 chars each) | yes | At least one domain tag is required. |
 | `insight` | Insight | yes | Tripartite insight: what happened, why it matters, what to do. |
 | `context` | Context | no | Language, framework, and pattern context. |
 | `evidence` | Evidence | no | Confidence and confirmation metrics. |
 | `tier` | `"local"` \| `"private"` \| `"public"` | no | Storage tier. |
-| `created_by` | string | no | Identifier of the agent or user that created this unit. |
+| `created_by` | string (<= 256 chars) | no | Identifier of the agent or user that created this unit. |
 | `superseded_by` | string (`ku_<32 hex>`) | no | ID of the replacing knowledge unit, if any. |
 | `extensions` | Extensions | no | Implementation-specific namespaced fields; not portable across implementations. |
 | `flags` | Flag[] | no | Recorded flags against this unit. |
@@ -35,17 +35,17 @@ A single unit of shared agent knowledge. This is the core data type; other schem
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `summary` | string | yes | What happened. |
-| `detail` | string | yes | Why it matters. |
-| `action` | string | yes | What to do. |
+| `summary` | string (<= 500 chars) | yes | What happened. |
+| `detail` | string (<= 8000 chars) | yes | Why it matters. |
+| `action` | string (<= 2000 chars) | yes | What to do. |
 
 **Context** — language, framework, and pattern metadata.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `languages` | string[] | no | Programming languages. |
-| `frameworks` | string[] | no | Frameworks. |
-| `pattern` | string | no | Reusable cross-cutting pattern. |
+| `languages` | string[] (<= 16 items, <= 64 chars each) | no | Programming languages. |
+| `frameworks` | string[] (<= 16 items, <= 64 chars each) | no | Frameworks. |
+| `pattern` | string (<= 200 chars) | no | Reusable cross-cutting pattern. |
 
 **Extensions** — implementation-specific fields carried under namespaced keys, not portable across implementations. See the `Extensions` definition in `knowledge_unit.json` for the normative producer and consumer rules.
 
@@ -64,7 +64,7 @@ A single unit of shared agent knowledge. This is the core data type; other schem
 |-------|------|----------|-------------|
 | `reason` | `"stale"` \| `"incorrect"` \| `"duplicate"` | yes | Why the unit was flagged. |
 | `timestamp` | date-time | no | When the flag was recorded. |
-| `detail` | string | no | Optional explanation. Server-side only; never returned to querying agents. |
+| `detail` | string (<= 1000 chars) | no | Optional explanation. Server-side only; never returned to querying agents. |
 | `duplicate_of` | string (`ku_<32 hex>`) | conditional | Required when reason is `duplicate`. |
 
 ---
@@ -77,9 +77,9 @@ Query parameters for searching knowledge units.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `domains` | string[] (>= 1) | yes | At least one domain is required. |
-| `languages` | string[] | no | Filter by programming languages. |
-| `frameworks` | string[] | no | Filter by frameworks. |
+| `domains` | string[] (>= 1, <= 16 items, <= 64 chars each) | yes | At least one domain is required. |
+| `languages` | string[] (<= 16 items, <= 64 chars each) | no | Filter by programming languages. |
+| `frameworks` | string[] (<= 16 items, <= 64 chars each) | no | Filter by frameworks. |
 | `limit` | integer (1 -- 50) | no | Maximum results; default 5, server caps at 50. |
 
 ---
@@ -92,11 +92,11 @@ Request to propose a new knowledge unit.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `domains` | string[] (>= 1) | yes | At least one domain is required. |
+| `domains` | string[] (>= 1, <= 16 items, <= 64 chars each) | yes | At least one domain is required. |
 | `insight` | Insight | yes | Tripartite insight (defined in knowledge_unit.json). |
 | `context` | Context | no | Language, framework, and pattern context. |
 | `extensions` | Extensions | no | Implementation-specific namespaced fields (defined in knowledge_unit.json). |
-| `created_by` | string | no | Identifier of the proposing agent or user. |
+| `created_by` | string (<= 256 chars) | no | Identifier of the proposing agent or user. |
 
 ---
 
@@ -122,7 +122,7 @@ Request to flag a knowledge unit.
 |-------|------|----------|-------------|
 | `unit_id` | string (`ku_<32 hex>`) | yes | ID of the knowledge unit to flag. |
 | `reason` | `"stale"` \| `"incorrect"` \| `"duplicate"` | yes | Why the unit is being flagged. |
-| `detail` | string | no | Optional explanation. Server-side only; never returned to querying agents. |
+| `detail` | string (<= 1000 chars) | no | Optional explanation. Server-side only; never returned to querying agents. |
 | `duplicate_of` | string (`ku_<32 hex>`) | conditional | Required when reason is `duplicate`. |
 
 ---

--- a/schema/flag.json
+++ b/schema/flag.json
@@ -14,6 +14,7 @@
     "reason": { "$ref": "knowledge_unit.json#/$defs/FlagReason" },
     "detail": {
       "type": "string",
+      "maxLength": 1000,
       "description": "Optional explanation when flagging. Server-side only; never returned to querying agents."
     },
     "duplicate_of": {

--- a/schema/knowledge_unit.json
+++ b/schema/knowledge_unit.json
@@ -19,8 +19,9 @@
     },
     "domains": {
       "type": "array",
-      "items": { "type": "string" },
+      "items": { "type": "string", "maxLength": 64 },
       "minItems": 1,
+      "maxItems": 16,
       "description": "At least one domain is required."
     },
     "insight": { "$ref": "#/$defs/Insight" },
@@ -29,6 +30,7 @@
     "tier": { "$ref": "#/$defs/Tier" },
     "created_by": {
       "type": "string",
+      "maxLength": 256,
       "description": "Identifier of the agent or user that created this unit."
     },
     "superseded_by": {
@@ -76,6 +78,7 @@
         },
         "detail": {
           "type": "string",
+          "maxLength": 1000,
           "description": "Optional explanation when flagging. Server-side only; never returned to querying agents."
         },
         "duplicate_of": {
@@ -101,14 +104,17 @@
       "properties": {
         "summary": {
           "type": "string",
+          "maxLength": 500,
           "description": "What happened."
         },
         "detail": {
           "type": "string",
+          "maxLength": 8000,
           "description": "Why it matters."
         },
         "action": {
           "type": "string",
+          "maxLength": 2000,
           "description": "What to do."
         }
       },
@@ -120,14 +126,17 @@
       "properties": {
         "languages": {
           "type": "array",
-          "items": { "type": "string" }
+          "items": { "type": "string", "maxLength": 64 },
+          "maxItems": 16
         },
         "frameworks": {
           "type": "array",
-          "items": { "type": "string" }
+          "items": { "type": "string", "maxLength": 64 },
+          "maxItems": 16
         },
         "pattern": {
-          "type": "string"
+          "type": "string",
+          "maxLength": 200
         }
       },
       "additionalProperties": false

--- a/schema/limits.go
+++ b/schema/limits.go
@@ -1,0 +1,124 @@
+package cqschema
+
+import (
+	"encoding/json"
+	"sync"
+)
+
+// JSON keys used to navigate the embedded knowledge_unit.json.
+const (
+	keyContext    = "Context"
+	keyDefs       = "$defs"
+	keyFlag       = "Flag"
+	keyInsight    = "Insight"
+	keyItems      = "items"
+	keyMaxItems   = "maxItems"
+	keyMaxLength  = "maxLength"
+	keyProperties = "properties"
+)
+
+// loadLimits parses the free-text ceilings from the embedded
+// knowledge_unit.json, memoized so the document is parsed once on first use.
+var loadLimits = sync.OnceValue(func() fieldLimits {
+	var schema map[string]any
+	if err := json.Unmarshal(knowledgeUnitSchema, &schema); err != nil {
+		panic("cqschema: invalid knowledge_unit.json: " + err.Error())
+	}
+	props := objectField(schema, keyProperties)
+	defs := objectField(schema, keyDefs)
+	insightProps := objectField(objectField(defs, keyInsight), keyProperties)
+	contextProps := objectField(objectField(defs, keyContext), keyProperties)
+	flagProps := objectField(objectField(defs, keyFlag), keyProperties)
+
+	domains := objectField(props, "domains")
+	languages := objectField(contextProps, "languages")
+	frameworks := objectField(contextProps, "frameworks")
+
+	return fieldLimits{
+		summaryMaxLength:    schemaInt(objectField(insightProps, "summary"), keyMaxLength),
+		detailMaxLength:     schemaInt(objectField(insightProps, "detail"), keyMaxLength),
+		actionMaxLength:     schemaInt(objectField(insightProps, "action"), keyMaxLength),
+		domainMaxLength:     schemaInt(objectField(domains, keyItems), keyMaxLength),
+		createdByMaxLength:  schemaInt(objectField(props, "created_by"), keyMaxLength),
+		patternMaxLength:    schemaInt(objectField(contextProps, "pattern"), keyMaxLength),
+		languageMaxLength:   schemaInt(objectField(languages, keyItems), keyMaxLength),
+		frameworkMaxLength:  schemaInt(objectField(frameworks, keyItems), keyMaxLength),
+		flagDetailMaxLength: schemaInt(objectField(flagProps, "detail"), keyMaxLength),
+		domainsMaxItems:     schemaInt(domains, keyMaxItems),
+		languagesMaxItems:   schemaInt(languages, keyMaxItems),
+		frameworksMaxItems:  schemaInt(frameworks, keyMaxItems),
+	}
+})
+
+// fieldLimits holds the length and cardinality ceilings declared on the
+// free-text fields of knowledge_unit.json.
+type fieldLimits struct {
+	summaryMaxLength    int
+	detailMaxLength     int
+	actionMaxLength     int
+	domainMaxLength     int
+	createdByMaxLength  int
+	patternMaxLength    int
+	languageMaxLength   int
+	frameworkMaxLength  int
+	flagDetailMaxLength int
+	domainsMaxItems     int
+	languagesMaxItems   int
+	frameworksMaxItems  int
+}
+
+// ActionMaxLength returns the maximum length, in characters, of insight.action.
+func ActionMaxLength() int { return loadLimits().actionMaxLength }
+
+// CreatedByMaxLength returns the maximum length, in characters, of created_by.
+func CreatedByMaxLength() int { return loadLimits().createdByMaxLength }
+
+// DetailMaxLength returns the maximum length, in characters, of insight.detail.
+func DetailMaxLength() int { return loadLimits().detailMaxLength }
+
+// DomainMaxLength returns the maximum length, in characters, of a single domain tag.
+func DomainMaxLength() int { return loadLimits().domainMaxLength }
+
+// DomainsMaxItems returns the maximum number of domain tags on a unit.
+func DomainsMaxItems() int { return loadLimits().domainsMaxItems }
+
+// FlagDetailMaxLength returns the maximum length, in characters, of a flag's detail.
+func FlagDetailMaxLength() int { return loadLimits().flagDetailMaxLength }
+
+// FrameworkMaxLength returns the maximum length, in characters, of a single framework tag.
+func FrameworkMaxLength() int { return loadLimits().frameworkMaxLength }
+
+// FrameworksMaxItems returns the maximum number of framework tags in context.
+func FrameworksMaxItems() int { return loadLimits().frameworksMaxItems }
+
+// LanguageMaxLength returns the maximum length, in characters, of a single language tag.
+func LanguageMaxLength() int { return loadLimits().languageMaxLength }
+
+// LanguagesMaxItems returns the maximum number of language tags in context.
+func LanguagesMaxItems() int { return loadLimits().languagesMaxItems }
+
+// PatternMaxLength returns the maximum length, in characters, of context.pattern.
+func PatternMaxLength() int { return loadLimits().patternMaxLength }
+
+// SummaryMaxLength returns the maximum length, in characters, of insight.summary.
+func SummaryMaxLength() int { return loadLimits().summaryMaxLength }
+
+// objectField returns the named child object of a parsed schema node,
+// panicking if it is absent or not an object.
+func objectField(node map[string]any, key string) map[string]any {
+	child, ok := node[key].(map[string]any)
+	if !ok {
+		panic("cqschema: knowledge_unit.json missing object " + key)
+	}
+	return child
+}
+
+// schemaInt returns the named integer keyword (such as maxLength or
+// maxItems) declared on a parsed schema node, panicking if it is absent.
+func schemaInt(node map[string]any, keyword string) int {
+	value, ok := node[keyword].(float64)
+	if !ok {
+		panic("cqschema: knowledge_unit.json missing " + keyword + " keyword")
+	}
+	return int(value)
+}

--- a/schema/limits_test.go
+++ b/schema/limits_test.go
@@ -1,0 +1,90 @@
+package cqschema
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFieldLimitsMatchSchema(t *testing.T) {
+	t.Parallel()
+
+	var schema map[string]any
+	require.NoError(t, json.Unmarshal(KnowledgeUnitSchema(), &schema))
+
+	require.Equal(
+		t,
+		schemaLimit(t, schema, "$defs", "Insight", "properties", "summary", "maxLength"),
+		SummaryMaxLength(),
+	)
+	require.Equal(t, schemaLimit(t, schema, "$defs", "Insight", "properties", "detail", "maxLength"), DetailMaxLength())
+	require.Equal(t, schemaLimit(t, schema, "$defs", "Insight", "properties", "action", "maxLength"), ActionMaxLength())
+	require.Equal(t, schemaLimit(t, schema, "properties", "domains", "items", "maxLength"), DomainMaxLength())
+	require.Equal(t, schemaLimit(t, schema, "properties", "created_by", "maxLength"), CreatedByMaxLength())
+	require.Equal(
+		t,
+		schemaLimit(t, schema, "$defs", "Context", "properties", "pattern", "maxLength"),
+		PatternMaxLength(),
+	)
+	require.Equal(
+		t,
+		schemaLimit(t, schema, "$defs", "Context", "properties", "languages", "items", "maxLength"),
+		LanguageMaxLength(),
+	)
+	require.Equal(
+		t,
+		schemaLimit(t, schema, "$defs", "Context", "properties", "frameworks", "items", "maxLength"),
+		FrameworkMaxLength(),
+	)
+	require.Equal(
+		t,
+		schemaLimit(t, schema, "$defs", "Flag", "properties", "detail", "maxLength"),
+		FlagDetailMaxLength(),
+	)
+	require.Equal(t, schemaLimit(t, schema, "properties", "domains", "maxItems"), DomainsMaxItems())
+	require.Equal(
+		t,
+		schemaLimit(t, schema, "$defs", "Context", "properties", "languages", "maxItems"),
+		LanguagesMaxItems(),
+	)
+	require.Equal(
+		t,
+		schemaLimit(t, schema, "$defs", "Context", "properties", "frameworks", "maxItems"),
+		FrameworksMaxItems(),
+	)
+}
+
+func TestFieldLimitsArePositive(t *testing.T) {
+	t.Parallel()
+
+	require.Positive(t, SummaryMaxLength())
+	require.Positive(t, DetailMaxLength())
+	require.Positive(t, ActionMaxLength())
+	require.Positive(t, DomainMaxLength())
+	require.Positive(t, CreatedByMaxLength())
+	require.Positive(t, PatternMaxLength())
+	require.Positive(t, LanguageMaxLength())
+	require.Positive(t, FrameworkMaxLength())
+	require.Positive(t, FlagDetailMaxLength())
+	require.Positive(t, DomainsMaxItems())
+	require.Positive(t, LanguagesMaxItems())
+	require.Positive(t, FrameworksMaxItems())
+}
+
+// schemaLimit walks path through the parsed schema, treating every element
+// but the last as an object key and the last as an integer keyword, and
+// returns that integer.
+func schemaLimit(t *testing.T, schema map[string]any, path ...string) int {
+	t.Helper()
+
+	node := schema
+	for _, key := range path[:len(path)-1] {
+		child, ok := node[key].(map[string]any)
+		require.True(t, ok)
+		node = child
+	}
+	value, ok := node[path[len(path)-1]].(float64)
+	require.True(t, ok)
+	return int(value)
+}

--- a/schema/propose.json
+++ b/schema/propose.json
@@ -8,8 +8,9 @@
   "properties": {
     "domains": {
       "type": "array",
-      "items": { "type": "string" },
+      "items": { "type": "string", "maxLength": 64 },
       "minItems": 1,
+      "maxItems": 16,
       "description": "At least one domain is required."
     },
     "insight": { "$ref": "knowledge_unit.json#/$defs/Insight" },
@@ -17,6 +18,7 @@
     "extensions": { "$ref": "knowledge_unit.json#/$defs/Extensions" },
     "created_by": {
       "type": "string",
+      "maxLength": 256,
       "description": "Identifier of the agent or user proposing this unit."
     }
   },

--- a/schema/python/src/cq_schema/__init__.py
+++ b/schema/python/src/cq_schema/__init__.py
@@ -1,11 +1,13 @@
-"""Canonical JSON Schemas and parsed scoring values for cq.
+"""Canonical JSON Schemas and parsed constants for cq.
 
 This package ships the JSON Schema documents that define cq's wire format
-together with a small set of scoring constants parsed from
-`scoring.values.json`. Consumers receive raw schema documents (as bytes
-or parsed dicts) plus the constants; they bring their own JSON Schema
-validator. Adding one as a hard dependency would force every consumer to
-install it, even those that only need the constants.
+together with a small set of constants parsed from those documents: the
+scoring values from `scoring.values.json` and the free-text length and
+cardinality ceilings declared on `knowledge_unit.json`. Consumers receive
+raw schema documents (as bytes or parsed dicts) plus the constants; they
+bring their own JSON Schema validator. Adding one as a hard dependency
+would force every consumer to install it, even those that only need the
+constants.
 """
 
 from __future__ import annotations
@@ -15,32 +17,45 @@ from importlib.resources import files
 from typing import Any
 
 __all__ = [
+    "ACTION_MAX_LENGTH",
     "CONFIDENCE_CEILING",
     "CONFIDENCE_FLOOR",
     "CONFIRMATION_BOOST",
+    "CREATED_BY_MAX_LENGTH",
+    "DETAIL_MAX_LENGTH",
+    "DOMAIN_MAX_LENGTH",
     "DOMAIN_WEIGHT",
+    "DOMAINS_MAX_ITEMS",
+    "FLAG_DETAIL_MAX_LENGTH",
     "FLAG_PENALTY",
+    "FRAMEWORK_MAX_LENGTH",
     "FRAMEWORK_WEIGHT",
+    "FRAMEWORKS_MAX_ITEMS",
     "INITIAL_CONFIDENCE",
+    "LANGUAGE_MAX_LENGTH",
     "LANGUAGE_WEIGHT",
+    "LANGUAGES_MAX_ITEMS",
+    "PATTERN_MAX_LENGTH",
     "PATTERN_WEIGHT",
+    "SUMMARY_MAX_LENGTH",
     "load_schema",
     "load_schema_bytes",
 ]
 
 _DATA = files("cq_schema") / "_data"
-_SCORING_CONSTANT_NAMES = {
-    "DOMAIN_WEIGHT",
-    "LANGUAGE_WEIGHT",
-    "FRAMEWORK_WEIGHT",
-    "PATTERN_WEIGHT",
-    "INITIAL_CONFIDENCE",
-    "CONFIRMATION_BOOST",
-    "FLAG_PENALTY",
-    "CONFIDENCE_CEILING",
-    "CONFIDENCE_FLOOR",
-}
+
+# JSON keys used to navigate knowledge_unit.json.
+_KEY_CONTEXT = "Context"
+_KEY_DEFS = "$defs"
+_KEY_FLAG = "Flag"
+_KEY_INSIGHT = "Insight"
+_KEY_ITEMS = "items"
+_KEY_MAX_ITEMS = "maxItems"
+_KEY_MAX_LENGTH = "maxLength"
+_KEY_PROPERTIES = "properties"
+
 _scoring_constants: dict[str, float] | None = None
+_schema_limits: dict[str, int] | None = None
 
 
 def load_schema_bytes(name: str) -> bytes:
@@ -75,6 +90,14 @@ def load_schema(name: str) -> dict[str, Any]:
 
 
 def _load_scoring_constants() -> dict[str, float]:
+    """Parse the relevance weights and confidence constants from scoring.values.json.
+
+    Returns:
+        Mapping of each public scoring constant name to its float value.
+
+    Raises:
+        RuntimeError: If the bundled schema data files are missing.
+    """
     try:
         raw = (_DATA / "scoring.values.json").read_text(encoding="utf-8")
     except FileNotFoundError as error:
@@ -98,11 +121,57 @@ def _load_scoring_constants() -> dict[str, float]:
     }
 
 
-def __getattr__(name: str) -> float:
-    if name not in _SCORING_CONSTANT_NAMES:
+def _load_schema_limits() -> dict[str, int]:
+    """Parse the free-text length and array-cardinality ceilings from knowledge_unit.json.
+
+    Returns:
+        Mapping of each public limit constant name to its integer value.
+
+    Raises:
+        RuntimeError: If the bundled schema data files are missing.
+    """
+    try:
+        raw = (_DATA / "knowledge_unit.json").read_text(encoding="utf-8")
+    except FileNotFoundError as error:
+        raise RuntimeError(
+            "cq_schema data files are missing; run `make sync-schema` (or `make setup-schema`) from the repository root"
+        ) from error
+
+    schema = json.loads(raw)
+    properties = schema[_KEY_PROPERTIES]
+    defs = schema[_KEY_DEFS]
+    insight = defs[_KEY_INSIGHT][_KEY_PROPERTIES]
+    context = defs[_KEY_CONTEXT][_KEY_PROPERTIES]
+    flag = defs[_KEY_FLAG][_KEY_PROPERTIES]
+    return {
+        "ACTION_MAX_LENGTH": int(insight["action"][_KEY_MAX_LENGTH]),
+        "CREATED_BY_MAX_LENGTH": int(properties["created_by"][_KEY_MAX_LENGTH]),
+        "DETAIL_MAX_LENGTH": int(insight["detail"][_KEY_MAX_LENGTH]),
+        "DOMAIN_MAX_LENGTH": int(properties["domains"][_KEY_ITEMS][_KEY_MAX_LENGTH]),
+        "DOMAINS_MAX_ITEMS": int(properties["domains"][_KEY_MAX_ITEMS]),
+        "FLAG_DETAIL_MAX_LENGTH": int(flag["detail"][_KEY_MAX_LENGTH]),
+        "FRAMEWORK_MAX_LENGTH": int(context["frameworks"][_KEY_ITEMS][_KEY_MAX_LENGTH]),
+        "FRAMEWORKS_MAX_ITEMS": int(context["frameworks"][_KEY_MAX_ITEMS]),
+        "LANGUAGE_MAX_LENGTH": int(context["languages"][_KEY_ITEMS][_KEY_MAX_LENGTH]),
+        "LANGUAGES_MAX_ITEMS": int(context["languages"][_KEY_MAX_ITEMS]),
+        "PATTERN_MAX_LENGTH": int(context["pattern"][_KEY_MAX_LENGTH]),
+        "SUMMARY_MAX_LENGTH": int(insight["summary"][_KEY_MAX_LENGTH]),
+    }
+
+
+def __getattr__(name: str) -> int | float:
+    if name not in __all__:
         raise AttributeError(f"module 'cq_schema' has no attribute {name!r}")
 
-    global _scoring_constants
+    global _scoring_constants, _schema_limits
     if _scoring_constants is None:
         _scoring_constants = _load_scoring_constants()
-    return _scoring_constants[name]
+    if name in _scoring_constants:
+        return _scoring_constants[name]
+
+    if _schema_limits is None:
+        _schema_limits = _load_schema_limits()
+    if name in _schema_limits:
+        return _schema_limits[name]
+
+    raise AttributeError(f"module 'cq_schema' has no attribute {name!r}")

--- a/schema/python/tests/test_cq_schema.py
+++ b/schema/python/tests/test_cq_schema.py
@@ -38,6 +38,12 @@ def test_load_schema_bytes_matches_load_schema(name: str) -> None:
     assert json.loads(raw) == parsed
 
 
+@pytest.mark.parametrize("name", SCHEMA_NAMES)
+def test_bundled_schema_matches_canonical(name: str) -> None:
+    canonical = Path(__file__).resolve().parent.parent.parent / f"{name}.json"
+    assert cq_schema.load_schema(name) == json.loads(canonical.read_text(encoding="utf-8"))
+
+
 def test_load_schema_missing_raises() -> None:
     with pytest.raises(FileNotFoundError):
         cq_schema.load_schema("does_not_exist")
@@ -81,6 +87,29 @@ def test_schema_limits_match_schema() -> None:
     assert properties["domains"]["maxItems"] == cq_schema.DOMAINS_MAX_ITEMS
     assert context["languages"]["maxItems"] == cq_schema.LANGUAGES_MAX_ITEMS
     assert context["frameworks"]["maxItems"] == cq_schema.FRAMEWORKS_MAX_ITEMS
+
+
+def test_request_schemas_mirror_knowledge_unit_bounds() -> None:
+    ku = cq_schema.load_schema("knowledge_unit")
+    ku_props = ku["properties"]
+    ku_context = ku["$defs"]["Context"]["properties"]
+    ku_flag = ku["$defs"]["Flag"]["properties"]
+
+    for schema_name in ("propose", "query"):
+        domains = cq_schema.load_schema(schema_name)["properties"]["domains"]
+        assert domains["items"]["maxLength"] == ku_props["domains"]["items"]["maxLength"]
+        assert domains["maxItems"] == ku_props["domains"]["maxItems"]
+
+    propose = cq_schema.load_schema("propose")
+    assert propose["properties"]["created_by"]["maxLength"] == ku_props["created_by"]["maxLength"]
+
+    query = cq_schema.load_schema("query")
+    for field in ("languages", "frameworks"):
+        assert query["properties"][field]["items"]["maxLength"] == ku_context[field]["items"]["maxLength"]
+        assert query["properties"][field]["maxItems"] == ku_context[field]["maxItems"]
+
+    flag = cq_schema.load_schema("flag")
+    assert flag["properties"]["detail"]["maxLength"] == ku_flag["detail"]["maxLength"]
 
 
 def test_scoring_values_validates_against_scoring_schema() -> None:

--- a/schema/python/tests/test_cq_schema.py
+++ b/schema/python/tests/test_cq_schema.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 from pathlib import Path
 
 import jsonschema
@@ -58,6 +59,28 @@ def test_scoring_constants_match_values_file() -> None:
     assert confidence["flag_penalty"] == cq_schema.FLAG_PENALTY
     assert confidence["ceiling"] == cq_schema.CONFIDENCE_CEILING
     assert confidence["floor"] == cq_schema.CONFIDENCE_FLOOR
+
+
+def test_schema_limits_match_schema() -> None:
+    schema = cq_schema.load_schema("knowledge_unit")
+    properties = schema["properties"]
+    defs = schema["$defs"]
+    insight = defs["Insight"]["properties"]
+    context = defs["Context"]["properties"]
+    flag = defs["Flag"]["properties"]
+
+    assert insight["summary"]["maxLength"] == cq_schema.SUMMARY_MAX_LENGTH
+    assert insight["detail"]["maxLength"] == cq_schema.DETAIL_MAX_LENGTH
+    assert insight["action"]["maxLength"] == cq_schema.ACTION_MAX_LENGTH
+    assert properties["domains"]["items"]["maxLength"] == cq_schema.DOMAIN_MAX_LENGTH
+    assert properties["created_by"]["maxLength"] == cq_schema.CREATED_BY_MAX_LENGTH
+    assert context["pattern"]["maxLength"] == cq_schema.PATTERN_MAX_LENGTH
+    assert context["languages"]["items"]["maxLength"] == cq_schema.LANGUAGE_MAX_LENGTH
+    assert context["frameworks"]["items"]["maxLength"] == cq_schema.FRAMEWORK_MAX_LENGTH
+    assert flag["detail"]["maxLength"] == cq_schema.FLAG_DETAIL_MAX_LENGTH
+    assert properties["domains"]["maxItems"] == cq_schema.DOMAINS_MAX_ITEMS
+    assert context["languages"]["maxItems"] == cq_schema.LANGUAGES_MAX_ITEMS
+    assert context["frameworks"]["maxItems"] == cq_schema.FRAMEWORKS_MAX_ITEMS
 
 
 def test_scoring_values_validates_against_scoring_schema() -> None:
@@ -130,3 +153,106 @@ def test_extensions_accept_namespaced_keys() -> None:
         },
     }
     jsonschema.validate(instance=instance, schema=schema)
+
+
+_VALID_ID = "ku_00000000000000000000000000000099"
+
+
+def _unit(**fields: object) -> dict[str, object]:
+    instance: dict[str, object] = {
+        "id": _VALID_ID,
+        "domains": ["d"],
+        "insight": {"summary": "s", "detail": "d", "action": "a"},
+    }
+    instance.update(fields)
+    return instance
+
+
+def _unit_with_summary(value: str) -> dict[str, object]:
+    return _unit(insight={"summary": value, "detail": "d", "action": "a"})
+
+
+def _unit_with_detail(value: str) -> dict[str, object]:
+    return _unit(insight={"summary": "s", "detail": value, "action": "a"})
+
+
+def _unit_with_action(value: str) -> dict[str, object]:
+    return _unit(insight={"summary": "s", "detail": "d", "action": value})
+
+
+def _unit_with_domain(value: str) -> dict[str, object]:
+    return _unit(domains=[value])
+
+
+def _unit_with_created_by(value: str) -> dict[str, object]:
+    return _unit(created_by=value)
+
+
+def _unit_with_pattern(value: str) -> dict[str, object]:
+    return _unit(context={"pattern": value})
+
+
+def _unit_with_language(value: str) -> dict[str, object]:
+    return _unit(context={"languages": [value]})
+
+
+def _unit_with_framework(value: str) -> dict[str, object]:
+    return _unit(context={"frameworks": [value]})
+
+
+def _unit_with_flag_detail(value: str) -> dict[str, object]:
+    return _unit(flags=[{"reason": "stale", "detail": value}])
+
+
+@pytest.mark.parametrize(
+    ("limit_name", "build"),
+    [
+        ("SUMMARY_MAX_LENGTH", _unit_with_summary),
+        ("DETAIL_MAX_LENGTH", _unit_with_detail),
+        ("ACTION_MAX_LENGTH", _unit_with_action),
+        ("DOMAIN_MAX_LENGTH", _unit_with_domain),
+        ("CREATED_BY_MAX_LENGTH", _unit_with_created_by),
+        ("PATTERN_MAX_LENGTH", _unit_with_pattern),
+        ("LANGUAGE_MAX_LENGTH", _unit_with_language),
+        ("FRAMEWORK_MAX_LENGTH", _unit_with_framework),
+        ("FLAG_DETAIL_MAX_LENGTH", _unit_with_flag_detail),
+    ],
+)
+def test_free_text_field_enforces_max_length(limit_name: str, build: Callable[[str], dict[str, object]]) -> None:
+    schema = cq_schema.load_schema("knowledge_unit")
+    limit = getattr(cq_schema, limit_name)
+
+    jsonschema.validate(instance=build("x" * limit), schema=schema)
+
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=build("x" * (limit + 1)), schema=schema)
+
+
+def _unit_with_domains(count: int) -> dict[str, object]:
+    return _unit(domains=["d"] * count)
+
+
+def _unit_with_languages(count: int) -> dict[str, object]:
+    return _unit(context={"languages": ["l"] * count})
+
+
+def _unit_with_frameworks(count: int) -> dict[str, object]:
+    return _unit(context={"frameworks": ["f"] * count})
+
+
+@pytest.mark.parametrize(
+    ("limit_name", "build"),
+    [
+        ("DOMAINS_MAX_ITEMS", _unit_with_domains),
+        ("LANGUAGES_MAX_ITEMS", _unit_with_languages),
+        ("FRAMEWORKS_MAX_ITEMS", _unit_with_frameworks),
+    ],
+)
+def test_array_field_enforces_max_items(limit_name: str, build: Callable[[int], dict[str, object]]) -> None:
+    schema = cq_schema.load_schema("knowledge_unit")
+    limit = getattr(cq_schema, limit_name)
+
+    jsonschema.validate(instance=build(limit), schema=schema)
+
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=build(limit + 1), schema=schema)

--- a/schema/query.json
+++ b/schema/query.json
@@ -8,18 +8,21 @@
   "properties": {
     "domains": {
       "type": "array",
-      "items": { "type": "string" },
+      "items": { "type": "string", "maxLength": 64 },
       "minItems": 1,
+      "maxItems": 16,
       "description": "At least one domain is required."
     },
     "languages": {
       "type": "array",
-      "items": { "type": "string" },
+      "items": { "type": "string", "maxLength": 64 },
+      "maxItems": 16,
       "description": "Filter by programming languages."
     },
     "frameworks": {
       "type": "array",
-      "items": { "type": "string" },
+      "items": { "type": "string", "maxLength": 64 },
+      "maxItems": 16,
       "description": "Filter by frameworks."
     },
     "limit": {


### PR DESCRIPTION
## Summary

The insight fields (`summary`/`detail`/`action`) and several related free-text fields were declared as unbounded strings.
A schema-valid unit could therefore be unstorable in a length-bounded store, and every implementation invented its own private ceiling — so a unit valid on one install could be rejected by another.

This adds a hard `maxLength` to each free-text field and a `maxItems` to the producer-supplied arrays.
The numbers are single-sourced in the JSON Schema and exposed as constants from both the Go and Python schema packages, so a consumer reads one number instead of hardcoding its own.

Implements the schema half of RFC #500.

## Ceilings

| Field | Bound |
|---|---|
| `insight.summary` | maxLength 500 |
| `insight.detail` | maxLength 8000 |
| `insight.action` | maxLength 2000 |
| `domains[]` item | maxLength 64 |
| `created_by` | maxLength 256 |
| `context.pattern` | maxLength 200 |
| `context.languages[]` / `frameworks[]` item | maxLength 64 |
| `flags[].detail` | maxLength 1000 |
| `domains[]` / `languages[]` / `frameworks[]` | maxItems 16 |

`detail` is 8000 rather than the RFC's straw 4000: corpus data on #500 showed a small real corpus already grazing 4000, so it is sized against the machine author, well above 2× observed maxima.
`flags[]` cardinality is intentionally left unbounded — it is server-managed and append-only, so a cap would block recording legitimate flags rather than protect a producer.

## What's included

- **Schema** — bounds on `knowledge_unit.json`, mirrored wherever a field is redeclared at the wire boundary (`propose.json`, `query.json`, `flag.json`), plus the field tables in `README.md`.
- **Go** (`schema/limits.go`) — accessors parsed from the embedded schema, with a drift test (accessor == schema) and a positivity guard.
- **Python** (`cq_schema`) — the same ceilings as lazily-loaded constants, with a drift test and per-field boundary tests (at-limit accepted, over-limit rejected).

## Breaking change

This is a breaking tightening of the wire schema: units above the new ceilings become invalid.
In practice existing units sit far below the bounds, but it warrants a breaking `schema/vX.Y.Z` release.

## Verification

- `make test-schema-go`, `make test-schema-python`, `make lint-schema-go`, `make lint-schema-python` — all green.
- Repo-root `make lint` and `make test` pass every component **except** `server-frontend`, which fails on a pre-existing pnpm `minimumReleaseAge` policy (`undici@7.29.0`) on `main`, unrelated to this change.

## Not in this PR

SDK/CLI/server enforcement and the prompt/implementer-guidance docs are tracked separately under the epic (#503–#507).

Closes #502
Part of #501


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposed schema limit constants in the Python package for maximum text lengths and array item counts.
* **Bug Fixes**
  * Tightened validation across knowledge unit, query, propose, and flag requests by enforcing stricter `maxLength` and `maxItems` limits (including domains, languages, frameworks, identifiers, and free-text fields).
* **Documentation**
  * Updated the Schema Reference documentation to match the new validation limits.
* **Tests**
  * Added coverage to verify the limits match the exported constants and to ensure oversized values/arrays are rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->