### PR TITLE
feat(cli): add --timeout persistent flag for parity with CQ_TIMEOUT

### DIFF
--- a/cli/cmd/cli.go
+++ b/cli/cmd/cli.go
@@ -36,7 +36,7 @@ const (
 	// the SDK's handling of XDG_DATA_HOME.
 	envVarXDGConfigHome = "XDG_CONFIG_HOME"
 
-	// defaultCLITimeout is the CLI operation timeout when CQ_TIMEOUT is not set.
+	// defaultCLITimeout is the CLI operation timeout when neither --timeout nor CQ_TIMEOUT is set.
 	defaultCLITimeout = 30 * time.Second
 
 	// jsonIndentSpaces is the number of spaces used for JSON indentation in CLI output.
@@ -53,6 +53,11 @@ var (
 	// flagDBPath holds the resolved --db-path persistent flag value.
 	flagDBPath string
 
+	// flagTimeout holds the resolved --timeout persistent flag value. A
+	// non-positive value means "unset"; cliTimeout then falls back to
+	// CQ_TIMEOUT and finally the default.
+	flagTimeout time.Duration
+
 	// jsonIndent is the indent string for JSON output.
 	jsonIndent = strings.Repeat(" ", jsonIndentSpaces)
 )
@@ -62,10 +67,21 @@ func InitFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&flagAddr, "addr", os.Getenv(envVarAddr), "Remote API address (env: "+envVarAddr+")")
 	fs.StringVar(&flagAPIKey, "api-key", "", "API key for remote authentication (env: "+envVarAPIKey+")")
 	fs.StringVar(&flagDBPath, "db-path", os.Getenv(envVarDBPath), "Local database path (env: "+envVarDBPath+")")
+	fs.DurationVar(
+		&flagTimeout,
+		"timeout",
+		0,
+		"CLI operation timeout, e.g. 30s (env: "+envVarTimeout+", default "+defaultCLITimeout.String()+")",
+	)
 }
 
