### PR TITLE
feat(sdk-go): enforce domains minItems:1 at the Propose boundary

### DIFF
--- a/sdk/go/validate.go
+++ b/sdk/go/validate.go
@@ -38,11 +38,21 @@ func validateLength(field string, value string, limit int) error {
 	return nil
 }
 
-// validateProposeParams rejects any free-text field or tag list on params that
-// exceeds its schema-declared ceiling, collecting every violation so a producer
-// can shorten all of them in one pass. Each ceiling comes from the schema
-// package, never a hardcoded literal, and an over-limit value fails the whole
-// propose rather than being truncated.
+// validateNonEmpty rejects an empty tag list, naming the plural field. It
+// enforces the schema's minItems:1 lower bound, a bare presence check with no
+// ceiling value to source and so no schema accessor.
+func validateNonEmpty(field string, items []string) error {
+	if len(items) == 0 {
+		return fmt.Errorf("%s must not be empty", field)
+	}
+	return nil
+}
+
+// validateProposeParams rejects params that break a schema-declared bound —
+// its required at-least-one-domain lower bound, or any free-text or tag-list
+// ceiling — collecting every violation so a producer can fix them in one pass.
+// Each ceiling comes from the schema package, never a hardcoded literal, and a
+// violating value fails the whole propose rather than being truncated.
 func validateProposeParams(params ProposeParams) error {
 	return errors.Join(
 		validateLength("summary", params.Summary, cqschema.SummaryMaxLength()),
@@ -53,6 +63,7 @@ func validateProposeParams(params ProposeParams) error {
 		validateItemLengths("domain", params.Domains, cqschema.DomainMaxLength()),
 		validateItemLengths("language", params.Languages, cqschema.LanguageMaxLength()),
 		validateItemLengths("framework", params.Frameworks, cqschema.FrameworkMaxLength()),
+		validateNonEmpty("domains", params.Domains),
 		validateCount("domains", params.Domains, cqschema.DomainsMaxItems()),
 		validateCount("languages", params.Languages, cqschema.LanguagesMaxItems()),
 		validateCount("frameworks", params.Frameworks, cqschema.FrameworksMaxItems()),

--- a/sdk/go/validate_test.go
+++ b/sdk/go/validate_test.go
@@ -120,6 +120,27 @@ func TestValidateProposeParamsRejectsOverMaxItems(t *testing.T) {
 	}
 }
 
+// TestValidateProposeParamsRejectsEmptyDomains guards the schema's minItems:1
+// lower bound on domains: a proposal carrying no domain is rejected at the
+// boundary, alongside the ceilings, rather than one layer down in the store.
+func TestValidateProposeParamsRejectsEmptyDomains(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name    string
+		domains []string
+	}{
+		{"nil", nil},
+		{"empty", []string{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			params := validParams()
+			params.Domains = tc.domains
+			require.EqualError(t, validateProposeParams(params), "domains must not be empty")
+		})
+	}
+}
+
 // TestValidateProposeParamsCountsRunesNotBytes guards the schema's maxLength
 // semantics: length is measured in Unicode code points, so a multibyte string
 // at the character ceiling is accepted even though its byte length is larger.


### PR DESCRIPTION
## Summary

Closes #515.

The schema declares `domains` with `minItems: 1`, but `validateProposeParams` enforced only the free-text and tag-list ceilings (added in #513).
Required-ness was caught one layer down in the store, so input validation was split across two boundaries and the remote path surfaced a less actionable message.
This enforces the `domains` lower bound at the `Propose` boundary too, so required-ness and the ceilings are enforced together with one consistent, domain-worded error (`domains must not be empty`).

## Details

- The check is a bare `len == 0` guard — it mirrors the Python SDK's `domains: list[_Domain] = Field(min_length=1)` (list has at least one item), closing a small Go/Python parity difference.
- No new schema accessor is added: `minItems: 1` carries no numeric ceiling to source, unlike the `maxLength`/`maxItems` siblings that read limits from the schema package.
- The store-layer guard stays as a backstop and still rejects whitespace-only or duplicate domains after normalization; this change consolidates the common empty-domains rejection at the boundary and improves the remote-path message.

## Out of scope (deliberately not changed)

The issue asks whether other schema-required fields (`insight.summary`/`detail`/`action`) warrant the same boundary-level check.
Those are required to be *present*, not *non-empty*: the schema declares no `minLength`, the Python SDK enforces only presence, and no layer enforces non-empty on them.
Adding a non-empty check there would over-enforce beyond the schema and introduce a new Go/Python divergence, so it is intentionally excluded.

## Testing

- Added `TestValidateProposeParamsRejectsEmptyDomains` (table-driven: `nil` and `empty` domains), written test-first and confirmed failing before the fix.
- `make lint-sdk-go` and `make test-sdk-go` pass, as does the full repo-root `make lint` / `make test` gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Proposal validation now rejects requests with missing or empty domain lists.
  * Validation documentation now clarifies required minimum values and maximum limits.

* **Tests**
  * Added coverage confirming that both nil and empty domain lists are rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->