### PR TITLE
docs: note the enforced free-text ceilings alongside the soft targets

### DIFF
--- a/plugins/cq/commands/reflect.md
+++ b/plugins/cq/commands/reflect.md
@@ -58,6 +58,8 @@ For each candidate, assign:
 - **domains** — two to five lowercase domain tags (e.g. `["api", "stripe", "rate-limiting"]`).
 - Optionally: **languages**, **frameworks**, **pattern** if relevant.
 
+These are soft targets; the schema also enforces hard ceilings — 500 characters for `summary`, 8000 for `detail`, 2000 for `action` — and an over-limit candidate is rejected, never truncated.
+
 For each candidate that resolved an error that occurred earlier in this session (i.e. a tool call or action failed before the successful resolution was found), mark it with ⏱ in the Step 3 presentation. Record the count of ⏱ candidates in the Step 6 summary — these represent missed mid-task propose calls and make the protocol gap visible to the user.
 
 If the session contained no events meeting the above criteria, skip Steps 3–5 and follow the "no candidates" instruction in Step 6.

--- a/plugins/cq/skills/cq/SKILL.md
+++ b/plugins/cq/skills/cq/SKILL.md
@@ -158,6 +158,8 @@ Provide all three insight fields:
 - **detail** — Fuller explanation with enough context to understand the issue. Include a timestamp and source where possible.
 - **action** — Concrete instruction on what to do about it. Start with an imperative verb (e.g. `Use`, `Set`, `Replace`, `When X, do Y`). Prefer principle + verification method over exact values.
 
+These are soft targets; the schema also enforces hard ceilings — 500 characters for `summary`, 8000 for `detail`, 2000 for `action` — and an over-limit proposal is rejected, never truncated.
+
 #### VIBE√ safety check
 
 Before calling `propose`, evaluate every candidate against four safety dimensions. This applies to all propose calls — those triggered by `/cq:reflect` and direct proposes made while working on a task.

--- a/schema/README.md
+++ b/schema/README.md
@@ -247,6 +247,14 @@ Discovery document published at `/.well-known/cq-node.json` by a cq node. See th
 | `api_version` | string (`v\d+`) | yes | Protocol version spoken at api_base_url. |
 | `node_name` | string (<= 200 chars) | no | Human-readable display name for this node. |
 
+## Free-text ceilings
+
+The `maxLength` bounds on free-text fields (such as `insight.summary`, `insight.detail`, and `insight.action`) are hard ceilings declared once in the schema files and exposed as constants by the Go and Python packages. They are ceilings, not targets: authoring guidance sets much smaller soft targets, and the ceilings exist only to reject pathological input. Lengths count Unicode code points, not bytes. Implementations must:
+
+- Size length-bounded storage at or above the schema ceilings.
+- Enforce the schema's number exactly, never a private smaller one.
+- Never truncate over-limit input — reject the whole unit with a clear error.
+
 ## Development
 
 The Go module at the schema root embeds all `.json` files and exposes them programmatically. The Python package under `python/` wraps the same files. Both are released independently; see the [top-level development guide](../DEVELOPMENT.md) for details.

--- a/sdk/go/prompts/SKILL.md
+++ b/sdk/go/prompts/SKILL.md
@@ -158,6 +158,8 @@ Provide all three insight fields:
 - **detail** — Fuller explanation with enough context to understand the issue. Include a timestamp and source where possible.
 - **action** — Concrete instruction on what to do about it. Start with an imperative verb (e.g. `Use`, `Set`, `Replace`, `When X, do Y`). Prefer principle + verification method over exact values.
 
+These are soft targets; the schema also enforces hard ceilings — 500 characters for `summary`, 8000 for `detail`, 2000 for `action` — and an over-limit proposal is rejected, never truncated.
+
 #### VIBE√ safety check
 
 Before calling `propose`, evaluate every candidate against four safety dimensions. This applies to all propose calls — those triggered by `/cq:reflect` and direct proposes made while working on a task.