-// cliTimeout returns the CLI operation timeout from CQ_TIMEOUT env var or the default.
+// cliTimeout resolves the CLI operation timeout with precedence: the --timeout
+// flag, then the CQ_TIMEOUT env var (integer seconds), then the default.
 func cliTimeout() time.Duration {
+	if flagTimeout > 0 {
+		return flagTimeout
+	}
+
 	if v := os.Getenv(envVarTimeout); v != "" {
 		if d, err := strconv.Atoi(v); err == nil && d > 0 {
 			return time.Duration(d) * time.Second

--- a/cli/cmd/cli.go
+++ b/cli/cmd/cli.go
@@ -71,7 +71,7 @@ func InitFlags(fs *pflag.FlagSet) {
 		&flagTimeout,
 		"timeout",
 		0,
-		"CLI operation timeout, e.g. 30s (env: "+envVarTimeout+", default "+defaultCLITimeout.String()+")",
+		"CLI operation timeout, e.g. 30s (env: "+envVarTimeout+" in seconds, default "+defaultCLITimeout.String()+")",
 	)
 }
 

--- a/cli/cmd/cli_test.go
+++ b/cli/cmd/cli_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/require"
@@ -13,8 +14,49 @@ func TestInitFlagsRegistersAllFlags(t *testing.T) {
 	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
 	InitFlags(fs)
 
-	for _, name := range []string{"addr", "api-key", "db-path"} {
+	for _, name := range []string{"addr", "api-key", "db-path", "timeout"} {
 		require.NotNil(t, fs.Lookup(name), "expected flag %s to be registered", name)
+	}
+}
+
+func TestInitFlagsTimeoutUsesZeroSentinelDefault(t *testing.T) {
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	InitFlags(fs)
+
+	f := fs.Lookup("timeout")
+	require.NotNil(t, f)
+
+	// The flag carries a 0 sentinel so flag > env > default resolution stays in
+	// cliTimeout. Because 0 is the zero value for a duration, pflag suppresses a
+	// misleading "(default 0s)"; the real default is documented in the usage.
+	require.Equal(t, "0s", f.DefValue)
+	require.Contains(t, f.Usage, envVarTimeout)
+	require.Contains(t, f.Usage, "default "+defaultCLITimeout.String())
+	require.NotContains(t, fs.FlagUsages(), "(default 0s)")
+}
+
+func TestCLITimeout(t *testing.T) {
+	tests := []struct {
+		name string
+		flag time.Duration
+		env  string
+		want time.Duration
+	}{
+		{name: "flag overrides env and default", flag: 3 * time.Second, env: "8", want: 3 * time.Second},
+		{name: "flag honors sub-second durations", flag: 500 * time.Millisecond, env: "", want: 500 * time.Millisecond},
+		{name: "env used when flag unset", flag: 0, env: "8", want: 8 * time.Second},
+		{name: "default when flag and env unset", flag: 0, env: "", want: defaultCLITimeout},
+		{name: "default when env is non-numeric", flag: 0, env: "abc", want: defaultCLITimeout},
+		{name: "default when env is non-positive", flag: 0, env: "0", want: defaultCLITimeout},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(envVarTimeout, tc.env)
+			setFlag(t, &flagTimeout, tc.flag)
+
+			require.Equal(t, tc.want, cliTimeout())
+		})
 	}
 }
 

--- a/cli/cmd/cli_test.go
+++ b/cli/cmd/cli_test.go
@@ -33,6 +33,30 @@ func TestInitFlagsTimeoutUsesZeroSentinelDefault(t *testing.T) {
 	require.Contains(t, f.Usage, envVarTimeout)
 	require.Contains(t, f.Usage, "default "+defaultCLITimeout.String())
 	require.NotContains(t, fs.FlagUsages(), "(default 0s)")
+
+	// The env var is parsed as integer seconds (unlike the duration flag), so
+	// the help must document the unit to avoid a silent fallback on e.g.
+	// CQ_TIMEOUT=30s.
+	require.Contains(t, f.Usage, "seconds")
+}
+
+func TestInitFlagsParsesTimeoutDuration(t *testing.T) {
+	setFlag(t, &flagTimeout, 0)
+
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	InitFlags(fs)
+
+	require.NoError(t, fs.Parse([]string{"--timeout=1m30s"}))
+	require.Equal(t, 90*time.Second, flagTimeout)
+}
+
+func TestInitFlagsRejectsInvalidTimeout(t *testing.T) {
+	setFlag(t, &flagTimeout, 0)
+
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	InitFlags(fs)
+
+	require.Error(t, fs.Parse([]string{"--timeout=not-a-duration"}))
 }
 
 func TestCLITimeout(t *testing.T) {

--- a/cli/cmd/cmd_test.go
+++ b/cli/cmd/cmd_test.go
@@ -23,7 +23,7 @@ func testSetup(t *testing.T) {
 }
 
 // setFlag sets a package-level flag variable and restores it after the test.
-func setFlag(t *testing.T, target *string, value string) {
+func setFlag[T any](t *testing.T, target *T, value T) {
 	t.Helper()
 
 	prev := *target

--- a/cli/main.go
+++ b/cli/main.go
@@ -100,7 +100,7 @@ func hideFlagsFor(root *cobra.Command, names ...string) {
 	for _, c := range root.Commands() {
 		if hidden[c.Name()] {
 			c.SetHelpFunc(func(c *cobra.Command, args []string) {
-				for _, name := range []string{"addr", "api-key", "db-path"} {
+				for _, name := range []string{"addr", "api-key", "db-path", "timeout"} {
 					if f := c.Flags().Lookup(name); f != nil {
 						f.Hidden = true
 					}


### PR DESCRIPTION
Adds a `--timeout` persistent flag so the CLI operation timeout is configurable via a flag, not only the `CQ_TIMEOUT` environment variable — matching the other core connection settings (`--addr`, `--api-key`, `--db-path`).

## Design
- `--timeout` accepts a `time.Duration` (e.g. `--timeout 30s`, `500ms`, `1m30s`), consistent with every other timeout in the Go tree and with `cq.WithTimeout`, which the value feeds directly.
- `CQ_TIMEOUT` stays integer seconds — fully backward compatible.
- Precedence: `--timeout` flag > `CQ_TIMEOUT` > 30s default, resolved in `cliTimeout()` via a `0` sentinel default (pflag omits a misleading `(default 0s)`; the real default is in the usage text).
- Hidden on the `prompt` command alongside the other client flags.

## Testing
- `make lint-cli` — clean.
- `make test-cli` — all pass, including table-driven precedence tests and the pre-existing `TestQueryHonorsConfiguredRemoteTimeout`.
- Manual: `--timeout` shows on `cq query --help`, hidden on `cq prompt … --help`, invalid durations error clearly.

Closes #519


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a persistent `--timeout` option for configuring command timeouts.
  * Timeout values support duration formats, with environment values interpreted in seconds.
  * Timeout resolution prioritises the command-line option, then `CQ_TIMEOUT`, then the default.
* **Improvements**
  * Invalid timeout values are now rejected with clear validation.
  * Updated CLI help and usage information.
  * Timeout options remain hidden from commands where they are not applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->