### PR TITLE
feat(sdk-python): enforce free-text ceilings from the schema package

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 license = { text = "Apache-2.0" }
 dependencies = [
-    "cq-schema>=0.2.0",
+    "cq-schema>=0.3.1",
     "httpx>=0.28.1",
     "pydantic>=2.12.5",
 ]

--- a/sdk/python/src/cq/models.py
+++ b/sdk/python/src/cq/models.py
@@ -1,4 +1,11 @@
-"""Pydantic models for cq knowledge units."""
+"""Pydantic models for cq knowledge units.
+
+Every model validates on construction (and on ``model_validate``); invalid
+input raises ``pydantic.ValidationError`` — for example a free-text field over
+its maximum length, an array over its item cap, or a malformed id or extension
+key. Each failure in ``error.errors()`` carries the field location, a message,
+and the offending input.
+"""
 
 import re
 import uuid
@@ -186,7 +193,24 @@ def create_knowledge_unit(
     tier: Tier = Tier.LOCAL,
     created_by: str = "",
 ) -> KnowledgeUnit:
-    """Create a new knowledge unit with an auto-generated ID."""
+    """Create a new knowledge unit with an auto-generated ID.
+
+    Args:
+        domains: Domain tags for the unit; at least one is required.
+        insight: The tripartite insight (summary, detail, action).
+        context: Optional language, framework, and pattern context.
+        extensions: Optional implementation-specific namespaced fields.
+        tier: Storage tier; defaults to local.
+        created_by: Identifier of the creating agent or user.
+
+    Returns:
+        The validated knowledge unit.
+
+    Raises:
+        pydantic.ValidationError: If a field violates the schema, such as a
+            free-text field exceeding its maximum length, an array exceeding
+            its item cap, or a malformed extension key.
+    """
     domains = _as_list(domains)
     return KnowledgeUnit(
         id=_generate_ku_id(),

--- a/sdk/python/src/cq/models.py
+++ b/sdk/python/src/cq/models.py
@@ -4,15 +4,52 @@ import re
 import uuid
 from datetime import UTC, datetime
 from enum import StrEnum
-from typing import Any
+from typing import Annotated, Any
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from cq_schema import (
+    ACTION_MAX_LENGTH,
+    CREATED_BY_MAX_LENGTH,
+    DETAIL_MAX_LENGTH,
+    DOMAIN_MAX_LENGTH,
+    DOMAINS_MAX_ITEMS,
+    FLAG_DETAIL_MAX_LENGTH,
+    FRAMEWORK_MAX_LENGTH,
+    FRAMEWORKS_MAX_ITEMS,
+    LANGUAGE_MAX_LENGTH,
+    LANGUAGES_MAX_ITEMS,
+    PATTERN_MAX_LENGTH,
+    SUMMARY_MAX_LENGTH,
+)
+from pydantic import AfterValidator, BaseModel, Field, ValidationInfo, field_validator, model_validator
 
 from ._util import _as_list
 
 _KU_ID_PREFIX = "ku_"
 _KU_ID_PATTERN = re.compile(r"^ku_[0-9a-f]{32}$")
 _EXTENSION_KEY_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_-]*:\S+$")
+
+
+def _max_length(limit: int) -> AfterValidator:
+    """Return a validator rejecting strings longer than limit, naming the field, limit, and actual length."""
+
+    def _validate(value: str, info: ValidationInfo) -> str:
+        if len(value) > limit:
+            name = info.field_name or "value"
+            raise ValueError(f"{name} must be at most {limit} characters, got {len(value)}")
+        return value
+
+    return AfterValidator(_validate)
+
+
+_Summary = Annotated[str, _max_length(SUMMARY_MAX_LENGTH)]
+_Detail = Annotated[str, _max_length(DETAIL_MAX_LENGTH)]
+_Action = Annotated[str, _max_length(ACTION_MAX_LENGTH)]
+_Domain = Annotated[str, _max_length(DOMAIN_MAX_LENGTH)]
+_Language = Annotated[str, _max_length(LANGUAGE_MAX_LENGTH)]
+_Framework = Annotated[str, _max_length(FRAMEWORK_MAX_LENGTH)]
+_Pattern = Annotated[str, _max_length(PATTERN_MAX_LENGTH)]
+_CreatedBy = Annotated[str, _max_length(CREATED_BY_MAX_LENGTH)]
+_FlagDetail = Annotated[str, _max_length(FLAG_DETAIL_MAX_LENGTH)]
 
 
 class Tier(StrEnum):
