### PR TITLE
refactor(sdk-go): order scoring.go declarations alphabetically

### DIFF
--- a/sdk/go/scoring.go
+++ b/sdk/go/scoring.go
@@ -54,31 +54,6 @@ func RankCandidates(candidates []KnowledgeUnit, params QueryParams) []KnowledgeU
 	return units
 }
 
-// relevance scores how relevant ku is to the given query parameters.
-func (ku KnowledgeUnit) relevance(
-	queryDomains []string,
-	queryLanguages []string,
-	queryFrameworks []string,
-	queryPattern string,
-) float64 {
-	domainScore := jaccardSimilarity(ku.Domains, queryDomains)
-	var languageScore, frameworkScore, patternScore float64
-	if anyMatch(ku.Context.Languages, queryLanguages) {
-		languageScore = 1.0
-	}
-	if anyMatch(ku.Context.Frameworks, queryFrameworks) {
-		frameworkScore = 1.0
-	}
-	if queryPattern != "" && ku.Context.Pattern != "" && strings.EqualFold(queryPattern, ku.Context.Pattern) {
-		patternScore = 1.0
-	}
-	score := cqschema.DomainWeight()*domainScore +
-		cqschema.LanguageWeight()*languageScore +
-		cqschema.FrameworkWeight()*frameworkScore +
-		cqschema.PatternWeight()*patternScore
-	return min(max(score, 0.0), 1.0)
-}
-
 // anyMatch reports whether any element in queries appears in items.
 func anyMatch(items []string, queries []string) bool {
 	if len(queries) == 0 {
@@ -148,4 +123,29 @@ func jaccardSimilarity(a []string, b []string) float64 {
 	}
 	union := len(setA) + len(setB) - intersection
 	return float64(intersection) / float64(union)
+}
+
+// relevance scores how relevant ku is to the given query parameters.
+func (ku KnowledgeUnit) relevance(
+	queryDomains []string,
+	queryLanguages []string,
+	queryFrameworks []string,
+	queryPattern string,
+) float64 {
+	domainScore := jaccardSimilarity(ku.Domains, queryDomains)
+	var languageScore, frameworkScore, patternScore float64
+	if anyMatch(ku.Context.Languages, queryLanguages) {
+		languageScore = 1.0
+	}
+	if anyMatch(ku.Context.Frameworks, queryFrameworks) {
+		frameworkScore = 1.0
+	}
+	if queryPattern != "" && ku.Context.Pattern != "" && strings.EqualFold(queryPattern, ku.Context.Pattern) {
+		patternScore = 1.0
+	}
+	score := cqschema.DomainWeight()*domainScore +
+		cqschema.LanguageWeight()*languageScore +
+		cqschema.FrameworkWeight()*frameworkScore +
+		cqschema.PatternWeight()*patternScore
+	return min(max(score, 0.0), 1.0)
 }


### PR DESCRIPTION
## Summary

Reorders the top-level declarations in `sdk/go/scoring.go` so they follow the package's existing convention (as in `store.go` and `options.go`): the exported entry point first, then unexported declarations in alphabetical order.

The `relevance` method was previously hoisted directly after `RankCandidates` (top-down grouping). It now sits at the end of the file, giving the order:

`RankCandidates` → `anyMatch` → `applyConfirmation` → `applyFlag` → `jaccardSimilarity` → `relevance`

This is a pure positional move of the method and its doc comment — no logic changes.

## Verification

- `make lint` — 0 issues
- `make test` — full SDK suite passes
- `go build ./...` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganised internal scoring logic without changing functionality or user-visible behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->