### PR TITLE
fix(frontend): report why login failed instead of always blaming credentials

### DIFF
--- a/server/frontend/src/pages/LoginPage.test.tsx
+++ b/server/frontend/src/pages/LoginPage.test.tsx
@@ -1,0 +1,78 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { AuthProvider } from "../auth"
+import { LoginPage } from "./LoginPage"
+
+const originalFetch = globalThis.fetch
+
+function mockFetch(status: number, body: unknown = {}) {
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  }) as unknown as typeof fetch
+}
+
+function submitLogin() {
+  render(
+    <AuthProvider>
+      <LoginPage />
+    </AuthProvider>,
+  )
+  fireEvent.change(screen.getByLabelText(/username/i), {
+    target: { value: "demo" },
+  })
+  fireEvent.change(screen.getByLabelText(/password/i), {
+    target: { value: "demo123" },
+  })
+  fireEvent.click(screen.getByRole("button", { name: /sign in/i }))
+}
+
+describe("LoginPage error reporting", () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    localStorage.clear()
+    vi.restoreAllMocks()
+  })
+
+  it("reports bad credentials when the API returns 401", async () => {
+    mockFetch(401, { detail: "Invalid credentials" })
+    submitLogin()
+    expect(await screen.findByText("Invalid credentials")).toBeInTheDocument()
+  })
+
+  it("reports unavailability, not bad credentials, on a 502 from the dev proxy", async () => {
+    mockFetch(502)
+    submitLogin()
+    expect(
+      await screen.findByText(/unavailable \(HTTP 502\)/i),
+    ).toBeInTheDocument()
+    expect(screen.queryByText("Invalid credentials")).not.toBeInTheDocument()
+  })
+
+  it("reports unavailability when the server errors with 500", async () => {
+    mockFetch(500, { detail: "boom" })
+    submitLogin()
+    expect(
+      await screen.findByText(/unavailable \(HTTP 500\)/i),
+    ).toBeInTheDocument()
+  })
+
+  it("surfaces the server's detail for other 4xx responses", async () => {
+    mockFetch(429, { detail: "Too many attempts" })
+    submitLogin()
+    expect(await screen.findByText("Too many attempts")).toBeInTheDocument()
+  })
+
+  it("reports an unreachable server when fetch itself fails", async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockRejectedValue(
+        new TypeError("Failed to fetch"),
+      ) as unknown as typeof fetch
+    submitLogin()
+    expect(
+      await screen.findByText(/cannot reach the cq server/i),
+    ).toBeInTheDocument()
+  })
+})

--- a/server/frontend/src/pages/LoginPage.tsx
+++ b/server/frontend/src/pages/LoginPage.tsx
@@ -1,5 +1,23 @@
 import { type FormEvent, useState } from "react"
+import { ApiError } from "../api"
 import { useAuth } from "../auth"
+
+// Only a 401 means the username/password were wrong. Every other failure —
+// an unreachable API, a dev-proxy error, a 5xx — is an availability problem,
+// and reporting it as "Invalid credentials" sends people looking for the
+// wrong bug entirely.
+function loginErrorMessage(err: unknown): string {
+  if (!(err instanceof ApiError)) {
+    return "Cannot reach the cq server. Check that the API is running."
+  }
+  if (err.status === 401) {
+    return "Invalid credentials"
+  }
+  if (err.status >= 500) {
+    return `The cq server is unavailable (HTTP ${err.status}).`
+  }
+  return err.message
+}
 
 export function LoginPage() {
   const { login } = useAuth()
@@ -14,8 +32,8 @@ export function LoginPage() {
     setLoading(true)
     try {
       await login(username, password)
-    } catch {
-      setError("Invalid credentials")
+    } catch (err) {
+      setError(loginErrorMessage(err))
     } finally {
       setLoading(false)
     }


### PR DESCRIPTION
Hi! I ran into this issue when trying to run `cq` locally and noticed the `catch` would map every failure to "Invalid credentials", which may not be true. So this helps check the response status and display a more accurate error message.

## What changed and why

`LoginPage` caught every login failure with a bare `catch` and rendered `"Invalid credentials"`:

```tsx
} catch {
  setError("Invalid credentials")
}
```

The API layer already distinguishes these cases — `request()` in `api.ts` throws an `ApiError` carrying the HTTP status — but the handler discarded it. The result is that an unreachable backend, a Vite dev-proxy 502, or a 5xx all tell the user their password is wrong.

This is easy to hit as a new contributor: `make dev-ui` starts only Vite, which proxies `/api/v1` to `localhost:8742`. Without `make dev-api` running, the proxy returns 502 and the dashboard reports bad credentials — sending you off to debug your seeded user instead of the API that was never started.

The handler now maps the failure to what actually happened, following the `ApiError` idiom already used in `ReviewPage` and `KnowledgeUnitModal`:

| Failure | Message |
|---|---|
| 401 | `Invalid credentials` (unchanged) |
| 5xx | server unavailable, with the status |
| other 4xx | the server's own `detail` |
| non-`ApiError` (fetch rejected) | server unreachable |

## How to test

```bash
make test-server-frontend
```

Five cases are covered in `LoginPage.test.tsx`, one per branch. The four non-401 cases fail against the previous handler and pass with this change; the 401 case passes both ways, pinning the behaviour that was already correct.

To see the original problem by hand, run `make dev-ui` without `make dev-api` and attempt a login.

## Notes

The same bare-`catch` pattern exists at `App.tsx:46`, `Layout.tsx:94`, and `ReviewPage.tsx:47`. Those are less misleading — none of them claim a specific cause the way the login form did — so I left them out to keep this focused. Happy to follow up if you'd like them addressed too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved login error messages to distinguish invalid credentials, service unavailability, server errors, and other API errors.
  * Added clearer feedback when a connection failure prevents login.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->