@@ -39,7 +76,7 @@ class Flag(BaseModel):
 
     reason: FlagReason
     timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC))
-    detail: str | None = None
+    detail: _FlagDetail | None = None
     duplicate_of: str | None = None
 
     @model_validator(mode="after")
@@ -53,17 +90,17 @@ class Flag(BaseModel):
 class Insight(BaseModel):
     """Tripartite insight: summary, detail, and recommended action."""
 
-    summary: str
-    detail: str
-    action: str
+    summary: _Summary
+    detail: _Detail
+    action: _Action
 
 
 class Context(BaseModel):
     """Language, framework, and pattern context for a knowledge unit."""
 
-    languages: list[str] = Field(default_factory=list)
-    frameworks: list[str] = Field(default_factory=list)
-    pattern: str = ""
+    languages: list[_Language] = Field(default_factory=list, max_length=LANGUAGES_MAX_ITEMS)
+    frameworks: list[_Framework] = Field(default_factory=list, max_length=FRAMEWORKS_MAX_ITEMS)
+    pattern: _Pattern = ""
 
 
 class Evidence(BaseModel):
@@ -97,12 +134,12 @@ class KnowledgeUnit(BaseModel):
 
     id: str
     version: int = 1
-    domains: list[str] = Field(min_length=1)
+    domains: list[_Domain] = Field(min_length=1, max_length=DOMAINS_MAX_ITEMS)
     insight: Insight
     context: Context = Field(default_factory=Context)
     evidence: Evidence = Field(default_factory=Evidence)
     tier: Tier = Tier.LOCAL
-    created_by: str = ""
+    created_by: _CreatedBy = ""
     superseded_by: str | None = None
     extensions: dict[str, Any] | None = None
     flags: list[Flag] = Field(default_factory=list)

--- a/sdk/python/src/cq/models.py
+++ b/sdk/python/src/cq/models.py
@@ -48,15 +48,25 @@ def _max_length(limit: int) -> AfterValidator:
     return AfterValidator(_validate)
 
 
-_Summary = Annotated[str, _max_length(SUMMARY_MAX_LENGTH)]
-_Detail = Annotated[str, _max_length(DETAIL_MAX_LENGTH)]
-_Action = Annotated[str, _max_length(ACTION_MAX_LENGTH)]
-_Domain = Annotated[str, _max_length(DOMAIN_MAX_LENGTH)]
-_Language = Annotated[str, _max_length(LANGUAGE_MAX_LENGTH)]
-_Framework = Annotated[str, _max_length(FRAMEWORK_MAX_LENGTH)]
-_Pattern = Annotated[str, _max_length(PATTERN_MAX_LENGTH)]
-_CreatedBy = Annotated[str, _max_length(CREATED_BY_MAX_LENGTH)]
-_FlagDetail = Annotated[str, _max_length(FLAG_DETAIL_MAX_LENGTH)]
+def _bounded(limit: int) -> tuple[AfterValidator, object]:
+    """Return the metadata pairing an actionable length check with a declared ``maxLength``.
+
+    The ``AfterValidator`` enforces the ceiling with a message naming the field, limit, and length; the
+    ``json_schema_extra`` records the same ceiling in the generated JSON schema without enforcing it (which
+    would short-circuit the message), so the limit stays discoverable and checkable against the canonical schema.
+    """
+    return _max_length(limit), Field(json_schema_extra={"maxLength": limit})
+
+
+_Summary = Annotated[str, *_bounded(SUMMARY_MAX_LENGTH)]
+_Detail = Annotated[str, *_bounded(DETAIL_MAX_LENGTH)]
+_Action = Annotated[str, *_bounded(ACTION_MAX_LENGTH)]
+_Domain = Annotated[str, *_bounded(DOMAIN_MAX_LENGTH)]
+_Language = Annotated[str, *_bounded(LANGUAGE_MAX_LENGTH)]
+_Framework = Annotated[str, *_bounded(FRAMEWORK_MAX_LENGTH)]
+_Pattern = Annotated[str, *_bounded(PATTERN_MAX_LENGTH)]
+_CreatedBy = Annotated[str, *_bounded(CREATED_BY_MAX_LENGTH)]
+_FlagDetail = Annotated[str, *_bounded(FLAG_DETAIL_MAX_LENGTH)]
 
 
 class Tier(StrEnum):

