### PR TITLE
fix(frontend): reduce pnpm minimumReleaseAge cooldown from 7 to 3 days

### DIFF
--- a/server/frontend/pnpm-workspace.yaml
+++ b/server/frontend/pnpm-workspace.yaml
@@ -1,3 +1,3 @@
-# Delay installation of newly published packages by 7 days (10080 minutes).
+# Delay installation of newly published packages by 3 days (4320 minutes).
 # Malware is typically detected within hours, so this window provides protection.
-minimumReleaseAge: 10080
+minimumReleaseAge: 4320


### PR DESCRIPTION
## Change

Lowers the supply-chain release-age window in `server/frontend/pnpm-workspace.yaml` from **7 days** (10080 minutes) to **3 days** (4320 minutes). Shortens the window during which freshly published dependencies are blocked, while retaining protection against malware (typically detected within hours of publication).

## Context

- `minimumReleaseAge` is already a **top-level** key (not nested), so pnpm honors it.
- No `.npmrc` files (rules out the sibling silently-ignored failure mode).
- No nested `pnpm:` key in any YAML, no `"pnpm"` block in `package.json`.
- `server/frontend` is the only pnpm-configured subcomponent.

## Verification

`pnpm config get minimumReleaseAge` (pnpm 11.7.0) returns `4320`, confirming the key is honored and the 3-day window is live.

## Note

Per pnpm behavior, this window is re-checked on every `pnpm run` against the committed lockfile, not just at install. If the lockfile contains a dependency published within the last 3 days, CI/dev/build will fail until it ages out.