### PR TITLE
fix(cli): honor configured remote timeout

### DIFF
--- a/cli/cmd/cli.go
+++ b/cli/cmd/cli.go
@@ -106,7 +106,7 @@ func configDir() (string, error) {
 
 // newCLIClient creates a new SDK client using the persistent flag values.
 func newCLIClient() (*cq.Client, error) {
-	var opts []cq.ClientOption
+	opts := []cq.ClientOption{cq.WithTimeout(cliTimeout())}
 	if flagAddr != "" {
 		opts = append(opts, cq.WithAddr(flagAddr))
 	}

--- a/cli/cmd/query_test.go
+++ b/cli/cmd/query_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -152,6 +153,28 @@ func TestQueryPrintsRemoteWarningsToStderr(t *testing.T) {
 	stderr := errBuf.String()
 	require.Contains(t, stderr, "warning:")
 	require.Contains(t, stderr, "decoding")
+}
+
+func TestQueryHonorsConfiguredRemoteTimeout(t *testing.T) {
+	testSetup(t)
+	t.Setenv(envVarTimeout, "8")
+	withFakeRemote(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/knowledge" {
+			http.NotFound(w, r)
+			return
+		}
+
+		time.Sleep(cq.DefaultTimeout() + time.Second)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":"ku_00000000000000000000000000000001","version":1,"domains":["api"],"insight":{"summary":"slow remote response","detail":"d","action":"a"},"context":{"languages":[],"frameworks":[],"pattern":""},"evidence":{"confidence":0.5,"confirmations":1},"tier":"private","flags":[]}]}`))
+	}))
+
+	query := NewQueryCmd()
+	var out bytes.Buffer
+	query.SetOut(&out)
+	query.SetArgs([]string{"--domain", "api"})
+	require.NoError(t, query.Execute())
+	require.Contains(t, out.String(), "slow remote response")
 }
 
 func TestQueryPatternFlag(t *testing.T) {

--- a/cli/cmd/query_test.go
+++ b/cli/cmd/query_test.go
@@ -166,7 +166,11 @@ func TestQueryHonorsConfiguredRemoteTimeout(t *testing.T) {
 
 		time.Sleep(cq.DefaultTimeout() + time.Second)
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"data":[{"id":"ku_00000000000000000000000000000001","version":1,"domains":["api"],"insight":{"summary":"slow remote response","detail":"d","action":"a"},"context":{"languages":[],"frameworks":[],"pattern":""},"evidence":{"confidence":0.5,"confirmations":1},"tier":"private","flags":[]}]}`))
+		_, _ = w.Write(
+			[]byte(
+				`{"data":[{"id":"ku_00000000000000000000000000000001","version":1,"domains":["api"],"insight":{"summary":"slow remote response","detail":"d","action":"a"},"context":{"languages":[],"frameworks":[],"pattern":""},"evidence":{"confidence":0.5,"confirmations":1},"tier":"private","flags":[]}]}`,
+			),
+		)
 	}))
 
 	query := NewQueryCmd()

--- a/cli/cmd/query_test.go
+++ b/cli/cmd/query_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"net/http"
+	"strconv"
 	"testing"
 	"time"
 
@@ -157,14 +158,24 @@ func TestQueryPrintsRemoteWarningsToStderr(t *testing.T) {
 
 func TestQueryHonorsConfiguredRemoteTimeout(t *testing.T) {
 	testSetup(t)
-	t.Setenv(envVarTimeout, "8")
+
+	// The remote responds slower than the SDK's default HTTP timeout but faster
+	// than the configured CQ_TIMEOUT, so the request only succeeds if CQ_TIMEOUT
+	// is what governs the client. Guard the ordering so a future bump to the SDK
+	// default fails loudly here instead of flaking.
+	const configuredTimeout = 8 * time.Second
+	remoteDelay := cq.DefaultTimeout() + time.Second
+	require.Less(t, remoteDelay, configuredTimeout,
+		"SDK default HTTP timeout grew too close to CQ_TIMEOUT; raise configuredTimeout")
+
+	t.Setenv(envVarTimeout, strconv.Itoa(int(configuredTimeout/time.Second)))
 	withFakeRemote(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/v1/knowledge" {
 			http.NotFound(w, r)
 			return
 		}
 
-		time.Sleep(cq.DefaultTimeout() + time.Second)
+		time.Sleep(remoteDelay)
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write(
 			[]byte(


### PR DESCRIPTION
## Summary

- Pass CQ_TIMEOUT to the Go SDK when constructing CLI clients.
- Cover a remote response that exceeds the SDK default but completes within the configured CLI timeout.

## Checks

- go test ./...
- go vet ./...
- make lint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where the CLI’s configured timeout was not consistently applied to remote query requests.
  - Queries can now wait for slower remote responses within the configured timeout period, reducing premature request failures.

- **Tests**
  - Added coverage to verify that delayed remote responses are handled successfully when a suitable timeout is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->