--- a/sdk/go/prompts/reflect.md
+++ b/sdk/go/prompts/reflect.md
@@ -58,6 +58,8 @@ For each candidate, assign:
 - **domains** — two to five lowercase domain tags (e.g. `["api", "stripe", "rate-limiting"]`).
 - Optionally: **languages**, **frameworks**, **pattern** if relevant.
 
+These are soft targets; the schema also enforces hard ceilings — 500 characters for `summary`, 8000 for `detail`, 2000 for `action` — and an over-limit candidate is rejected, never truncated.
+
 For each candidate that resolved an error that occurred earlier in this session (i.e. a tool call or action failed before the successful resolution was found), mark it with ⏱ in the Step 3 presentation. Record the count of ⏱ candidates in the Step 6 summary — these represent missed mid-task propose calls and make the protocol gap visible to the user.
 
 If the session contained no events meeting the above criteria, skip Steps 3–5 and follow the "no candidates" instruction in Step 6.

--- a/sdk/python/src/cq/prompts/SKILL.md
+++ b/sdk/python/src/cq/prompts/SKILL.md
@@ -158,6 +158,8 @@ Provide all three insight fields:
 - **detail** — Fuller explanation with enough context to understand the issue. Include a timestamp and source where possible.
 - **action** — Concrete instruction on what to do about it. Start with an imperative verb (e.g. `Use`, `Set`, `Replace`, `When X, do Y`). Prefer principle + verification method over exact values.
 
+These are soft targets; the schema also enforces hard ceilings — 500 characters for `summary`, 8000 for `detail`, 2000 for `action` — and an over-limit proposal is rejected, never truncated.
+
 #### VIBE√ safety check
 
 Before calling `propose`, evaluate every candidate against four safety dimensions. This applies to all propose calls — those triggered by `/cq:reflect` and direct proposes made while working on a task.

--- a/sdk/python/src/cq/prompts/reflect.md
+++ b/sdk/python/src/cq/prompts/reflect.md
@@ -58,6 +58,8 @@ For each candidate, assign:
 - **domains** — two to five lowercase domain tags (e.g. `["api", "stripe", "rate-limiting"]`).
 - Optionally: **languages**, **frameworks**, **pattern** if relevant.
 
+These are soft targets; the schema also enforces hard ceilings — 500 characters for `summary`, 8000 for `detail`, 2000 for `action` — and an over-limit candidate is rejected, never truncated.
+
 For each candidate that resolved an error that occurred earlier in this session (i.e. a tool call or action failed before the successful resolution was found), mark it with ⏱ in the Step 3 presentation. Record the count of ⏱ candidates in the Step 6 summary — these represent missed mid-task propose calls and make the protocol gap visible to the user.
 
 If the session contained no events meeting the above criteria, skip Steps 3–5 and follow the "no candidates" instruction in Step 6.


### PR DESCRIPTION
Closes #507. Part of #501.

The prompt guidance keeps setting the soft targets (summary is one line, detail is two-to-four sentences). Each authoring list now carries a one-line note of the schema-enforced hard ceilings so authors know the limit, and the schema docs record the implementer guidance.

## Changes

- `plugins/cq/skills/cq/SKILL.md`, `plugins/cq/commands/reflect.md`: soft targets unchanged; each field list gains a one-line note of the hard ceilings (500 chars `summary`, 8000 `detail`, 2000 `action`) and that over-limit input is rejected, never truncated.
- `schema/README.md`: new "Free-text ceilings" section — size length-bounded storage at or above the ceilings, enforce the schema's number exactly (never a private smaller one), never truncate — reject with a clear error. Notes that lengths count Unicode code points.
- `sdk/go/prompts/` and `sdk/python/src/cq/prompts/` copies regenerated via `make sync-prompts`.

## Validation

- `make check-prompts-sync` green (what `ci-prompts-sync` runs).
- `make lint-sdk-python` green (pre-commit over the changed package files).
- Ceiling numbers taken from `schema/knowledge_unit.json`, matching the table in #501.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Documented maximum lengths for proposal fields: 500 characters for summaries, 8,000 for details, and 2,000 for actions.
  * Clarified that limits count Unicode characters and are enforced exactly.
  * Proposals exceeding these limits are rejected rather than truncated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->