### PR TITLE
fix(schema): type the parsed constants precisely for static checkers

### DIFF
--- a/schema/python/src/cq_schema/__init__.py
+++ b/schema/python/src/cq_schema/__init__.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import json
 from importlib.resources import files
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 __all__ = [
     "ACTION_MAX_LENGTH",
@@ -41,6 +41,33 @@ __all__ = [
     "load_schema",
     "load_schema_bytes",
 ]
+
+if TYPE_CHECKING:
+    # __getattr__ serves these at runtime and must return a single type for
+    # both groups, so it widens to int | float. Declare each constant's
+    # concrete type here so static checkers see the ceilings as int and the
+    # scoring values as float.
+    ACTION_MAX_LENGTH: int
+    CONFIDENCE_CEILING: float
+    CONFIDENCE_FLOOR: float
+    CONFIRMATION_BOOST: float
+    CREATED_BY_MAX_LENGTH: int
+    DETAIL_MAX_LENGTH: int
+    DOMAIN_MAX_LENGTH: int
+    DOMAIN_WEIGHT: float
+    DOMAINS_MAX_ITEMS: int
+    FLAG_DETAIL_MAX_LENGTH: int
+    FLAG_PENALTY: float
+    FRAMEWORK_MAX_LENGTH: int
+    FRAMEWORK_WEIGHT: float
+    FRAMEWORKS_MAX_ITEMS: int
+    INITIAL_CONFIDENCE: float
+    LANGUAGE_MAX_LENGTH: int
+    LANGUAGE_WEIGHT: float
+    LANGUAGES_MAX_ITEMS: int
+    PATTERN_MAX_LENGTH: int
+    PATTERN_WEIGHT: float
+    SUMMARY_MAX_LENGTH: int
 
 _DATA = files("cq_schema") / "_data"
 

--- a/schema/python/tests/test_cq_schema.py
+++ b/schema/python/tests/test_cq_schema.py
@@ -89,6 +89,18 @@ def test_schema_limits_match_schema() -> None:
     assert context["frameworks"]["maxItems"] == cq_schema.FRAMEWORKS_MAX_ITEMS
 
 
+def test_length_and_item_limits_are_int() -> None:
+    for name in cq_schema.__all__:
+        if name.endswith(("_MAX_LENGTH", "_MAX_ITEMS")):
+            assert isinstance(getattr(cq_schema, name), int)
+
+
+def test_scoring_constants_are_float() -> None:
+    for name in cq_schema.__all__:
+        if name.isupper() and not name.endswith(("_MAX_LENGTH", "_MAX_ITEMS")):
+            assert isinstance(getattr(cq_schema, name), float)
+
+
 def test_request_schemas_mirror_knowledge_unit_bounds() -> None:
     ku = cq_schema.load_schema("knowledge_unit")
     ku_props = ku["properties"]

--- a/schema/python/tests/test_cq_schema.py
+++ b/schema/python/tests/test_cq_schema.py
@@ -92,13 +92,13 @@ def test_schema_limits_match_schema() -> None:
 def test_length_and_item_limits_are_int() -> None:
     for name in cq_schema.__all__:
         if name.endswith(("_MAX_LENGTH", "_MAX_ITEMS")):
-            assert isinstance(getattr(cq_schema, name), int)
+            assert type(getattr(cq_schema, name)) is int
 
 
 def test_scoring_constants_are_float() -> None:
     for name in cq_schema.__all__:
         if name.isupper() and not name.endswith(("_MAX_LENGTH", "_MAX_ITEMS")):
-            assert isinstance(getattr(cq_schema, name), float)
+            assert type(getattr(cq_schema, name)) is float
 
 
 def test_request_schemas_mirror_knowledge_unit_bounds() -> None:


### PR DESCRIPTION
## Summary

`cq_schema` serves its parsed constants at runtime via module `__getattr__`, which must return a single type for both the float scoring values and the int ceilings — so it widens to `int | float`.
That leaves the length/item ceilings typed `int | float`, which the first consumer (the Python SDK, #504) can't pass where an `int` is required (for example Pydantic's `max_length`) without a cast.

This declares each constant's concrete type in a `TYPE_CHECKING` block — `int` for the ceilings, `float` for the scoring values — so static checkers see the precise type.
Runtime is unchanged: the block isn't executed and `__getattr__` still serves the values.

It also adds runtime guards asserting the ceilings are `int` and the scoring constants `float`, so the loaders can't drift from the declared types.

## Verification

- `make test-schema-python` — 57 passed (incl. the two new type guards)
- `make lint-schema-python` — ruff + ty + lock check all pass

## Release

This unblocks #504 (Python SDK enforcement), which needs the ceilings typed as `int`.
Warrants a `schema/v0.3.1` patch release; the SDK will then pin `cq-schema>=0.3.1`.

Refs #504


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the accuracy of type information for exported schema constants, helping static analysis and developer tooling identify limits and scoring values correctly.

* **Tests**
  * Added checks to ensure all exported length and item limit constants are integers, and exported scoring-related constants use floating-point types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->