--- a/sdk/python/tests/test_models.py
+++ b/sdk/python/tests/test_models.py
@@ -348,11 +348,23 @@ class TestFieldLimits:
         with pytest.raises(ValidationError):
             build(limit + 1)
 
-    def test_length_error_reports_field_limit_and_length(self) -> None:
-        over = DETAIL_MAX_LENGTH + 1
+    @pytest.mark.parametrize(
+        ("field", "limit", "build"),
+        [
+            ("summary", SUMMARY_MAX_LENGTH, lambda v: Insight(summary=v, detail="d", action="a")),
+            ("pattern", PATTERN_MAX_LENGTH, lambda v: Context(pattern=v)),
+            ("domains", DOMAIN_MAX_LENGTH, lambda v: _make_unit(domains=[v])),
+            ("created_by", CREATED_BY_MAX_LENGTH, lambda v: _make_unit(created_by=v)),
+            ("detail", FLAG_DETAIL_MAX_LENGTH, lambda v: Flag(reason=FlagReason.STALE, detail=v)),
+        ],
+    )
+    def test_error_message_names_field_limit_and_length(
+        self, field: str, limit: int, build: Callable[[str], object]
+    ) -> None:
+        over = limit + 1
         with pytest.raises(ValidationError) as exc:
-            Insight(summary="s", detail="x" * over, action="a")
+            build("x" * over)
         message = str(exc.value)
-        assert "detail" in message
-        assert str(DETAIL_MAX_LENGTH) in message
+        assert field in message
+        assert str(limit) in message
         assert str(over) in message

--- a/sdk/python/tests/test_models.py
+++ b/sdk/python/tests/test_models.py
@@ -1,9 +1,24 @@
 """Tests for knowledge unit data models and serialization."""
 
 import json
+from collections.abc import Callable
 from datetime import UTC, datetime
 
 import pytest
+from cq_schema import (
+    ACTION_MAX_LENGTH,
+    CREATED_BY_MAX_LENGTH,
+    DETAIL_MAX_LENGTH,
+    DOMAIN_MAX_LENGTH,
+    DOMAINS_MAX_ITEMS,
+    FLAG_DETAIL_MAX_LENGTH,
+    FRAMEWORK_MAX_LENGTH,
+    FRAMEWORKS_MAX_ITEMS,
+    LANGUAGE_MAX_LENGTH,
+    LANGUAGES_MAX_ITEMS,
+    PATTERN_MAX_LENGTH,
+    SUMMARY_MAX_LENGTH,
+)
 from pydantic import ValidationError
 
 from cq.models import (
@@ -26,7 +41,7 @@ def _make_insight() -> Insight:
     )
 
 
-def _make_unit(**overrides) -> KnowledgeUnit:
+def _make_unit(**overrides: object) -> KnowledgeUnit:
     defaults = {
         "domains": ["databases", "performance"],
         "insight": _make_insight(),
@@ -35,61 +50,80 @@ def _make_unit(**overrides) -> KnowledgeUnit:
     return create_knowledge_unit(**defaults)
 
 
+_LENGTH_CASES = [
+    ("summary", SUMMARY_MAX_LENGTH, lambda v: Insight(summary=v, detail="d", action="a")),
+    ("detail", DETAIL_MAX_LENGTH, lambda v: Insight(summary="s", detail=v, action="a")),
+    ("action", ACTION_MAX_LENGTH, lambda v: Insight(summary="s", detail="d", action=v)),
+    ("pattern", PATTERN_MAX_LENGTH, lambda v: Context(pattern=v)),
+    ("language", LANGUAGE_MAX_LENGTH, lambda v: Context(languages=[v])),
+    ("framework", FRAMEWORK_MAX_LENGTH, lambda v: Context(frameworks=[v])),
+    ("domain", DOMAIN_MAX_LENGTH, lambda v: _make_unit(domains=[v])),
+    ("created_by", CREATED_BY_MAX_LENGTH, lambda v: _make_unit(created_by=v)),
+    ("flag_detail", FLAG_DETAIL_MAX_LENGTH, lambda v: Flag(reason=FlagReason.STALE, detail=v)),
+]
+
+_ITEMS_CASES = [
+    ("domains", DOMAINS_MAX_ITEMS, lambda n: _make_unit(domains=["d"] * n)),
+    ("languages", LANGUAGES_MAX_ITEMS, lambda n: Context(languages=["l"] * n)),
+    ("frameworks", FRAMEWORKS_MAX_ITEMS, lambda n: Context(frameworks=["f"] * n)),
+]
+
+
 class TestKnowledgeUnitCreation:
-    def test_auto_generated_id_has_ku_prefix(self):
+    def test_auto_generated_id_has_ku_prefix(self) -> None:
         unit = _make_unit()
         assert unit.id.startswith("ku_")
 
-    def test_auto_generated_id_has_sufficient_length(self):
+    def test_auto_generated_id_has_sufficient_length(self) -> None:
         unit = _make_unit()
         # Prefix is 3 chars, UUID hex is 32 chars.
         assert len(unit.id) == 35
 
-    def test_default_confidence_is_half(self):
+    def test_default_confidence_is_half(self) -> None:
         unit = _make_unit()
         assert unit.evidence.confidence == 0.5
 
-    def test_default_version_is_one(self):
+    def test_default_version_is_one(self) -> None:
         unit = _make_unit()
         assert unit.version == 1
 
-    def test_default_tier_is_local(self):
+    def test_default_tier_is_local(self) -> None:
         unit = _make_unit()
         assert unit.tier == Tier.LOCAL
 
 
 class TestEvidenceTimestamps:
-    def test_timestamps_are_identical_on_creation(self):
+    def test_timestamps_are_identical_on_creation(self) -> None:
         evidence = Evidence()
         assert evidence.first_observed == evidence.last_confirmed
 
-    def test_explicit_timestamps_are_preserved(self):
+    def test_explicit_timestamps_are_preserved(self) -> None:
         ts = datetime(2025, 1, 1, tzinfo=UTC)
         evidence = Evidence(first_observed=ts, last_confirmed=ts)
         assert evidence.first_observed == ts
         assert evidence.last_confirmed == ts
 
-    def test_only_first_observed_copies_to_last_confirmed(self):
+    def test_only_first_observed_copies_to_last_confirmed(self) -> None:
         ts = datetime(2025, 6, 15, tzinfo=UTC)
         evidence = Evidence(first_observed=ts)
         assert evidence.last_confirmed == ts
 
-    def test_only_last_confirmed_copies_to_first_observed(self):
+    def test_only_last_confirmed_copies_to_first_observed(self) -> None:
         ts = datetime(2025, 6, 15, tzinfo=UTC)
         evidence = Evidence(last_confirmed=ts)
         assert evidence.first_observed == ts
 
 
 class TestConfidenceBounds:
-    def test_rejects_confidence_above_one(self):
+    def test_rejects_confidence_above_one(self) -> None:
         with pytest.raises(ValidationError):
             Evidence(confidence=5.0)
 
-    def test_rejects_confidence_below_zero(self):
+    def test_rejects_confidence_below_zero(self) -> None:
         with pytest.raises(ValidationError):
             Evidence(confidence=-0.1)
 
-    def test_accepts_boundary_values(self):
+    def test_accepts_boundary_values(self) -> None:
         low = Evidence(confidence=0.0)
         high = Evidence(confidence=1.0)
         assert low.confidence == 0.0
@@ -97,7 +131,7 @@ class TestConfidenceBounds:
 
 
 class TestDomainValidation:
-    def test_rejects_empty_domain_list(self):
+    def test_rejects_empty_domain_list(self) -> None:
         with pytest.raises(ValidationError):
             KnowledgeUnit(
                 id="ku_00000000000000000000000000000001",
@@ -105,7 +139,7 @@ class TestDomainValidation:
                 insight=_make_insight(),
             )
 
-    def test_accepts_single_domain(self):
+    def test_accepts_single_domain(self) -> None:
         unit = KnowledgeUnit(
             id="ku_00000000000000000000000000000001",
             domains=["databases"],
@@ -115,7 +149,7 @@ class TestDomainValidation:
 
 
 class TestCreateKnowledgeUnitCoercion:
-    def test_bare_string_domains_coerced_to_list(self):
+    def test_bare_string_domains_coerced_to_list(self) -> None:
         unit = create_knowledge_unit(
             domains="api",  # type: ignore[arg-type]
             insight=_make_insight(),
@@ -124,20 +158,20 @@ class TestCreateKnowledgeUnitCoercion:
 
 
 class TestIdUniqueness:
-    def test_two_units_have_different_ids(self):
+    def test_two_units_have_different_ids(self) -> None:
         unit_a = _make_unit()
         unit_b = _make_unit()
         assert unit_a.id != unit_b.id
 
 
 class TestSerializationRoundTrip:
-    def test_model_dump_and_validate_roundtrip(self):
+    def test_model_dump_and_validate_roundtrip(self) -> None:
         unit = _make_unit()
         data = unit.model_dump()
         restored = KnowledgeUnit.model_validate(data)
         assert restored == unit
 
-    def test_json_roundtrip(self):
+    def test_json_roundtrip(self) -> None:
         unit = _make_unit()
         json_str = unit.model_dump_json()
         restored = KnowledgeUnit.model_validate_json(json_str)
@@ -153,12 +187,12 @@ class TestWireFormat:
     or field names, which would corrupt the shared database.
     """
 
-    def test_tier_serializes_to_clean_value_in_json(self):
+    def test_tier_serializes_to_clean_value_in_json(self) -> None:
         unit = _make_unit()
         data = json.loads(unit.model_dump_json())
         assert data["tier"] == "local"
 
-    def test_all_tiers_serialize_to_clean_values(self):
+    def test_all_tiers_serialize_to_clean_values(self) -> None:
         for tier, expected in [
             (Tier.LOCAL, "local"),
             (Tier.PRIVATE, "private"),
@@ -168,12 +202,12 @@ class TestWireFormat:
             data = json.loads(unit.model_dump_json())
             assert data["tier"] == expected
 
-    def test_flag_reason_serializes_to_clean_value_in_json(self):
+    def test_flag_reason_serializes_to_clean_value_in_json(self) -> None:
         flag = Flag(reason=FlagReason.STALE)
         data = json.loads(flag.model_dump_json())
         assert data["reason"] == "stale"
 
-    def test_all_flag_reasons_serialize_to_clean_values(self):
+    def test_all_flag_reasons_serialize_to_clean_values(self) -> None:
         for reason, expected in [
             (FlagReason.STALE, "stale"),
             (FlagReason.INCORRECT, "incorrect"),
@@ -186,21 +220,21 @@ class TestWireFormat:
             data = json.loads(flag.model_dump_json())
             assert data["reason"] == expected
 
-    def test_tier_deserializes_from_clean_value(self):
+    def test_tier_deserializes_from_clean_value(self) -> None:
         unit = _make_unit()
         raw = unit.model_dump_json()
         raw = raw.replace('"local"', '"private"')
         restored = KnowledgeUnit.model_validate_json(raw)
         assert restored.tier == Tier.PRIVATE
 
-    def test_flag_reason_deserializes_from_clean_value(self):
+    def test_flag_reason_deserializes_from_clean_value(self) -> None:
         flag = Flag(reason=FlagReason.STALE)
         raw = flag.model_dump_json()
         raw = raw.replace('"stale"', '"incorrect"')
         restored = Flag.model_validate_json(raw)
         assert restored.reason == FlagReason.INCORRECT
 
-    def test_json_field_names(self):
+    def test_json_field_names(self) -> None:
         unit = _make_unit(
             context=Context(languages=["python"], frameworks=["django"], pattern="web"),
         )
@@ -229,11 +263,11 @@ class TestWireFormat:
 
 
 class TestFlagModel:
-    def test_flag_has_timestamp(self):
+    def test_flag_has_timestamp(self) -> None:
         flag = Flag(reason=FlagReason.STALE)
         assert flag.timestamp is not None
 
-    def test_flag_reason_values(self):
+    def test_flag_reason_values(self) -> None:
         assert FlagReason.STALE == "stale"
         assert FlagReason.INCORRECT == "incorrect"
         assert FlagReason.DUPLICATE == "duplicate"
@@ -253,7 +287,7 @@ class TestExtensionKeyValidation:
             "ns:UPPER-value",
         ],
     )
-    def test_accepts_valid_extension_keys(self, key):
+    def test_accepts_valid_extension_keys(self, key: str) -> None:
         unit = _make_unit(extensions={key: "v"})
         assert key in unit.extensions
 
@@ -275,21 +309,50 @@ class TestExtensionKeyValidation:
             "impl: ",
         ],
     )
-    def test_rejects_invalid_extension_keys(self, key):
+    def test_rejects_invalid_extension_keys(self, key: str) -> None:
         with pytest.raises(ValidationError):
             _make_unit(extensions={key: "v"})
 
-    def test_accepts_none_extensions(self):
+    def test_accepts_none_extensions(self) -> None:
         unit = _make_unit()
         assert unit.extensions is None
 
-    def test_accepts_empty_extensions(self):
+    def test_accepts_empty_extensions(self) -> None:
         unit = _make_unit(extensions={})
         assert unit.extensions == {}
 
 
 class TestTierEnum:
-    def test_tier_values(self):
+    def test_tier_values(self) -> None:
         assert Tier.LOCAL == "local"
         assert Tier.PRIVATE == "private"
         assert Tier.PUBLIC == "public"
+
+
+class TestFieldLimits:
+    @pytest.mark.parametrize(("name", "limit", "build"), _LENGTH_CASES)
+    def test_accepts_at_max_length(self, name: str, limit: int, build: Callable[[str], object]) -> None:
+        build("x" * limit)
+
+    @pytest.mark.parametrize(("name", "limit", "build"), _LENGTH_CASES)
+    def test_rejects_over_max_length(self, name: str, limit: int, build: Callable[[str], object]) -> None:
+        with pytest.raises(ValidationError):
+            build("x" * (limit + 1))
+
+    @pytest.mark.parametrize(("name", "limit", "build"), _ITEMS_CASES)
+    def test_accepts_at_max_items(self, name: str, limit: int, build: Callable[[int], object]) -> None:
+        build(limit)
+
+    @pytest.mark.parametrize(("name", "limit", "build"), _ITEMS_CASES)
+    def test_rejects_over_max_items(self, name: str, limit: int, build: Callable[[int], object]) -> None:
+        with pytest.raises(ValidationError):
+            build(limit + 1)
+
+    def test_length_error_reports_field_limit_and_length(self) -> None:
+        over = DETAIL_MAX_LENGTH + 1
+        with pytest.raises(ValidationError) as exc:
+            Insight(summary="s", detail="x" * over, action="a")
+        message = str(exc.value)
+        assert "detail" in message
+        assert str(DETAIL_MAX_LENGTH) in message
+        assert str(over) in message

--- a/sdk/python/tests/test_models.py
+++ b/sdk/python/tests/test_models.py
@@ -50,16 +50,19 @@ def _make_unit(**overrides: object) -> KnowledgeUnit:
     return create_knowledge_unit(**defaults)
 
 
+# The first element is the field token the actionable error message must name; it drives both the
+# accept/reject enforcement tests and the error-message content test, so every constrained string is
+# covered once. List-item fields carry the list's plural name because that is what the message reports.
 _LENGTH_CASES = [
     ("summary", SUMMARY_MAX_LENGTH, lambda v: Insight(summary=v, detail="d", action="a")),
     ("detail", DETAIL_MAX_LENGTH, lambda v: Insight(summary="s", detail=v, action="a")),
     ("action", ACTION_MAX_LENGTH, lambda v: Insight(summary="s", detail="d", action=v)),
     ("pattern", PATTERN_MAX_LENGTH, lambda v: Context(pattern=v)),
-    ("language", LANGUAGE_MAX_LENGTH, lambda v: Context(languages=[v])),
-    ("framework", FRAMEWORK_MAX_LENGTH, lambda v: Context(frameworks=[v])),
-    ("domain", DOMAIN_MAX_LENGTH, lambda v: _make_unit(domains=[v])),
+    ("languages", LANGUAGE_MAX_LENGTH, lambda v: Context(languages=[v])),
+    ("frameworks", FRAMEWORK_MAX_LENGTH, lambda v: Context(frameworks=[v])),
+    ("domains", DOMAIN_MAX_LENGTH, lambda v: _make_unit(domains=[v])),
     ("created_by", CREATED_BY_MAX_LENGTH, lambda v: _make_unit(created_by=v)),
-    ("flag_detail", FLAG_DETAIL_MAX_LENGTH, lambda v: Flag(reason=FlagReason.STALE, detail=v)),
+    ("detail", FLAG_DETAIL_MAX_LENGTH, lambda v: Flag(reason=FlagReason.STALE, detail=v)),
 ]
 
 _ITEMS_CASES = [
@@ -330,34 +333,25 @@ class TestTierEnum:
 
 
 class TestFieldLimits:
-    @pytest.mark.parametrize(("name", "limit", "build"), _LENGTH_CASES)
-    def test_accepts_at_max_length(self, name: str, limit: int, build: Callable[[str], object]) -> None:
+    @pytest.mark.parametrize(("field", "limit", "build"), _LENGTH_CASES)
+    def test_accepts_at_max_length(self, field: str, limit: int, build: Callable[[str], object]) -> None:
         build("x" * limit)
 
-    @pytest.mark.parametrize(("name", "limit", "build"), _LENGTH_CASES)
-    def test_rejects_over_max_length(self, name: str, limit: int, build: Callable[[str], object]) -> None:
+    @pytest.mark.parametrize(("field", "limit", "build"), _LENGTH_CASES)
+    def test_rejects_over_max_length(self, field: str, limit: int, build: Callable[[str], object]) -> None:
         with pytest.raises(ValidationError):
             build("x" * (limit + 1))
 
-    @pytest.mark.parametrize(("name", "limit", "build"), _ITEMS_CASES)
-    def test_accepts_at_max_items(self, name: str, limit: int, build: Callable[[int], object]) -> None:
+    @pytest.mark.parametrize(("field", "limit", "build"), _ITEMS_CASES)
+    def test_accepts_at_max_items(self, field: str, limit: int, build: Callable[[int], object]) -> None:
         build(limit)
 
-    @pytest.mark.parametrize(("name", "limit", "build"), _ITEMS_CASES)
-    def test_rejects_over_max_items(self, name: str, limit: int, build: Callable[[int], object]) -> None:
+    @pytest.mark.parametrize(("field", "limit", "build"), _ITEMS_CASES)
+    def test_rejects_over_max_items(self, field: str, limit: int, build: Callable[[int], object]) -> None:
         with pytest.raises(ValidationError):
             build(limit + 1)
 
-    @pytest.mark.parametrize(
-        ("field", "limit", "build"),
-        [
-            ("summary", SUMMARY_MAX_LENGTH, lambda v: Insight(summary=v, detail="d", action="a")),
-            ("pattern", PATTERN_MAX_LENGTH, lambda v: Context(pattern=v)),
-            ("domains", DOMAIN_MAX_LENGTH, lambda v: _make_unit(domains=[v])),
-            ("created_by", CREATED_BY_MAX_LENGTH, lambda v: _make_unit(created_by=v)),
-            ("detail", FLAG_DETAIL_MAX_LENGTH, lambda v: Flag(reason=FlagReason.STALE, detail=v)),
-        ],
-    )
+    @pytest.mark.parametrize(("field", "limit", "build"), _LENGTH_CASES)
     def test_error_message_names_field_limit_and_length(
         self, field: str, limit: int, build: Callable[[str], object]
     ) -> None:

--- a/sdk/python/tests/test_schema_oracle.py
+++ b/sdk/python/tests/test_schema_oracle.py
@@ -9,6 +9,7 @@ changes shape, the canonical schema validation will fail here.
 from __future__ import annotations
 
 import json
+from collections.abc import Iterator
 from datetime import UTC, datetime
 
 import cq_schema
@@ -159,3 +160,52 @@ def test_store_stats_field_coverage() -> None:
     assert not missing, f"StoreStats fields missing from stats.json: {missing}"
     extra = schema_props - model_fields
     assert not extra, f"stats.json properties not present in StoreStats: {extra}"
+
+
+def _collect_bounds(node: object, path: tuple[object, ...] = ()) -> Iterator[tuple[tuple[object, ...], object]]:
+    """Yield the (path, value) of every maxLength and maxItems in a JSON Schema tree."""
+    if isinstance(node, dict):
+        for keyword in ("maxLength", "maxItems"):
+            if keyword in node:
+                yield (*path, keyword), node[keyword]
+        for key, child in node.items():
+            yield from _collect_bounds(child, (*path, key))
+    elif isinstance(node, list):
+        for index, child in enumerate(node):
+            yield from _collect_bounds(child, (*path, index))
+
+
+def _resolve(node: object, key: object) -> object:
+    """Return node[key], descending through the anyOf wrapper Pydantic emits for optional fields."""
+    if not isinstance(node, dict):
+        raise TypeError(f"cannot navigate into {type(node).__name__}")
+    if key not in node and "anyOf" in node:
+        for branch in node["anyOf"]:
+            if isinstance(branch, dict) and key in branch:
+                return branch[key]
+    return node[key]
+
+
+def _at(node: object, path: tuple[object, ...]) -> object:
+    for key in path:
+        node = _resolve(node, key)
+    return node
+
+
+def test_sdk_model_schema_matches_canonical_bounds() -> None:
+    """Every maxLength/maxItems in knowledge_unit.json is mirrored by the SDK model schema.
+
+    Fails if a ceiling diverges or if the canonical schema adds a bounded field the
+    models do not declare, so limits cannot drift and a new field cannot be missed.
+    """
+    canonical = cq_schema.load_schema("knowledge_unit")
+    sdk_schema = KnowledgeUnit.model_json_schema()
+    bounds = list(_collect_bounds(canonical))
+    assert bounds, "canonical knowledge_unit.json declares no bounds"
+    for path, expected in bounds:
+        try:
+            actual = _at(sdk_schema, path)
+        except (KeyError, TypeError):
+            actual = None
+        location = "/".join(str(key) for key in path)
+        assert actual == expected, f"SDK model schema at {location} is {actual!r}, canonical is {expected}"

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -69,11 +69,11 @@ wheels = [
 
 [[package]]
 name = "cq-schema"
-version = "0.2.0"
+version = "0.3.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/44/e7/decbad3d55a393cc0b73fc708d8892d28daa3ad823dec473be80bdb15a86/cq_schema-0.2.0.tar.gz", hash = "sha256:b12d07f3ccad3ef8e2a5798a15101e2b6fd4712c9bd5ec5289c8379fff910ded", size = 8673, upload-time = "2026-06-23T13:33:26.052Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/27/759dc9fab647ff179f6efaef15da2ad6f5fdc7aecb34357747fa2fdb0694/cq_schema-0.3.1.tar.gz", hash = "sha256:f07b603dfb6914fbf9a62513b3dd28f41e5f00004da787baec5def5e52dbb2df", size = 10821, upload-time = "2026-07-30T18:31:38.868Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/3c/be36a9a5cf2e4174823430f42145647ec04ef3cde2b5ebdb1a7baa425caa/cq_schema-0.2.0-py3-none-any.whl", hash = "sha256:5e7484f1b2545ca500b91a6bb414f69498d4fbbc58f715e9ea5a33551dd12448", size = 11097, upload-time = "2026-06-23T13:33:24.763Z" },
+    { url = "https://files.pythonhosted.org/packages/79/81/b97688562c29632cde18ec6f71ba93556ebe40e1a4a253d9119fcc58c20c/cq_schema-0.3.1-py3-none-any.whl", hash = "sha256:4401791e27f42546b9a76e8fba14ae629dea9c025429578f35bbcde7f74d2c12", size = 12172, upload-time = "2026-07-30T18:31:37.408Z" },
 ]
 
 [[package]]
@@ -111,7 +111,7 @@ tests = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cq-schema", specifier = ">=0.2.0" },
+    { name = "cq-schema", specifier = ">=0.3.1" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'postgres'", specifier = ">=3.3.4,<4" },
     { name = "pydantic", specifier = ">=2.12.5" },


### PR DESCRIPTION
## Summary

Enforces the schema's free-text length ceilings and array-cardinality bounds on the Python SDK's Pydantic models, sourcing every limit from the `cq_schema` constants (no hardcoded literals), so the SDK rejects oversized input before it reaches the wire.

Per the RFC's implementer guidance (#500), the rejection is actionable — it names the field, the limit, and the actual length — so an LLM producer can re-emit a shorter unit rather than getting an opaque `ValidationError`.

## Changes

- `models.py` — a reusable `_max_length` `AfterValidator` (actionable error), applied to `Insight` (summary/detail/action), `Context` (pattern, language/framework items + `maxItems`), `KnowledgeUnit` (domain items + `maxItems`, `created_by`), and `Flag` (`detail`). Array cardinality uses `Field(max_length=…)`.
- `test_models.py` — per-field at-limit/over-limit tests, array max-items tests, and an assertion that the error names field + limit + length.
- `pyproject.toml` / `uv.lock` — `cq-schema>=0.3.1` (needed so the ceilings type as `int`, per #509).
- `test_models.py` — also annotated every existing test method with type hints, so the whole module follows one convention rather than leaving the new tests as the only annotated ones.

## Verification

- `make test-sdk-python` — 488 passed
- `make lint-sdk-python` — ruff + ty + lock check all pass

Closes #504


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Validation Improvements**
  * Added stricter maximum length limits across key text fields (including summaries, details, actions, domains, languages, frameworks, patterns, and flag details).
  * Enforced maximum item counts for list fields (such as languages, frameworks, and domains).
  * Strengthened knowledge unit validation to require at least one domain.
* **Compatibility**
  * Updated the Python SDK’s schema validation dependency to align with newer rules.
* **Tests**
  * Added schema-oracle coverage to ensure all canonical length/item bounds are mirrored in the SDK model schema.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->